### PR TITLE
Add `xsd:` namespace to `anyURI`

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -24,7 +24,7 @@ and inter-relatable content objects.
 ## Properties
 
 - spdxId
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 1
   - maxCount: 1
 - name

--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -24,12 +24,12 @@ such as its provenance, where to retrieve it, and how to verify its integrity.
 ## Properties
 
 - externalId
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 1
   - maxCount: 1
 - verifiedUsing
   - type: IntegrityMethod
 - locationHint
-  - type: anyURI
+  - type: xsd:anyURI
   - maxCount: 1
 

--- a/model/Core/Classes/ExternalReference.md
+++ b/model/Core/Classes/ExternalReference.md
@@ -23,7 +23,7 @@ location and context of a resource outside of the scope of SPDX-3.0 content.
   - type: ExternalReferenceType
   - maxCount: 1
 - locator
-  - type: anyURI
+  - type: xsd:anyURI
 - contentType
   - type: MediaType
   - maxCount: 1

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -21,6 +21,6 @@ TODO
   - type: xsd:string
   - maxCount: 1
 - namespace
-  - type: anyURI
+  - type: xsd:anyURI
   - maxCount: 1
 

--- a/model/Core/Properties/externalId.md
+++ b/model/Core/Properties/externalId.md
@@ -14,5 +14,5 @@ A externalId is TODO
 
 - name: externalId
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Core/Properties/locationHint.md
+++ b/model/Core/Properties/locationHint.md
@@ -14,5 +14,5 @@ A locationHint is TODO
 
 - name: locationHint
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Core/Properties/locator.md
+++ b/model/Core/Properties/locator.md
@@ -14,5 +14,5 @@ A locator is TODO
 
 - name: locator
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Core/Properties/namespace.md
+++ b/model/Core/Properties/namespace.md
@@ -14,5 +14,5 @@ A namespace is TODO
 
 - name: namespace
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Core/Properties/spdxId.md
+++ b/model/Core/Properties/spdxId.md
@@ -14,5 +14,5 @@ A spdxId is TODO
 
 - name: spdxId
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Software/Classes/File.md
+++ b/model/Software/Classes/File.md
@@ -14,7 +14,7 @@ TODO This is about the File class.
 ## Properties
 
 - contentIdentifier
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 - filePurpose

--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -13,22 +13,22 @@ TODO
 ## Properties
 
 - contentIdentifier
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 - packagePurpose
   - type: SoftwarePurpose
   - minCount: 0
 - downloadLocation
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 - packageUrl
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 - homePage
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 

--- a/model/Software/Classes/Snippet.md
+++ b/model/Software/Classes/Snippet.md
@@ -13,7 +13,7 @@ TODO
 ## Properties
 
 - contentIdentifier
-  - type: anyURI
+  - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
 - snippetPurpose

--- a/model/Software/Properties/contentIdentifier.md
+++ b/model/Software/Properties/contentIdentifier.md
@@ -14,5 +14,5 @@ A contentIdentifier is TODO
 
 - name: contentIdentifier
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Software/Properties/downloadLocation.md
+++ b/model/Software/Properties/downloadLocation.md
@@ -14,5 +14,5 @@ A downloadLocation is TODO
 
 - name: downloadLocation
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Software/Properties/homePage.md
+++ b/model/Software/Properties/homePage.md
@@ -14,5 +14,5 @@ A homePage is TODO
 
 - name: homePage
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -14,5 +14,5 @@ A packageUrl is TODO
 
 - name: packageUrl
 - Nature: DataProperty
-- Range: anyURI
+- Range: xsd:anyURI
 


### PR DESCRIPTION
anyURI is part of the xml schema: https://www.w3.org/TR/xmlschema11-2/#anyURI
Therefore we should prepend it with the `xsd:` namespace.