### PR TITLE
Dataset: fix names and cardinalities

### DIFF
--- a/model/Dataset/Classes/Dataset.md
+++ b/model/Dataset/Classes/Dataset.md
@@ -45,15 +45,17 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - type: xsd:string
   - minCount: 0
   - maxCount: 1
-- sensitivePersonalInformationType
+- sensitivePersonalInformation
   - type: PresenceType
   - minCount: 0
+  - maxCount: 1
 - anonymizationMethodUsed
   - type: xsd:string
   - minCount: 0
-- confidentialityLevelType
+- confidentialityLevel
   - type: ConfidentialityLevelType
   - minCount: 0
+  - maxCount: 1
 - datasetUpdateMechanism
   - type: xsd:string
   - minCount: 0


### PR DESCRIPTION
I fixed two property names to match the ones in the Properties folder.
Also added `maxCount: 1` to both as it does not make sense to have multiple values for `sensitivePersonalInformation` (a boolean) or `confidentialityLevel`.