### PR TITLE
External properties restrictions

### DIFF
--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -24,3 +24,8 @@ Commonly used when representing a unit of transfer of SPDX Elements.
   - minCount: 1
   - maxCount: 1
 
+## External properties restrictions
+
+- /Core/Element/name
+  - minCount: 1
+

--- a/model/Software/Classes/File.md
+++ b/model/Software/Classes/File.md
@@ -13,7 +13,7 @@ TODO This is about the File class.
 ## Metadata
 
 - name: File
-- SubclassOf: Core:Artifact
+- SubclassOf: /Core/Artifact
 
 ## Properties
 

--- a/model/Software/Classes/File.md
+++ b/model/Software/Classes/File.md
@@ -29,3 +29,8 @@ TODO This is about the File class.
   - minCount: 0
   - maxCount: 1
 
+## External properties restrictions
+
+- /Core/Element/name
+  - minCount: 1
+

--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -52,3 +52,8 @@ Note that some of these could be represented in SPDX as a file as well.
   - minCount: 0
   - maxCount: 1
 
+## External properties restrictions
+
+- /Core/Element/name
+  - minCount: 1
+

--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -24,7 +24,7 @@ Note that some of these could be represented in SPDX as a file as well.
 ## Metadata
 
 - name: Package
-- SubclassOf: Core:Artifact
+- SubclassOf: /Core/Artifact
 
 ## Properties
 

--- a/model/Software/Classes/Sbom.md
+++ b/model/Software/Classes/Sbom.md
@@ -16,7 +16,7 @@ its composition, licensing information, known quality or security issues, etc.
 ## Metadata
 
 - name: Sbom
-- SubclassOf: Core:Bom
+- SubclassOf: /Core/Bom
 
 ## Properties
 

--- a/model/Software/Classes/Snippet.md
+++ b/model/Software/Classes/Snippet.md
@@ -15,7 +15,7 @@ may have been originally created under another license or copied from a place wi
 ## Metadata
 
 - name: Snippet
-- SubclassOf: Core:Artifact
+- SubclassOf: /Core/Artifact
 
 ## Properties
 


### PR DESCRIPTION
Adds restrictions to external properties

The way to specify restrictions to external properties is:

- refer to the external property as a complete path of /{profile}/{class}/{property}
- add the shape defintion, which overwrites the original one.

Realistically, the restrictions will mostly be optional properties becoming mandatory,
i.e., minCount changing from 0 to 1.

