### PR TITLE
Renames the property of set member

### DIFF
--- a/model/Licensing/Classes/ConjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/ConjunctiveLicenseSet.md
@@ -29,6 +29,6 @@ left to the consumer of SPDX data to determine for themselves.
 
 ## Properties
 
-- child
+- member
   - type: LicenseExpression
   - minCount: 2

--- a/model/Licensing/Classes/DisjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/DisjunctiveLicenseSet.md
@@ -26,6 +26,6 @@ by the `OR` operator.
 
 ## Properties
 
-- child
+- member
   - type: LicenseExpression
   - minCount: 2

--- a/model/Licensing/Properties/member.md
+++ b/model/Licensing/Properties/member.md
@@ -1,0 +1,21 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# member
+
+## Summary
+
+A member is a license expression participating in a license set.
+
+## Description
+
+A member is a license expression participating
+in a conjuctive (of type ConjunctiveLicenseSet)
+or a disjunctive (of type DisjunctiveLicenseSet)
+license set.
+
+
+## Metadata
+
+- name: member
+- Nature: ObjectProperty
+- Range: LicenseExpression


### PR DESCRIPTION
Sets have members, not children.