### PR TITLE
Propose changing "identification" to "verification"

### DIFF
--- a/model/Core/Classes/IntegrityMethod.md
+++ b/model/Core/Classes/IntegrityMethod.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides an independently reproducible mechanism that permits identification of a specific Element.
+Provides an independently reproducible mechanism that permits verification of a specific Element.
 
 ## Description
 
-An IntegrityMethod provides an independently reproducible mechanism that permits identification
+An IntegrityMethod provides an independently reproducible mechanism that permits verification
 of a specific Element that correlates to the data in this SPDX document. This identifier enables
 a recipient to determine if anything in the original Element has been changed and eliminates
 confusion over which version or modification of a specific Element is referenced.


### PR DESCRIPTION
IntegrityMethod is used for integrity, not identification.  We have identification classes for that purpose (e.g. `packageUrl`, `externalIdentifiers`).