### PR TITLE
Initial draft of Licensing content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 *.bkp
 *.dtmp
+*.swp

--- a/model/Licensing/Classes/ConjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/ConjunctiveLicenseSet.md
@@ -1,0 +1,34 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ConjunctiveLicenseSet
+
+## Summary
+
+Portion of a LicenseExpression representing a set of licensing information
+where all elements apply.
+
+## Description
+
+A ConjunctiveLicenseSet indicates that _each_ of its subsidiary
+LicenseExpressions apply. In other words, a ConjunctiveLicenseSet of two or
+more licenses represents a licensing situation where _all_ of the specified
+licenses are to be complied with. It is represented in the SPDX License
+Expression Syntax by the `AND` operator.
+
+It is syntactically correct to specify a ConjunctiveLicenseSet where the
+subsidiary LicenseExpressions may be "incompatible" according to a particular
+interpretation of the corresponding Licenses. The SPDX License Expression
+Syntax does not take into account interpretation of license texts, which is
+left to the consumer of SPDX data to determine for themselves.
+
+## Metadata
+
+- name: ConjunctiveLicenseSet
+- SubclassOf: LicenseExpression
+- Instantiability: Concrete
+
+## Properties
+
+- child
+  - type: LicenseExpression
+  - mincount: 2

--- a/model/Licensing/Classes/CopyrightText.md
+++ b/model/Licensing/Classes/CopyrightText.md
@@ -1,0 +1,27 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# CopyrightText
+
+## Summary
+
+Concrete class representing copyright text that has actually been found.
+
+## Description
+
+A CopyrightText is the primary value that is used by a copyrightText field
+that indicates copyright text being found, i.e. with a value other than
+NONE or NOASSERTION.
+
+## Metadata
+
+- name: CopyrightText
+- SubclassOf: CopyrightTextField
+- Instantiability: Concrete
+
+## Properties
+
+- text
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+

--- a/model/Licensing/Classes/CopyrightTextField.md
+++ b/model/Licensing/Classes/CopyrightTextField.md
@@ -1,0 +1,26 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# CopyrightTextField
+
+## Summary
+
+Base abstract class used for the copyrightText field that can take a value
+of either a text value (via CopyrightText), NOASSERTION, or NONE.
+
+## Description
+
+A CopyrightTextField is the primary value that is used by a copyright text
+field for a software Package, File or Snippet. It represents either actual
+text (represented via a concrete CopyrightText), or the values NOASSERTION
+or NONE.
+
+**FIXME** The specific meanings of NOASSERTION or NONE are defined in the
+copyrightText property description. (**INCORRECT** - change to NoAssertionText
+or NoneText)
+
+## Metadata
+
+- name: CopyrightTextField
+- SubclassOf: none
+- Instantiability: Abstract
+

--- a/model/Licensing/Classes/CustomLicense.md
+++ b/model/Licensing/Classes/CustomLicense.md
@@ -1,0 +1,25 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# CustomLicense
+
+## Summary
+
+A license that is not listed on the SPDX License List.
+
+## Description
+
+A CustomLicense represents a License that is not listed on the SPDX License
+List at https://spdx.org/licenses, and is therefore defined by an SPDX data
+creator.
+
+**TBD** whether to define the meaning and purpose for each of the properties
+
+**TBD** how to indicate that the License ID must have the prefix "LicenseRef-"
+
+## Metadata
+
+- name: CustomLicense
+- SubclassOf: License
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/CustomLicenseException.md
+++ b/model/Licensing/Classes/CustomLicenseException.md
@@ -1,0 +1,15 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# CustomLicenseException
+
+## Summary
+
+**TBD** Not to be completed until the Change Proposal at https://github.com/spdx/change-proposal/issues/4 is decided upon. Should be treated as unconfirmed since this class and its name or meaning is subject to change.
+
+## Metadata
+
+- name: CustomLicenseException
+- SubclassOf: LicenseException
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/DisjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/DisjunctiveLicenseSet.md
@@ -1,0 +1,31 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# DisjunctiveLicenseSet
+
+## Summary
+
+Portion of a LicenseExpression representing a set of licensing information
+where only any one of the elements applies.
+
+## Description
+
+A DisjunctiveLicenseSet indicates that _only one_ of its subsidiary
+LicenseExpressions is required to apply. In other words, a
+DisjunctiveLicenseSet of two or more licenses represents a licensing
+situation where _only one_ of the specified licenses are to be complied with.
+A consumer of SPDX data would typically understand this to permit the recipient
+of the licensed content to choose which of the corresponding license they
+would prefer to use. It is represented in the SPDX License Expression Syntax
+by the `OR` operator.
+
+## Metadata
+
+- name: DisjunctiveLicenseSet
+- SubclassOf: LicenseExpression
+- Instantiability: Concrete
+
+## Properties
+
+- child
+  - type: LicenseExpression
+  - mincount: 2

