### PR TITLE
add CreationInfo related descriptions

### DIFF
--- a/model/Core/Classes/CreationInformation.md
+++ b/model/Core/Classes/CreationInformation.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the creation of the Element.
 
 ## Description
 
-TODO
+The CreationInformation provides information about who created the Element, and when and how it was created. 
 
 ## Metadata
 

--- a/model/Core/Classes/ProfileIdentifier.md
+++ b/model/Core/Classes/ProfileIdentifier.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides the model profile that the Element is specified in.
 
 ## Description
 
-TODO
+A profile identifier provides the model profile that the Element is specified in.
 
 ## Metadata
 

--- a/model/Core/Classes/SemVer.md
+++ b/model/Core/Classes/SemVer.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+A String constrained to the SemVer 2.0.0 specification.
 
 ## Description
 
-TODO
+The semantic version is a String constrained to the SemVer 2.0.0 specification.
 
 ## Metadata
 

--- a/model/Core/Properties/comment.md
+++ b/model/Core/Properties/comment.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provide consumers with comments by the creator of the Element about the Element.
 
 ## Description
 
-A comment is TODO
+A comment is an optional field for creators of the Element to provide comments
+to the readers/reviewers of the document.
 
 ## Metadata
 

--- a/model/Core/Properties/created.md
+++ b/model/Core/Properties/created.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies when the SPDX document was originally created.
 
 ## Description
 
-A created is TODO
+Created is a date that identifies when the Element was originally created.
+The time stamp can serve as an indication as to whether the analysis needs to be updated.
 
 ## Metadata
 

--- a/model/Core/Properties/createdBy.md
+++ b/model/Core/Properties/createdBy.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies who or what created the Element.
 
 ## Description
 
-A createdBy is TODO
+CreatedBy identifies who or what created the Element.
+The generation method will assist the recipient of the Element in assessing
+the general reliability/accuracy of the analysis information.
 
 ## Metadata
 

--- a/model/Core/Properties/creationInfo.md
+++ b/model/Core/Properties/creationInfo.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the creation of the Element.
 
 ## Description
 
-A creationInfo is TODO
+CreationInfo provides information about the creation of the Element.
 
 ## Metadata
 

--- a/model/Core/Properties/dataLicense.md
+++ b/model/Core/Properties/dataLicense.md
@@ -4,11 +4,35 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides the license under which the SPDX documentation of the Element can be used.
 
 ## Description
 
-A dataLicense is TODO
+The data license provides the license under which the SPDX documentation of the Element can be used.
+This is to alleviate any concern that content (the data or database) in an SPDX file
+is subject to any form of intellectual property right that could restrict the re-use
+of the information or the creation of another SPDX file for the same project(s).
+This approach avoids intellectual property and related restrictions over the SPDX file,
+however individuals can still contract with each other to restrict release
+of specific collections of SPDX files (which map to software bill of materials)
+and the identification of the supplier of SPDX files.
+Compliance with this document includes populating the SPDX fields therein
+with data related to such fields ("SPDX-Metadata"). 
+This document contains numerous fields where an SPDX file creator may provide
+relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness
+of "database rights" (in jurisdictions where applicable),
+such explanatory text is copyrightable subject matter in most Berne Convention countries.
+By using the SPDX specification, or any portion hereof,
+you hereby agree that any copyright rights (as determined by your jurisdiction)
+in any SPDX-Metadata, including without limitation explanatory text,
+shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. 
+For SPDX-Metadata not containing any copyright rights, 
+you hereby agree and acknowledge that the SPDX-Metadata is provided to you “as-is”
+and without any representations or warranties of any kind concerning the SPDX-Metadata,
+express, implied, statutory or otherwise, including without limitation warranties
+of title, merchantability, fitness for a particular purpose, non-infringement,
+or the absence of latent or other defects, accuracy, or the presence or absence of errors,
+whether or not discoverable, all to the greatest extent permissible under applicable law.
 
 ## Metadata
 

--- a/model/Core/Properties/profile.md
+++ b/model/Core/Properties/profile.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about which SPDX model profiles the Element belongs to.
 
 ## Description
 
-A profile is TODO
+This field provides information about which SPDX model profiles the Element belongs to.
 
 ## Metadata
 

--- a/model/Core/Properties/specVersion.md
+++ b/model/Core/Properties/specVersion.md
@@ -4,11 +4,18 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides a reference number that can be used to understand how to parse and interpret an Element.
 
 ## Description
 
-A specVersion is TODO
+The specVersion provides a reference number that can be used to understand how to parse and interpret an Element.
+It will enable both future changes to the specification and to support backward compatibility.
+The major version number shall be incremented when incompatible changes between versions are made
+(one or more sections are created, modified or deleted).
+The minor version number shall be incremented when backwards compatible changes are made.
+
+Here, parties exchanging information in accordance with the SPDX specification need to provide 
+100% transparency as to which SPDX specification version such information is conforming to.
 
 ## Metadata
 


### PR DESCRIPTION
This is an attempt to fill in the missing descriptions in the Core profile. Where possible, I tried to copy from the SPDX-2.3 specification.
Please note that this does not aim to be the final solution but will hopefully start discussions on possibly controversial points.