### PR TITLE
add builtTime, releaseTime and validUntilTime to Artifact

### DIFF
--- a/model/Core/Classes/Artifact.md
+++ b/model/Core/Classes/Artifact.md
@@ -23,4 +23,15 @@ such as an electronic file, a software package, a device or an element of data.
 - originatedBy
   - type: Identity
   - minCount: 0
-
+- builtTime
+  - type: xsd:dateTime
+  - minCount: 0
+  - maxCount: 1
+- releaseTime
+  - type: xsd:dateTime
+  - minCount: 0
+  - maxCount: 1
+- validUntilTime
+  - type: xsd:dateTime
+  - minCount: 0
+  - maxCount: 1

--- a/model/Core/Properties/builtTime.md
+++ b/model/Core/Properties/builtTime.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# builtTime
+
+## Summary
+
+Specifies the time an artifact was built.
+
+## Description
+
+A builtTime specifies the time an artifact was built.
+
+## Metadata
+
+- name: builtTime
+- Nature: DataProperty
+- Range: xsd:dateTime
+

--- a/model/Core/Properties/releaseTime.md
+++ b/model/Core/Properties/releaseTime.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# releaseTime
+
+## Summary
+
+Specifies the time an artifact was released.
+
+## Description
+
+A releaseTime specifies the time an artifact was released.
+
+## Metadata
+
+- name: releaseTime
+- Nature: DataProperty
+- Range: xsd:dateTime
+

--- a/model/Core/Properties/validUntilTime.md
+++ b/model/Core/Properties/validUntilTime.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# validUntilTime
+
+## Summary
+
+Specifies until when the artifact can be used before its usage needs to be reassessed.
+
+## Description
+
+A validUntilTime specifies until when the artifact can be used before its usage needs to be reassessed.
+
+## Metadata
+
+- name: validUntilTime
+- Nature: DataProperty
+- Range: xsd:dateTime
+


### PR DESCRIPTION
These entries not only ensure compatibility with 2.3 but can also be used by other profiles like dataset.