### PR TITLE
AI: Fix no assertion casing to match core

### DIFF
--- a/model/AI/Vocabularies/PresenceType.md
+++ b/model/AI/Vocabularies/PresenceType.md
@@ -18,4 +18,4 @@ This type is used to indicate if a given field is present or absent or unknown.
 
 - yes: Indicates presence of the field.
 - no: Indicates absence of the field.
-- noassertion: Makes no assertion about the field. 
+- noAssertion: Makes no assertion about the field. 


### PR DESCRIPTION
This commit changes `noassertion` to `noAssertion` in the AI PresenceType vocabulary to match core's.