--- a/model/Licensing/Classes/License.md
+++ b/model/Licensing/Classes/License.md
@@ -1,0 +1,70 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# License
+
+## Summary
+
+Abstract class for the portion of a LicenseExpression representing a license.
+
+## Description
+
+A License represents a license text, whether listed on the SPDX License List
+(ListedLicense) or defined by an SPDX data creator (CustomLicense).
+
+**TBD** whether to define the meaning and purpose for each of the properties
+
+**TBD** whether licenseID should be a separately defined property, rather
+than xsd:string
+
+## Metadata
+
+- name: License
+- SubclassOf: LicenseExpression
+- Instantiability: Abstract
+
+## Properties
+
+- comment
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- licenseId
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- name
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- licenseText
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- seeAlso
+  - type: anyURI
+  - minCount: 0
+  - maxCount: 1
+- example
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- isOsiApproved
+  - type: boolean
+  - minCount: 0
+  - maxCount: 1
+- isFsfLibre
+  - type: boolean
+  - minCount: 0
+  - maxCount: 1
+- standardLicenseHeader
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- isDeprecatedLicenseId
+  - type: boolean
+  - minCount: 0
+  - maxCount: 1
+- obsoletedBy
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1

--- a/model/Licensing/Classes/LicenseException.md
+++ b/model/Licensing/Classes/LicenseException.md
@@ -1,0 +1,15 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# LicenseException
+
+## Summary
+
+**TBD** Not to be completed until the Change Proposal at https://github.com/spdx/change-proposal/issues/4 is decided upon. Should be treated as unconfirmed since this class and its name or meaning is subject to change.
+
+## Metadata
+
+- name: LicenseException
+- SubclassOf: none
+- Instantiability: Abstract
+
+## Properties

--- a/model/Licensing/Classes/LicenseExpression.md
+++ b/model/Licensing/Classes/LicenseExpression.md
@@ -1,0 +1,26 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# LicenseExpression
+
+## Summary
+
+Abstract class representing a license expression consisting of one or more
+licenses (optionally including exceptions), which may be combined according
+to the SPDX license expression syntax.
+
+## Description
+
+A LicenseExpression is used by a licensing field for a software package,
+file or snippet when its value is not NOASSERTION or NONE. It can be a
+single license (either on the SPDX License List or a custom-defined license);
+a single license with an "or later" operator applied; the foregoing with an
+exception applied; or a set of licenses combined by applying "AND" and "OR"
+operators recursively.
+
+## Metadata
+
+- name: LicenseExpression
+- SubclassOf: LicenseField
+- Instantiability: Abstract
+
+## Properties

--- a/model/Licensing/Classes/LicenseField.md
+++ b/model/Licensing/Classes/LicenseField.md
@@ -1,0 +1,24 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# LicenseField
+
+## Summary
+
+Base abstract class used for all fields that can take a value of either a
+license expression, NOASSERTION, or NONE.
+
+## Description
+
+A LicenseField is the primary value that is used by a licensing field for a
+software Package, File or Snippet. It represents either a license expression,
+or the values NOASSERTION or NONE. The specific meanings of NOASSERTION or
+NONE for the particular licensing field are defined in the corresponding
+property description.
+
+## Metadata
+
+- name: LicenseField
+- SubclassOf: none
+- Instantiability: Abstract
+
+## Properties

