### PR TITLE
Core: Use singular for properties

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -45,10 +45,10 @@ and inter-relatable content objects.
   - maxCount: 1
 - verifiedUsing
   - type: IntegrityMethod
-- externalReferences
+- externalReference
   - type: ExternalReference
-- externalIdentifiers
+- externalIdentifier
   - type: ExternalIdentifier
-- extensions
+- extension
   - type: Extension
 

--- a/model/Core/Properties/extension.md
+++ b/model/Core/Properties/extension.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# extensions
+# extension
 
 ## Summary
 
@@ -12,5 +12,5 @@ TODO
 
 ## Metadata
 
-- name: extensions
+- name: extension
 

--- a/model/Core/Properties/externalIdentifier.md
+++ b/model/Core/Properties/externalIdentifier.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalIdentifiers
+# externalIdentifier
 
 ## Summary
 
@@ -14,7 +14,7 @@ that uniquely identifies an Element.
 
 ## Metadata
 
-- name: externalIdentifiers
+- name: externalIdentifier
 - Nature: ObjectProperty
 - Range: ExternalIdentifier
 

--- a/model/Core/Properties/externalReference.md
+++ b/model/Core/Properties/externalReference.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalReferences
+# externalReference
 
 ## Summary
 
@@ -14,7 +14,7 @@ that provides additional characteristics of an Element.
 
 ## Metadata
 
-- name: externalReferences
+- name: externalReference
 - Nature: ObjectProperty
 - Range: ExternalReference
 


### PR DESCRIPTION
According to https://github.com/spdx/spdx-3-model/issues/226, property names should be kept singular. I changed this for Core.

Two issues remain:
- There are both `namespace` and `namespaces`. Maybe we can find a better word for the latter as it is actually a `namespaceMap`?
- `imports` would become `import`, which would be a keyword in many programming languages, for example in Python. That is not a good idea. As this is an external map, maybe `importMap` might be an idea?