### PR TITLE
Build profile: use slash notation to reference classes from Core

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -19,7 +19,7 @@ ExternalIdentifier of type "urlScheme" may be used to identify build logs. In th
 ## Metadata
 
 - name: Build
-- SubclassOf: Core:Element
+- SubclassOf: /Core/Element
 - Instantiability: Concrete
 
 ## Properties
@@ -39,7 +39,7 @@ ExternalIdentifier of type "urlScheme" may be used to identify build logs. In th
   - type: xsd:anyURI
   - minCount: 0
 - configSourceDigest
-  - type: Hash
+  - type: /Core/Hash
   - minCount: 0
 - parameters
   - type: xsd:map<string>string

--- a/model/Build/Properties/configSourceDigest.md
+++ b/model/Build/Properties/configSourceDigest.md
@@ -14,5 +14,5 @@ configSourceDigest is the checksum of the build configuration file used by a bui
 
 - name: configSourceDigest
 - Nature: DataProperty
-- Range: Hash
+- Range: /Core/Hash
 


### PR DESCRIPTION
As is used for example [here](https://github.com/spdx/spdx-3-model/blob/main/model/Software/Classes/Package.md).