--- a/model/Licensing/Classes/ListedLicense.md
+++ b/model/Licensing/Classes/ListedLicense.md
@@ -1,0 +1,32 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ListedLicense
+
+## Summary
+
+A license listed on the SPDX License List.
+
+## Description
+
+A ListedLicense represents a License that is listed on the SPDX License List
+at https://spdx.org/licenses.
+
+**TBD** whether to define the meaning and purpose for each of the properties
+
+## Metadata
+
+- name: ListedLicense
+- SubclassOf: License
+- Instantiability: Concrete
+
+## Properties
+
+- listVersionAdded
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- deprecatedVersion
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+

--- a/model/Licensing/Classes/ListedLicense.md
+++ b/model/Licensing/Classes/ListedLicense.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A license listed on the SPDX License List.
+A license that is listed on the SPDX License List.
 
 ## Description
 

--- a/model/Licensing/Classes/ListedLicenseException.md
+++ b/model/Licensing/Classes/ListedLicenseException.md
@@ -1,0 +1,15 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ListedLicenseException
+
+## Summary
+
+**TBD** Not to be completed until the Change Proposal at https://github.com/spdx/change-proposal/issues/4 is decided upon. Should be treated as unconfirmed since this class and its name or meaning is subject to change.
+
+## Metadata
+
+- name: ListedLicenseException
+- SubclassOf: LicenseException
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/NoAssertionLicense.md
+++ b/model/Licensing/Classes/NoAssertionLicense.md
@@ -1,0 +1,29 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# NoAssertionLicense
+
+## Summary
+
+Concrete class representing an absence of an assertion about license
+information.
+
+## Description
+
+**TBD** whether the meaning of NoAssertionLicense in the context of the concludedLicense and declaredLicense properties should be here rather than in those property definitions
+
+A NoAssertionLicense is the primary value that is used by a concludedLicense
+or declaredLicense field that indicates that the SPDX data creator is making
+no assertion about the license information for the corresponding software
+Package, File or Snippet.
+
+The specific meaning of NoAssertionLicense in the context of a
+concludedLicense or declaredLicense field is more fully set forth in the
+Property definitions for those fields.
+
+## Metadata
+
+- name: NoAssertionLicense
+- SubclassOf: LicenseField
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/NoAssertionText.md
+++ b/model/Licensing/Classes/NoAssertionText.md
@@ -1,0 +1,31 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# NoAssertionText
+
+## Summary
+
+Concrete class representing an absence of an assertion about the presence of
+copyright text.
+
+## Description
+
+**TBD** whether these details should be defined in the copyrightText property instead of here
+
+A NoAssertionText is the primary value that is used by a copyrightText field
+that indicates that the SPDX data creator is making no assertion about whether
+any copyright information is present, or what its contents are if it is
+present.
+
+If a copyrightText has a NOASSERTION value, this indicates that one of the
+following applies:
+* the SPDX data creator has made no attempt to determine this field; or
+* the SPDX data creator has intentionally provided no information (no meaning
+  should be implied from the absence of an assertion).
+
+## Metadata
+
+- name: NoAssertionText
+- SubclassOf: CopyrightTextField
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/NoneLicense.md
+++ b/model/Licensing/Classes/NoneLicense.md
@@ -1,0 +1,28 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# NoneLicense
+
+## Summary
+
+Concrete class representing an assertion that no license information is
+present, as applicable.
+
+## Description
+
+**TBD** whether the meaning of NoneLicense in the context of the concludedLicense and declaredLicense properties should be here rather than in those property definitions
+
+A NoneLicense is the primary value that is used by a concludedLicense or
+declaredLicense field that indicates the absence of license information from
+the corresponding software Package, File or Snippet.
+
+The specific meaning of NoneLicense in the context of a concludedLicense or
+declaredLicense field is more fully set forth in the Property definitions for
+those fields.
+
+## Metadata
+
+- name: NoneLicense
+- SubclassOf: LicenseField
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/NoneText.md
+++ b/model/Licensing/Classes/NoneText.md
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# NoneText
+
+## Summary
+
+Concrete class representing an assertion that no copyright text is present.
+
+## Description
+
+**TBD** whether these details should be defined in the copyrightText property instead of here
+
+A NoneText is the primary value that is used by a copyrightText field that
+indicates that the corresponding software Package, File or Snippet does not
+contain any copyright information.
+
+## Metadata
+
+- name: NoneText
+- SubclassOf: CopyrightTextField
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Classes/OrLaterOperator.md
+++ b/model/Licensing/Classes/OrLaterOperator.md
@@ -1,0 +1,34 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# OrLaterOperator
+
+## Summary
+
+Portion of a LicenseExpression representing this version, or any later version,
+of the indicated License.
+
+## Description
+
+An OrLaterOperator indicates that this portion of the LicenseExpression
+represents either (1) the specified version of the corresponding License, or
+(2) any later version of that License. It is represented in the SPDX License
+Expression Syntax by the `+` operator.
+
+It is context-dependent, and unspecified by SPDX, as to what constitutes a
+"later version" of any particular License. Some Licenses may not be versioned,
+or may not have clearly-defined ordering for versions. The consumer of SPDX
+data will need to determine for themselves what meaning to attribute to a
+"later version" operator for a particular License.
+
+## Metadata
+
+- name: OrLaterOperator
+- SubclassOf: LicenseExpression
+- Instantiability: Concrete
+
+## Properties
+
+- license
+  - type: License
+  - minCount: 1
+  - maxCount: 1

