### PR TITLE
Core: add PositiveIntegerRange class

### DIFF
--- a/model/Core/Classes/PositiveIntegerRange.md
+++ b/model/Core/Classes/PositiveIntegerRange.md
@@ -1,0 +1,30 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# PositiveIntegerRange
+
+## Summary
+
+A tuple of two positive integers that define a range.
+
+## Description
+
+PositiveIntegerRange is a tuple of two positive integers that define a range.
+"begin" must be less than or equal to "end".
+
+## Metadata
+
+- name: PositiveIntegerRange
+- SubclassOf: none
+- Instantiability: Concrete
+
+## Properties
+
+- begin
+  - type: xsd:positiveInteger
+  - minCount: 1
+  - maxCount: 1
+- end
+  - type: xsd:positiveInteger
+  - minCount: 1
+  - maxCount: 1
+

--- a/model/Core/Properties/begin.md
+++ b/model/Core/Properties/begin.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# begin
+
+## Summary
+
+Defines the beginning of a range.
+
+## Description
+
+begin is a positive integer that defines the beginning of a range.
+
+## Metadata
+
+- name: begin
+- Nature: DataProperty
+- Range: xsd:positiveInteger
+

--- a/model/Core/Properties/end.md
+++ b/model/Core/Properties/end.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# end
+
+## Summary
+
+Defines the end of a range.
+
+## Description
+
+end is a positive integer that defines the end of a range.
+
+## Metadata
+
+- name: end
+- Nature: DataProperty
+- Range: xsd:positiveInteger
+

--- a/model/Software/Classes/Snippet.md
+++ b/model/Software/Classes/Snippet.md
@@ -27,11 +27,11 @@ may have been originally created under another license or copied from a place wi
   - type: SoftwarePurpose
   - minCount: 0
 - byteRange
-  - type: positiveIntegerRange
+  - type: /Core/PositiveIntegerRange
   - minCount: 0
   - maxCount: 1
 - lineRange
-  - type: positiveIntegerRange
+  - type: /Core/PositiveIntegerRange
   - minCount: 0
   - maxCount: 1
 


### PR DESCRIPTION
I noticed that the `PositiveIntegerRange` class and its properties were not yet defined in markdown.
`PositiveIntegerRange` is currently only used in the Software namespace in the properties `byteRange` and `lineRange` of the `Snippet` class, but I think it is safer to include it in the Core namespace to enable future extensions to make use of it.