### PR TITLE
add Element related descriptions

### DIFF
--- a/model/Core/Properties/description.md
+++ b/model/Core/Properties/description.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides a detailed description of the Element.
 
 ## Description
 
-A description is TODO
+This field is a detailed description of the Element. It may also be extracted from the Element itself.
+The intent is to provide recipients of the SPDX file with a detailed technical explanation
+of the functionality, anticipated use, and anticipated implementation of the Element.
+This field may also include a description of improvements over prior versions of the Element.
 
 ## Metadata
 

--- a/model/Core/Properties/name.md
+++ b/model/Core/Properties/name.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies the name of an Element as designated by the creator.
 
 ## Description
 
-A name is TODO
+This field identifies the name of an Element as designated by the creator. 
+The name of an Element is an important convention and easier to refer to than the URI.
 
 ## Metadata
 

--- a/model/Core/Properties/originatedBy.md
+++ b/model/Core/Properties/originatedBy.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies from where or whom the Element originally came.
 
 ## Description
 
-A originatedBy is TODO
+OriginatedBy identifies from where or whom the Element originally came.
 
 ## Metadata
 

--- a/model/Core/Properties/spdxId.md
+++ b/model/Core/Properties/spdxId.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies an Element to be referenced by other Elements.
 
 ## Description
 
-A spdxId is TODO
+SpdxId uniquely identifies an Element which may thereby be referenced by other Elements.
+These references may be internal or external.
+While there may be several versions of the same Element, each one needs to be able to be referred to uniquely
+so that relationships between Elements can be clearly articulated.
 
 ## Metadata
 

--- a/model/Core/Properties/summary.md
+++ b/model/Core/Properties/summary.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+A short description of an Element.
 
 ## Description
 
-A summary is TODO
+A summary is a short description of an Element. Here, the intent is to allow the Element creator to 
+provide concise information about the function or use of the Element.
 
 ## Metadata
 


### PR DESCRIPTION
This is an attempt to fill in the missing descriptions in the Core profile. Where possible, I tried to copy from the SPDX-2.3 specification.
Please note that this does not aim to be the final solution but will hopefully start discussions on possibly controversial points.