### PR TITLE
Add `comment` property in CreationInformation.md

### DIFF
--- a/model/Core/Classes/CreationInformation.md
+++ b/model/Core/Classes/CreationInformation.md
@@ -19,6 +19,10 @@ TODO
 
 - specVersion
   - type: SemVer
+- comment
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
 - created
   - type: xsd:dateTime
 - createdBy


### PR DESCRIPTION
As seen in the model.png.
This field will be needed to convert the SPDX2 property `CreatorComment` to SPDX3.

Signed-off-by: Armin Tänzer <armin.taenzer@tngtech.com>