### PR TITLE
add Software related descriptions

### DIFF
--- a/model/Software/Classes/File.md
+++ b/model/Software/Classes/File.md
@@ -2,6 +2,10 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # File
 
+## Summary
+
+TODO
+
 ## Description
 
 TODO This is about the File class.

--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -2,9 +2,24 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # Package
 
+## Summary
+
+Refers to any unit of content that can be associated with a distribution of software.
+
 ## Description
 
-TODO
+A package refers to any unit of content that can be associated with a distribution of software.
+Typically, a package is composed of one or more files.  
+Any of the following non-limiting examples may be (but are not required to be) represented in SPDX as a package:
+
+ - a tarball, zip file or other archive
+ - a directory or sub-directory
+ - a separately distributed piece of software which another Package or File uses or depends upon (e.g., a Python package, a Go module, ...)
+ - a container image, and/or each image layer within a container image
+ - a collection of one or more sub-packages
+ - a Git repository snapshot from a particular point in time
+
+Note that some of these could be represented in SPDX as a file as well.
 
 ## Metadata
 

--- a/model/Software/Classes/Sbom.md
+++ b/model/Software/Classes/Sbom.md
@@ -2,12 +2,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # Sbom
 
+## Summary
+
+A container for a grouping of SPDX-3.0 content characterizing details about a software product.
+
 ## Description
 
 A Software Bill of Materials (SBOM) is a container for a grouping of SPDX-3.0 content
 characterizing details about a software product.
 This could include details of the content and composition of the product,
-provenence details of the product and/or
+provenance details of the product and/or
 its composition, licensing information, known quality or security issues, etc.
 
 ## Metadata

--- a/model/Software/Classes/Sbom.md
+++ b/model/Software/Classes/Sbom.md
@@ -4,12 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A container for a grouping of SPDX-3.0 content characterizing details about a software product.
+A collection of SPDX Elements describing a single package.
 
 ## Description
 
-A Software Bill of Materials (SBOM) is a container for a grouping of SPDX-3.0 content
-characterizing details about a software product.
+A Software Bill of Materials (SBOM) is a collection of SPDX Elements describing a single package.
 This could include details of the content and composition of the product,
 provenance details of the product and/or
 its composition, licensing information, known quality or security issues, etc.

--- a/model/Software/Classes/Snippet.md
+++ b/model/Software/Classes/Snippet.md
@@ -2,9 +2,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # Snippet
 
+## Summary
+
+Describes a certain part of a file.
+
 ## Description
 
-TODO
+A Snippet describes a certain part of a file and can be used when the file is known to have some content
+that has been included from another original source. Snippets are useful for denoting when part of a file
+may have been originally created under another license or copied from a place with a known vulnerability.
 
 ## Metadata
 

--- a/model/Software/Properties/byteRange.md
+++ b/model/Software/Properties/byteRange.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Defines the byte range in the original host file that the snippet information applies to.
 
 ## Description
 
-A byteRange is TODO
+This field defines the byte range in the original host file that the snippet information applies to.
+A range of bytes is independent of various formatting concerns, and the most accurate way 
+of referring to the differences. The choice was made to start the numbering of 
+the byte range at 1 to be consistent with the W3C pointer method vocabulary.
 
 ## Metadata
 

--- a/model/Software/Properties/contentType.md
+++ b/model/Software/Properties/contentType.md
@@ -8,7 +8,7 @@ Provides information about the content type of an Element.
 
 ## Description
 
-This field is a reasonable estimation of the content type of the Element, from a developer perspective.
+This field is a reasonable estimation of the content type of the Element, from a creator perspective.
 Content type is intrinsic to the Element, independent of how the Element is being used.
 
 ## Metadata

--- a/model/Software/Properties/contentType.md
+++ b/model/Software/Properties/contentType.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the content type of an Element.
 
 ## Description
 
-A contentType is TODO
+This field is a reasonable estimation of the content type of the Element, from a developer perspective.
+Content type is intrinsic to the Element, independent of how the Element is being used.
 
 ## Metadata
 

--- a/model/Software/Properties/downloadLocation.md
+++ b/model/Software/Properties/downloadLocation.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Identifies the download Uniform Resource Identifier for the package at the time that the document was created.
 
 ## Description
 
