### PR TITLE
add spaces for parsing compatibility

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -46,12 +46,12 @@ ExternalIdentifier of type "urlScheme" may be used to identify build logs. In th
   - minCount: 0
 - buildStart
   - type: xsd:dateTime
-  - minCount:0
-  - maxCount:1
+  - minCount: 0
+  - maxCount: 1
 - buildEnd
   - type: xsd:dateTime
-  - minCount:0
-  - maxCount:1
+  - minCount: 0
+  - maxCount: 1
 - environment
   - type: xsd:map<string>string
   - minCount: 0

--- a/model/Dataset/Classes/Dataset.md
+++ b/model/Dataset/Classes/Dataset.md
@@ -21,7 +21,7 @@ Metadata information that can be added to a dataset that may be used in a softwa
 - dataCollectionProcess
   - type: xsd:string
   - minCount: 0
-  - maxCount:1
+  - maxCount: 1
 - intendedUse
   - type: xsd:string
   - minCount: 0


### PR DESCRIPTION
This adds a few missing spaces so that the automated spec-parser can parse the files.