--- a/model/Licensing/Classes/WithExceptionOperator.md
+++ b/model/Licensing/Classes/WithExceptionOperator.md
@@ -1,0 +1,15 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# WithExceptionOperator
+
+## Summary
+
+**TBD** Not to be completed until the Change Proposal at https://github.com/spdx/change-proposal/issues/4 is decided upon. Should be treated as unconfirmed since this class and its name or meaning is subject to change.
+
+## Metadata
+
+- name: WithExceptionOperator
+- SubclassOf: LicenseExpression
+- Instantiability: Concrete
+
+## Properties

--- a/model/Licensing/Properties/attributionText.md
+++ b/model/Licensing/Properties/attributionText.md
@@ -1,0 +1,33 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# attributionText
+
+## Summary
+
+An attributionText provides a place for the SPDX data creator to record
+acknowledgement text for a software Package, File or Snippet.
+
+## Description
+
+An attributionText for a software Package, File or Snippet provides a consumer
+of SPDX data with acknowledgement content, to assist redistributors of the
+Package, File or Snippet with reproducing those acknowledgements.
+
+For example, this field may include a statement that is required by a
+particular license to be reproduced in end-user documentation, advertising
+materials, or another form.
+
+This field may describe where, or in which contexts, the acknowledgements
+need to be reproduced, but it is not required to do so. The SPDX data creator
+may also explain elsewhere (such as in a licenseComment field) how they intend
+for data in this field to be used.
+
+An attributionText is is not meant to include the software Package, File or
+Snippet’s actual complete license text (see concludedLicense to identify the
+corresponding license).
+
+## Metadata
+
+- name: attributionText
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/concludedLicense.md
+++ b/model/Licensing/Properties/concludedLicense.md
@@ -1,0 +1,45 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# concludedLicense
+
+## Summary
+
+A concludedLicense identifies the license that that SPDX data creator has
+concluded as governing the software Package, File or Snippet.
+
+## Description
+
+A concludedLicense is the license identified by the SPDX data creator,
+based on analyzing the license information in the software Package, File
+or Snippet and other information to arrive at a reasonably objective
+conclusion as to what license governs it.
+
+If a concludedLicense has a NONE value, this indicates that the SPDX data
+creator has looked and did not find any license information for this
+software Package, File or Snippet.
+
+If a concludedLicense has a NOASSERTION value, this indicates that one of
+the follows applies:
+* the SPDX data creator has attempted to but cannot reach a reasonable
+  objective determination;
+* the SPDX data creator has made no attempt to determine this field; or
+* the SPDX data creator has intentionally provided no information (no
+  meaning should be implied by doing so).
+
+A written explanation of a NOASSERTION value MAY be provided in the
+licenseComment field.
+
+If the concludedLicense for a software Package, File or Snippet is not the
+same as its declaredLicense, a written explanation SHOULD be provided in
+the licenseComment field.
+
+If the declaredLicense for a software Package, File or Snippet is a choice
+of more than one license (e.g. a license expression combining two licenses
+through use of the `OR` operator), then the concludedLicense may either
+retain the license choice or identify which license was chosen.
+
+## Metadata
+
+- name: concludedLicense
+- Nature: ObjectProperty
+- Range: LicenseField

