### PR TITLE
add ExternalIdentifier.md to Core/Classes

### DIFF
--- a/model/Core/Classes/ExternalIdentifier.md
+++ b/model/Core/Classes/ExternalIdentifier.md
@@ -1,0 +1,34 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ExternalIdentifier
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+
+## Metadata
+
+- name: ExternalIdentifier
+- Instantiability: Concrete
+
+
+## Properties
+
+- externalIdentifierType
+  - type: ExternalIdentifierType
+  - minCount: 1
+  - maxCount: 1
+- identifier
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- comment
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+


### PR DESCRIPTION
So far, only `ExternalIdentifierType` exists in `Core/Vocabularies`, so I added `ExternalIdentifier` according to https://github.com/spdx/spdx-3-model/blob/main/model.png

Signed-off-by: Armin Tänzer <armin.taenzer@tngtech.com>