### PR TITLE
Update VEX relationships to even their directions and add prepositions

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -66,7 +66,7 @@ Build Profile specific RelationshipType descriptions can be found [here](https:/
 - buildInvokedBy: Agent that invoked the build
 - buildOnBehalfOf: Actor for which buildInvokedBy is acting on behalf of
 - buildHostOf: Element in which the build instance runs on
-- affected: (Security/VEX) Designates an elemented as affected by a vulnerability
-- notAffected: (Security/VEX) Specifies a vulnerability has no impact on an element
-- fixed: (Security/VEX) A vulnerability has been fixed in an element
-- underInvestigation: (Security/VEX) The impact of a vulnerability is being investigated
+- affects: (Security/VEX) Designates one or more elements as affected by a vulnerability
+- doesNotAffect: (Security/VEX) Specifies a vulnerability has no impact on one or more elements
+- fixedIn: (Security/VEX) A vulnerability has been fixed in one or more elements
+- underInvestigationFor: (Security/VEX) The impact of a vulnerability is being investigated


### PR DESCRIPTION
This commit modifies the proposed VEX relationships to make them all work in the same direction: from vulnerability to (VEX) product addressing [feedback from the tech call on May 2 2023](https://github.com/spdx/spdx-3-model/pull/248#issuecomment-1531761847).

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>