### PR TITLE
Build profile: use DictionaryEntry class for maps

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -42,7 +42,7 @@ ExternalIdentifier of type "urlScheme" may be used to identify build logs. In th
   - type: Hash
   - minCount: 0
 - parameters
-  - type: xsd:map<string>string
+  - type: /Core/DictionaryEntry
   - minCount: 0
 - buildStart
   - type: xsd:dateTime
@@ -53,5 +53,5 @@ ExternalIdentifier of type "urlScheme" may be used to identify build logs. In th
   - minCount:0
   - maxCount:1
 - environment
-  - type: xsd:map<string>string
+  - type: /Core/DictionaryEntry
   - minCount: 0

--- a/model/Build/Properties/environment.md
+++ b/model/Build/Properties/environment.md
@@ -14,4 +14,4 @@ environment is a map of environment variables and values that are set during a b
 
 - name: environment
 - Nature: DataProperty
-- Range: map<string>string
+- Range: /Core/DictionaryEntry

--- a/model/Build/Properties/parameters.md
+++ b/model/Build/Properties/parameters.md
@@ -14,5 +14,5 @@ parameters is a key-value map of all build parameters and their values that were
 
 - name: parameters
 - Nature: DataProperty
-- Range: map<string>string
+- Range: /Core/DictionaryEntry
 


### PR DESCRIPTION
This replaces the key-value-like property types with the new DictionaryEntry class.