### PR TITLE
add Annotation related descriptions

### DIFF
--- a/model/Core/Properties/annotationType.md
+++ b/model/Core/Properties/annotationType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Describes the type of annotation.
 
 ## Description
 
-A annotationType is TODO
+An annotationType describes the type of an annotation.
 
 ## Metadata
 

--- a/model/Core/Properties/statement.md
+++ b/model/Core/Properties/statement.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Commentary on an assertion that an annotator has made.
 
 ## Description
 
-A statement is TODO
+A statement is a commentary on an assertion that an annotator has made.
 
 ## Metadata
 

--- a/model/Core/Properties/subject.md
+++ b/model/Core/Properties/subject.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+An Element an annotator has made an assertion about.
 
 ## Description
 
-A subject is TODO
+A subject is an Element an annotator has made an assertion about.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/AnnotationType.md
+++ b/model/Core/Vocabularies/AnnotationType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Specifies the type of an annotation.
 
 ## Description
 
-TODO
+AnnotationType specifies the type of an annotation.
 
 ## Metadata
 
@@ -16,6 +16,5 @@ TODO
 
 ## Entries
 
-- other: TODOdescription
-- review: TODOdescription
-
+- other: Used to store extra information about an Element during creation.
+- review: Used when someone reviews the Element.

--- a/model/Core/Vocabularies/AnnotationType.md
+++ b/model/Core/Vocabularies/AnnotationType.md
@@ -16,5 +16,5 @@ AnnotationType specifies the type of an annotation.
 
 ## Entries
 
-- other: Used to store extra information about an Element during creation.
+- other: Used to store extra information about an Element which is not part of a Review (e.g. extra information provided during the creation of the Element).
 - review: Used when someone reviews the Element.


### PR DESCRIPTION
This is an attempt to fill in the missing descriptions in the Core profile. Where possible, I tried to copy from the SPDX-2.3 specification.
Please note that this does not aim to be the final solution but will hopefully start discussions on possibly controversial points.