--- a/model/Licensing/Properties/concludedLicense.md
+++ b/model/Licensing/Properties/concludedLicense.md
@@ -14,20 +14,20 @@ based on analyzing the license information in the software Package, File
 or Snippet and other information to arrive at a reasonably objective
 conclusion as to what license governs it.
 
-If a concludedLicense has a NONE value, this indicates that the SPDX data
-creator has looked and did not find any license information for this
+If a concludedLicense has a NONE value (NoneLicense), this indicates that the
+SPDX data creator has looked and did not find any license information for this
 software Package, File or Snippet.
 
-If a concludedLicense has a NOASSERTION value, this indicates that one of
-the follows applies:
+If a concludedLicense has a NOASSERTION value (NoAssertionLicense), this
+indicates that one of the following applies:
 * the SPDX data creator has attempted to but cannot reach a reasonable
   objective determination;
 * the SPDX data creator has made no attempt to determine this field; or
 * the SPDX data creator has intentionally provided no information (no
   meaning should be implied by doing so).
 
-A written explanation of a NOASSERTION value MAY be provided in the
-licenseComment field.
+A written explanation of a NOASSERTION value (NoAssertionLicense) MAY be
+provided in the licenseComment field.
 
 If the concludedLicense for a software Package, File or Snippet is not the
 same as its declaredLicense, a written explanation SHOULD be provided in

--- a/model/Licensing/Properties/copyrightText.md
+++ b/model/Licensing/Properties/copyrightText.md
@@ -1,0 +1,34 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# copyrightText
+
+## Summary
+
+A copyrightText identifies the text of one or more copyright notices for
+a software Package, File or Snippet, if any.
+
+## Description
+
+A copyrightText consists of the text(s) of the copyright notice(s) found
+for a software Package, File or Snippet, if any.
+
+If a copyrightText contains text, then it may contain any text related to
+one or more copyright notices (even if not complete) for that software
+Package, File or Snippet.
+
+If a copyrightText has a NONE value, this indicates that the software
+Package, File or Snippet contains no copyright notice whatsoever.
+
+If a copyrightText has a NOASSERTION value, this indicates that one of the
+following applies:
+* the SPDX data creator has attempted to but cannot reach a reasonable
+  objective determination;
+* the SPDX data creator has made no attempt to determine this field; or
+* the SPDX data creator has intentionally provided no information (no
+  meaning should be implied by doing so).
+
+## Metadata
+
+- name: copyrightText
+- Nature: ObjectProperty
+- Range: CopyrightTextField

--- a/model/Licensing/Properties/declaredLicense.md
+++ b/model/Licensing/Properties/declaredLicense.md
@@ -39,11 +39,12 @@ types of artifacts. For example:
     different File (e.g., comment at top of File if it is not within the
     Snippet, LICENSE file in the top directory of a repository)
 
