### PR TITLE
Licensing: cleanup of TBDs and add summary text

### DIFF
--- a/model/Licensing/Classes/CustomLicense.md
+++ b/model/Licensing/Classes/CustomLicense.md
@@ -12,10 +12,6 @@ A CustomLicense represents a License that is not listed on the SPDX License
 List at https://spdx.org/licenses, and is therefore defined by an SPDX data
 creator.
 
-**TBD** whether to define the meaning and purpose for each of the properties
-
-**TBD** how to indicate that the License ID must have the prefix "LicenseRef-"
-
 ## Metadata
 
 - name: CustomLicense

--- a/model/Licensing/Classes/License.md
+++ b/model/Licensing/Classes/License.md
@@ -11,11 +11,6 @@ Abstract class for the portion of a LicenseExpression representing a license.
 A License represents a license text, whether listed on the SPDX License List
 (ListedLicense) or defined by an SPDX data creator (CustomLicense).
 
-**TBD** whether to define the meaning and purpose for each of the properties
-
-**TBD** whether licenseID should be a separately defined property, rather
-than xsd:string
-
 ## Metadata
 
 - name: License

--- a/model/Licensing/Classes/ListedLicense.md
+++ b/model/Licensing/Classes/ListedLicense.md
@@ -11,8 +11,6 @@ A license that is listed on the SPDX License List.
 A ListedLicense represents a License that is listed on the SPDX License List
 at https://spdx.org/licenses.
 
-**TBD** whether to define the meaning and purpose for each of the properties
-
 ## Metadata
 
 - name: ListedLicense

--- a/model/Licensing/Classes/NoAssertionLicense.md
+++ b/model/Licensing/Classes/NoAssertionLicense.md
@@ -9,8 +9,6 @@ information.
 
 ## Description
 
-**TBD** whether the meaning of NoAssertionLicense in the context of the concludedLicense and declaredLicense properties should be here rather than in those property definitions
-
 A NoAssertionLicense is the primary value that is used by a concludedLicense
 or declaredLicense field that indicates that the SPDX data creator is making
 no assertion about the license information for the corresponding software

--- a/model/Licensing/Classes/NoAssertionText.md
+++ b/model/Licensing/Classes/NoAssertionText.md
@@ -9,8 +9,6 @@ copyright text.
 
 ## Description
 
-**TBD** whether these details should be defined in the copyrightText property instead of here
-
 A NoAssertionText is the primary value that is used by a copyrightText field
 that indicates that the SPDX data creator is making no assertion about whether
 any copyright information is present, or what its contents are if it is

--- a/model/Licensing/Classes/NoneLicense.md
+++ b/model/Licensing/Classes/NoneLicense.md
@@ -9,8 +9,6 @@ present, as applicable.
 
 ## Description
 
-**TBD** whether the meaning of NoneLicense in the context of the concludedLicense and declaredLicense properties should be here rather than in those property definitions
-
 A NoneLicense is the primary value that is used by a concludedLicense or
 declaredLicense field that indicates the absence of license information from
 the corresponding software Package, File or Snippet.

--- a/model/Licensing/Classes/NoneText.md
+++ b/model/Licensing/Classes/NoneText.md
@@ -8,8 +8,6 @@ Concrete class representing an assertion that no copyright text is present.
 
 ## Description
 
-**TBD** whether these details should be defined in the copyrightText property instead of here
-
 A NoneText is the primary value that is used by a copyrightText field that
 indicates that the corresponding software Package, File or Snippet does not
 contain any copyright information.

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Additional metadata relating to software licensing.
 
 ## Description
 
-TODO
+The Licensing namespace defines metadata fields applicable to software
+licensing. It also defines the classes and properties that comprise the
+SPDX License Expression syntax and that relate to the SPDX License List.
 
 ## Metadata
 


### PR DESCRIPTION
This change removes several of the TBDs, which have been moved out into separate issue threads at:

* https://github.com/spdx/spdx-3-model/issues/204
* https://github.com/spdx/spdx-3-model/issues/205