### PR TITLE
Security Profile: Add Relationship Types

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -66,4 +66,7 @@ Build Profile specific RelationshipType descriptions can be found [here](https:/
 - buildInvokedBy: Agent that invoked the build
 - buildOnBehalfOf: Actor for which buildInvokedBy is acting on behalf of
 - buildHostOf: Element in which the build instance runs on
-
+- affected: (Security/VEX) Designates an elemented as affected by a vulnerability
+- notAffected: (Security/VEX) Specifies a vulnerability has no impact on an element
+- fixed: (Security/VEX) A vulnerability has been fixed in an element
+- underInvestigation: (Security/VEX) The impact of a vulnerability is being investigated


### PR DESCRIPTION
This PR adds the new relationship types required by the security profile.

The first commit adds the VEX relationship types required by `VulnerabilityVexAssessmentRelationship`:

 - affected
 - notAffected
 - fixed
 - underInvestigation

**HOLD** until the final Security profile is in 

/cc @tsteenbe @rnjudge @jeff-schutt @karsten-klein @goneall 

