### PR TITLE
Update security externalReferenceType descriptions

### DIFF
--- a/model/Core/Vocabularies/ExternalReferenceType.md
+++ b/model/Core/Vocabularies/ExternalReferenceType.md
@@ -19,7 +19,6 @@ ExteralReferenceType specifies the type of an external reference.
 - altDownloadLocation: A reference to an alternative download location.
 - altWebPage: A reference to an alternative web page.
 - other: Used when the type doesn't match any of the other options.
-- securityAdvisory: A reference to the published security advisory (where advisory as defined per ISO 29147:2018). It may contain an impact statement whether a package (e.g. a product) is or is not affected by vulnerabilities.
-- securityFix: A reference to the source code with a fix for the vulnerability (e.g., a GitHub commit). 
-- securityOther: Used when the reference is security related but doesn't match any of the other types.
-
+- securityAdvisory: A reference to a published security advisory (where advisory as defined per ISO 29147:2018) that may affect one or more elements, e.g., vendor advisories or specific NVD entries
+- securityFix: A reference to the patch or source code that fixes a vulnerability
+- securityOther: A reference to related security information of unspecified type


### PR DESCRIPTION
Update the `securityAdvisory`, `securityFix`, and `securityOther` external reference type definitions based on discussion in the defects working group call on May 3rd.