### PR TITLE
Add identifier property

### DIFF
--- a/model/Core/Properties/identifier.md
+++ b/model/Core/Properties/identifier.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# identifier
+
+## Summary
+
+Uniquely identifies an external element.
+
+## Description
+
+An identifier uniquely identifies an external element.
+
+## Metadata
+
+- name: identifier
+- Nature: DataProperty
+- Range: xsd:string
+


### PR DESCRIPTION
The markdown file for the identifier property was still missing in core. 