### PR TITLE
Add License properties

### DIFF
--- a/model/Licensing/Properties/comment.md
+++ b/model/Licensing/Properties/comment.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# comment
+
+## Summary
+
+Comment on the license.
+
+## Description
+
+This field provides commentary on the license.
+
+## Metadata
+
+- name: comment
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/comment.md
+++ b/model/Licensing/Properties/comment.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Comment on the license.
+TODO
 
 ## Description
 
-This field provides commentary on the license.
+TODO
 
 ## Metadata
 

--- a/model/Licensing/Properties/deprecatedVersion.md
+++ b/model/Licensing/Properties/deprecatedVersion.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# deprecatedVersion
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: deprecatedVersion
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/example.md
+++ b/model/Licensing/Properties/example.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# example
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: example
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/isDeprecatedLicenseId.md
+++ b/model/Licensing/Properties/isDeprecatedLicenseId.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# isDeprecatedLicenseId
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: isDeprecatedLicenseId
+- Nature: DataProperty
+- Range: xsd:boolean

--- a/model/Licensing/Properties/isFsfLibre.md
+++ b/model/Licensing/Properties/isFsfLibre.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# isFsfLibre
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: isFsfLibre
+- Nature: DataProperty
+- Range: xsd:boolean

--- a/model/Licensing/Properties/isOsiApproved.md
+++ b/model/Licensing/Properties/isOsiApproved.md
@@ -1,0 +1,17 @@
+#SPDX-License-Identifier: Community-Spec-1.0
+
+# isOsiApproved
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: isOsiApproved
+- Nature: DataProperty
+- Range: xsd:boolean

--- a/model/Licensing/Properties/licenseId.md
+++ b/model/Licensing/Properties/licenseId.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The ID of the license.
+TODO
 
 ## Description
 
-This field provides the ID of the license.
+TODO
 
 ## Metadata
 

--- a/model/Licensing/Properties/licenseId.md
+++ b/model/Licensing/Properties/licenseId.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# licenseId
+
+## Summary
+
+The ID of the license.
+
+## Description
+
+This field provides the ID of the license.
+
+## Metadata
+
+- name: licenseId
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/licenseText.md
+++ b/model/Licensing/Properties/licenseText.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# licenseText
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: licenseText
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/listVersionAdded.md
+++ b/model/Licensing/Properties/listVersionAdded.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# listVersionAdded
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: listVersionAdded
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/name.md
+++ b/model/Licensing/Properties/name.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The name of the license.
+TODO
 
 ## Description
 
-This field provides the name of the license.
+TODO
 
 ## Metadata
 

--- a/model/Licensing/Properties/name.md
+++ b/model/Licensing/Properties/name.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# name
+
+## Summary
+
+The name of the license.
+
+## Description
+
+This field provides the name of the license.
+
+## Metadata
+
+- name: name
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/obsoletedBy.md
+++ b/model/Licensing/Properties/obsoletedBy.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# obsoletedBy
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: obsoletedBy
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Licensing/Properties/seeAlso.md
+++ b/model/Licensing/Properties/seeAlso.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# seeAlso
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: seeAlso
+- Nature: DataProperty
+- Range: xsd:anyURI

--- a/model/Licensing/Properties/standardLicenseHeader.md
+++ b/model/Licensing/Properties/standardLicenseHeader.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# standardLicenseHeader
+
+## Summary
+
+TODO
+
+## Description
+
+TODO
+
+## Metadata
+
+- name: standardLicenseHeader
+- Nature: DataProperty
+- Range: xsd:string


### PR DESCRIPTION
This adds the skeleton markdown files for the properties of the `License` class.

I noticed the following issue, already discussed in #167:
`name` and `comment` are already defined in Core. I suggest renaming them to `licenseName` and `licenseComment`. This in turn clashes with the already existing property `licenseComment`. The latter is not used (yet), and seems to only refer to concluded licenses, so I suggest renaming it to `concludedLicenseComment`.