### PR TITLE
add packageVersion property in Package.md

### DIFF
--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -19,6 +19,10 @@ TODO
 - packagePurpose
   - type: SoftwarePurpose
   - minCount: 0
+- packageVersion
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
 - downloadLocation
   - type: anyURI
   - minCount: 0

--- a/model/Software/Properties/packageVersion.md
+++ b/model/Software/Properties/packageVersion.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# packageVersion
+
+## Summary
+
+Identify the version of a package.
+
+## Description
+
+A packageVersion is useful for identification purposes and for indicating later changes of the package version.
+
+## Metadata
+
+- name: packageVersion
+- Nature: DataProperty
+- Range: xsd:string
+


### PR DESCRIPTION
As seen in the model.png.
This field will be needed to convert the SPDX2 property `PackageVersion` to SPDX3.

Signed-off-by: Armin Tänzer <armin.taenzer@tngtech.com>