-If a declaredLicense has a NONE value, this indicates that the corresponding
-Package, File or Snippet contains no license information whatsoever.
+If a declaredLicense has a NONE value (NoneLicense), this indicates that the
+corresponding Package, File or Snippet contains no license information
+whatsoever.
 
-If a declaredLicense has a NOASSERTION value, this indicates that one of
-the following applies:
+If a declaredLicense has a NOASSERTION value (NoAssertionLicense), this
+indicates that one of the following applies:
 * the SPDX data creator has attempted to but cannot reach a reasonable
   objective determination;
 * the SPDX data creator has made no attempt to determine this field; or

--- a/model/Licensing/Properties/declaredLicense.md
+++ b/model/Licensing/Properties/declaredLicense.md
@@ -1,0 +1,57 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# declaredLicense
+
+## Summary
+
+A declaredLicense identifies the license information actually found in the
+software Package, File or Snippet, for example as detected by use of
+automated tooling.
+
+## Description
+
+A declaredLicense is the license identified in text in the software package,
+file or snippet as the license declared by its authors.
+
+This field is not intended to capture license information obtained from an
+external source, such as a package's website. Such information can be
+included, as needed, in a concludedLicense field.
+
+A declaredLicense may be expressed differently in practice for different
+types of artifacts. For example:
+
+* for Packages:
+  * would include license info describing the license of the Package as a
+    whole, when it is found in the Package itself (e.g., LICENSE file,
+    README file, metadata in the repository, etc.)
+  * would not include any license information that is not in the Package
+    itself (e.g., license information from the project’s website or from a
+    third party repository or website)
+* for Files:
+  * would include license info found in the File itself (e.g., license
+    header or notice, comments, SPDX-License-Identifier expression)
+  * would not include license info found in a different file (e.g., LICENSE
+    file in the top directory of a repository)
+* for Snippets:
+  * would include license info found in the Snippet itself (e.g., license
+    notice, comments, SPDX-License-Identifier expression)
+  * would not include license info found elsewhere in the File or in a
+    different File (e.g., comment at top of File if it is not within the
+    Snippet, LICENSE file in the top directory of a repository)
+
+If a declaredLicense has a NONE value, this indicates that the corresponding
+Package, File or Snippet contains no license information whatsoever.
+
+If a declaredLicense has a NOASSERTION value, this indicates that one of
+the following applies:
+* the SPDX data creator has attempted to but cannot reach a reasonable
+  objective determination;
+* the SPDX data creator has made no attempt to determine this field; or
+* the SPDX data creator has intentionally provided no information (no meaning
+  should be implied by doing so).
+
+## Metadata
+
+- name: declaredLicense
+- Nature: ObjectProperty
+- Range: LicenseField

--- a/model/Licensing/Properties/licenseComment.md
+++ b/model/Licensing/Properties/licenseComment.md
@@ -1,0 +1,23 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# licenseComment
+
+## Summary
+
+A licenseComment records any background information or analysis relevant to
+determining the concludedLicense for a software Package, File or Snippet.
+
+## Description
+
+A licenseComment for a software Package, File or Snippet provides a detailed
+explanation of how the concludedLicense was determined, especially if:
+* the concludedLicense does not match the declaredLicense;
+* the concludedLicense is NOASSERTION; or
+* the SPDX data creator wants to provide other helpful information relevant
+  to determining the license of the software Package, File or Snippet.
+
+## Metadata
+
+- name: licenseComment
+- Nature: DataProperty
+- Range: xsd:string


### PR DESCRIPTION
This is a work-in-progress draft of the classes and other content for the Licensing profile. This should not be merged at present, in particular because:

* several placeholder files are empty
* the structure and details for the `*Exception` classes will likely be dependent on the outcome of [the pending change proposal](https://github.com/spdx/change-proposal/issues/4)
* still need to understand better how this as an optional "profile" ties into inserting these properties into classes defined in other "profiles" (such as Core and Software)

Submitting here as a draft to get greater visibility for the community into progress on this.

Signed-off-by: Steve Winslow <steve@swinslow.net>