### PR TITLE
Dataset profile: use DictionaryEntry for sensors property

### DIFF
--- a/model/Dataset/Classes/Dataset.md
+++ b/model/Dataset/Classes/Dataset.md
@@ -39,7 +39,7 @@ Metadata information that can be added to a a dataset that maybe used in a softw
   - minCount: 0
   - maxCount: 1
 - sensors
-  - type: xsd:string
+  - type: /Core/DictionaryEntry
   - minCount: 0
 - knownBiases
   - type: xsd:string

--- a/model/Dataset/Properties/sensors.md
+++ b/model/Dataset/Properties/sensors.md
@@ -14,4 +14,4 @@ The sensor and its calibration value in the form Sensor:calibration is noted.
 
 - name: sensors
 - Nature: DataProperty
-- Range: xsd:string
+- Range: /Core/DictionaryEntry


### PR DESCRIPTION
The `sensors` property uses a key-value-style format, which is provided by the new `DictionaryEntry` class.