### PR TITLE
add hyphens to markdown

### DIFF
--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -12,5 +12,5 @@ The Build namespace defines concepts related to building of artifacts.
 
 ## Metadata
 
-id: https://rdf.spdx.org/v3#Build
-name: Build
+- id: https://rdf.spdx.org/v3#Build
+- name: Build


### PR DESCRIPTION
This is necessary to adhere to the machine readable format.