### PR TITLE
add External ID/Ref related descriptions

### DIFF
--- a/model/Core/Classes/ExternalIdentifier.md
+++ b/model/Core/Classes/ExternalIdentifier.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+A reference to a resource outside the scope of SPDX-3.0 content that uniquely identifies an Element.
 
 ## Description
 
-TODO
-
+An ExternalIdentifier is a reference to a resource outside the scope of SPDX-3.0 content
+that uniquely identifies an Element.
 
 ## Metadata
 

--- a/model/Core/Classes/ExternalReference.md
+++ b/model/Core/Classes/ExternalReference.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A reference to a resource outside of the scope of SPDX-3.0 content.
+A reference to a resource outside the scope of SPDX-3.0 content.
 
 ## Description
 
-An External Reference is a grouping of characteristics unique to the identity,
-location and context of a resource outside of the scope of SPDX-3.0 content.
+An External Reference points to a resource outside the scope of the SPDX-3.0 content
+that provides additional characteristics of an Element.
 
 ## Metadata
 

--- a/model/Core/Classes/MediaType.md
+++ b/model/Core/Classes/MediaType.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Standardized way of indicating the type of content of an Element. A String constrained to the RFC 2046 specification.
 
 ## Description
 
-TODO
+The MediaType is a String constrained to the RFC 2046 specification. It provides a standardized
+way of indicating the type of content of an Element.
+A list of all possible media types is available at https://www.iana.org/assignments/media-types/media-types.xhtml.
 
 ## Metadata
 

--- a/model/Core/Properties/contentType.md
+++ b/model/Core/Properties/contentType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Specifies the media type of an Element.
 
 ## Description
 
-A contentType is TODO
+ContentType specifies the media type of an Element.
 
 ## Metadata
 

--- a/model/Core/Properties/externalIdentifierType.md
+++ b/model/Core/Properties/externalIdentifierType.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# externalIdentifierType
+
+## Summary
+
+Specifies the type of the external identifier.
+
+## Description
+
+An externalIdentifierType specifies the type of the external identifier.
+
+## Metadata
+
+- name: externalIdentifierType
+- Nature: DataProperty
+- Range: ExternalIdentifierType
+

--- a/model/Core/Properties/externalIdentifiers.md
+++ b/model/Core/Properties/externalIdentifiers.md
@@ -1,18 +1,20 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalIdentifiers
+# externalIdentifier
 
 ## Summary
 
-TODO
+Provides a reference to a resource outside the scope of SPDX-3.0 content
+that uniquely identifies an Element.
 
 ## Description
 
-TODO
+ExternalIdentifier points to a resource outside the scope of SPDX-3.0 content
+that uniquely identifies an Element.
 
 ## Metadata
 
-- name: externalIdentifiers
+- name: externalIdentifier
 - Nature: ObjectProperty
-- Range: ExternaIdentifier
+- Range: ExternalIdentifier
 

--- a/model/Core/Properties/externalIdentifiers.md
+++ b/model/Core/Properties/externalIdentifiers.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalIdentifier
+# externalIdentifiers
 
 ## Summary
 
@@ -14,7 +14,7 @@ that uniquely identifies an Element.
 
 ## Metadata
 
-- name: externalIdentifier
+- name: externalIdentifiers
 - Nature: ObjectProperty
 - Range: ExternalIdentifier
 

--- a/model/Core/Properties/externalReferenceType.md
+++ b/model/Core/Properties/externalReferenceType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Specifies the type of the external reference.
 
 ## Description
 
-A externalReferenceType is TODO
+An externalReferenceType specifies the type of the external reference.
 
 ## Metadata
 

--- a/model/Core/Properties/externalReferences.md
+++ b/model/Core/Properties/externalReferences.md
@@ -1,18 +1,20 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalReferences
+# externalReference
 
 ## Summary
 
-TODO
+Points to a resource outside the scope of the SPDX-3.0 content
+that provides additional characteristics of an Element.
 
 ## Description
 
-TODO
+This field points to a resource outside the scope of the SPDX-3.0 content
+that provides additional characteristics of an Element.
 
 ## Metadata
 
-- name: externalReferences
+- name: externalReference
 - Nature: ObjectProperty
 - Range: ExternalReference
 

--- a/model/Core/Properties/externalReferences.md
+++ b/model/Core/Properties/externalReferences.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalReference
+# externalReferences
 
 ## Summary
 
@@ -14,7 +14,7 @@ that provides additional characteristics of an Element.
 
 ## Metadata
 
-- name: externalReference
+- name: externalReferences
 - Nature: ObjectProperty
 - Range: ExternalReference
 

--- a/model/Core/Properties/locator.md
+++ b/model/Core/Properties/locator.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides the location of an external reference.
 
 ## Description
 
-A locator is TODO
+A locator provides the location of an external reference.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Specifies the type of an external identifier.
 
 ## Description
 
-TODO
+ExteralIdentifierType specifies the type of an external identifier.
 
 ## Metadata
 
@@ -16,13 +16,13 @@ TODO
 
 ## Entries
 
-- cpe22: TODOdescription
-- cpe23: TODOdescription
+- cpe22: https://cpe.mitre.org/files/cpe-specification_2.2.pdf
+- cpe23: https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
 - email: TODOdescription
-- gitoid: TODOdescription
-- other: TODOdescription
-- pkgUrl: TODOdescription
-- swhid: TODOdescription
-- swid: TODOdescription
+- gitoid: gitoid stands for Git Object ID. A gitoid of typeblob is a unique hash of a software artifact. Git relies on a Merkle Tree to index stored objects. See https://git-scm.com/book/en/v2/Git-Internals-Git-Objects. GitBOM is an amalgam of the terms "Git" and "SBOM". GitBOM is a minimalistic schema to describe software dependency graphs using a Merkle Tree, and is inspired by Git. A gitoid may refer to either the software artifact or its GitBOM document; this ambiguity exists because the GitBOM document is itself an artifact, and the gitoid of that artifact is its valid locator.
+- other: Used when the type doesn't match any of the other options.
+- pkgUrl: https://github.com/package-url/purl-spec
+- swhid: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
+- swid: https://www.ietf.org/archive/id/draft-ietf-sacm-coswid-21.html#section-2.3
 - urlScheme: TODOdescription
 

--- a/model/Core/Vocabularies/ExternalReferenceType.md
+++ b/model/Core/Vocabularies/ExternalReferenceType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Specifies the type of an external reference.
 
 ## Description
 
-TODO
+ExteralReferenceType specifies the type of an external reference.
 
 ## Metadata
 
@@ -16,10 +16,10 @@ TODO
 
 ## Entries
 
-- altDownloadLocation: TODOdescription
-- altWebPage: TODOdescription
-- other: TODOdescription
-- securityAdvisory: TODOdescription
-- securityFix: TODOdescription
-- securityOther: TODOdescription
+- altDownloadLocation: A reference to an alternative download location.
+- altWebPage: A reference to an alternative web page.
+- other: Used when the type doesn't match any of the other options.
+- securityAdvisory: A reference to the published security advisory (where advisory as defined per ISO 29147:2018). It may contain an impact statement whether a package (e.g. a product) is or is not affected by vulnerabilities.
+- securityFix: A reference to the source code with a fix for the vulnerability (e.g., a GitHub commit). 
+- securityOther: Used when the reference is security related but doesn't match any of the other types.
 


### PR DESCRIPTION
This is an attempt to fill in the missing descriptions in the Core profile. Where possible, I tried to copy from the SPDX-2.3 specification.
Please note that this does not aim to be the final solution but will hopefully start discussions on possibly controversial points.