-A downloadLocation is TODO
+DownloadLocation identifies the download Uniform Resource Identifier 
+for the package at the time that the document was created.
+Where and how to download the exact package being referenced 
+is critical for verification and tracking data.
 
 ## Metadata
 

--- a/model/Software/Properties/filePurpose.md
+++ b/model/Software/Properties/filePurpose.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the primary purpose of the file.
 
 ## Description
 
-A filePurpose is TODO
+FilePurpose provides information about the primary purpose of the file.
 
 ## Metadata
 

--- a/model/Software/Properties/homePage.md
+++ b/model/Software/Properties/homePage.md
@@ -4,11 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+A place for the SPDX document creator to record a website that serves as the package's home page.
 
 ## Description
 
-A homePage is TODO
+HomePage is a place for the SPDX document creator to record a website that serves as the package's home page.
+This saves the recipient of the SPDX document who is looking for more info from
+having to search for and verify a match between the package and the associated project home page.
+This link can also be used to reference further information about the package
+referenced by the SPDX document creator.
 
 ## Metadata
 

--- a/model/Software/Properties/lineRange.md
+++ b/model/Software/Properties/lineRange.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Defines the line range in the original host file that the snippet information applies to.
 
 ## Description
 
-A lineRange is TODO
+This field defines the line range in the original host file that the snippet information applies to.
+If there is a disagreement between the byte range and line range, the byte range values will take precedence.
+A range of lines is a convenient reference for those files where there is a known line delimiter. 
+The choice was made to start the numbering of the lines at 1 to be consistent with the W3C pointer method vocabulary.
 
 ## Metadata
 

--- a/model/Software/Properties/packagePurpose.md
+++ b/model/Software/Properties/packagePurpose.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the primary purpose of the package.
 
 ## Description
 
-A packagePurpose is TODO
+PackagePurpose provides information about the primary purpose of the package.
 
 ## Metadata
 

--- a/model/Software/Properties/snippetPurpose.md
+++ b/model/Software/Properties/snippetPurpose.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the primary purpose of the snippet.
 
 ## Description
 
-A snippetPurpose is TODO
+SnippetPurpose provides information about the primary purpose of the snippet.
 
 ## Metadata
 

--- a/model/Software/Vocabularies/SoftwarePurpose.md
+++ b/model/Software/Vocabularies/SoftwarePurpose.md
@@ -4,11 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provides information about the primary purpose of an Element.
 
 ## Description
 
-TODO
+This field provides information about the primary purpose of an Element.
+Software Purpose is intrinsic to how the Element is being used rather than the content of the Element.
+This field is a reasonable estimate of the most likely usage of the Element
+from the producer and consumer perspective from which both parties can draw conclusions
+about the context in which the Element exists.
 
 ## Metadata
 
@@ -16,23 +20,23 @@ TODO
 
 ## Entries
 
-- application: TODOdescription
-- archive: TODOdescription
+- application: the Element is a software application
+- archive: the Element refers to an archived collection of files (.tar, .zip, etc)
 - bom: TODOdescription
 - configuration: TODOdescription
-- container: TODOdescription
+- container: the Element refers to a container image which can be used by a container runtime application
 - data: TODOdescription
-- device: TODOdescription
+- device: the Element refers to a chipset, processor, or electronic board
 - documentation: TODOdescription
 - executable: TODOdescription
-- file: TODOdescription
-- firmware: TODOdescription
-- framework: TODOdescription
-- install: TODOdescription
-- library: TODOdescription
+- file: the Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc)
+- firmware: the Element provides low level control over a device's hardware
+- framework: the Element is a software framework
+- install: the Element is used to install software on disk
+- library: the Element is a software library
 - module: TODOdescription
-- operatingSystem: TODOdescription
-- other: TODOdescription
+- operatingSystem: the Element refers to an operating system
+- other: the Element doesn't fit into any of the other categories
 - patch: TODOdescription
-- source: TODOdescription
+- source: the Element is a collection of source files
 


### PR DESCRIPTION
This is an attempt to fill in the missing descriptions in the Software profile. Where possible, I tried to copy from the SPDX-2.3 specification.
Please note that this does not aim to be the final solution but will hopefully start discussions on possibly controversial points.

This misses descriptions for
- packageUrl
- contentIdentifier
- File

which I was not sure about their actual definition.