### PR TITLE
add missing name properties to Package and Snippet

### DIFF
--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -8,6 +8,7 @@ TODO
 
 ## Metadata
 
+- name: Package
 - SubclassOf: Core:Artifact
 
 ## Properties

--- a/model/Software/Classes/Snippet.md
+++ b/model/Software/Classes/Snippet.md
@@ -8,6 +8,7 @@ TODO
 
 ## Metadata
 
+- name: Snippet
 - SubclassOf: Core:Artifact
 
 ## Properties


### PR DESCRIPTION
these two properties were missed in the metadata of two files.