### PR TITLE
Adds DateTime data type in Core

### DIFF
--- a/model/Core/Classes/DateTime.md
+++ b/model/Core/Classes/DateTime.md
@@ -1,0 +1,25 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# DateTime
+
+## Summary
+
+A string representing a specific date and time.
+
+## Description
+
+A Datetime is a string representation of a specific date and time.
+It has resolution of seconds and is always expressed in UTC timezone.
+The specific format is one of the most commonly used ISO-8601 formats.
+
+## Metadata
+
+- name: DateTime
+- SubclassOf: xsd:string
+
+## Properties
+
+## Format
+
+- pattern: ^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$
+


### PR DESCRIPTION
The type might as well be called `Timestamp`,
but `DateTime` is already well-known from xsd.

Closes #215

Signed-off-by: Alexios Zavras (zvr) <github@zvr.gr>
