### PR TITLE
Add new types to ExternalReferenceType

### DIFF
--- a/model/Core/Vocabularies/ExternalReferenceType.md
+++ b/model/Core/Vocabularies/ExternalReferenceType.md
@@ -18,7 +18,23 @@ ExteralReferenceType specifies the type of an external reference.
 
 - altDownloadLocation: A reference to an alternative download location.
 - altWebPage: A reference to an alternative web page.
+- binaryArtifact: A reference to binary artifacts related to a package.
+- buildMeta: A reference build metadata related to a published package.
+- buildSystem: A reference build system used to create or publish the package.
+- chat: A reference to the instant messaging system used by the maintainer for a package.
+- documentation: A reference to the documentation for a package.
+- funding: A reference to funding informaton related to a package.
+- issueTracker: A reference to the issue tracker for a package.
+- mailingList: A reference to the mailing list used by the maintainer for a package.
+- metrics: A reference to metrics related to package such as OpenSSF scorecards.
+- license: A reference to additional license information related to an artifact.
 - other: Used when the type doesn't match any of the other options.
-- securityAdvisory: A reference to a published security advisory (where advisory as defined per ISO 29147:2018) that may affect one or more elements, e.g., vendor advisories or specific NVD entries
-- securityFix: A reference to the patch or source code that fixes a vulnerability
-- securityOther: A reference to related security information of unspecified type
+- releaseNotes: A reference to the release notes for a package.
+- releaseHistory: A reference to published list of releases for a package.
+- securityAdvisory: A reference to a published security advisory (where advisory as defined per ISO 29147:2018) that may affect one or more elements, e.g., vendor advisories or specific NVD entries.
+- securityFix: A reference to the patch or source code that fixes a vulnerability.
+- securityOther: A reference to related security information of unspecified type.
+- socialMedia: A reference to social media channel for a package.
+- sourceArtifact: A reference to an artifact containing the sources for a package.
+- support: A reference to support channel for a package.
+- vcs: A reference to a version control system related to a software artifact.


### PR DESCRIPTION
Provide SPDX creators an option to easily share any (raw) info collected which may be useful or can be clean-up by downstream users.

Relates-to: #251