### PR TITLE
Licensing: Rename LicenseExpression to AnyLicenseInfo

### DIFF
--- a/model/Licensing/Classes/AnyLicenseInfo.md
+++ b/model/Licensing/Classes/AnyLicenseInfo.md
@@ -1,16 +1,16 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# LicenseExpression
+# AnyLicenseInfo
 
 ## Summary
 
-Abstract class representing a license expression consisting of one or more
+Abstract class representing a license combination consisting of one or more
 licenses (optionally including exceptions), which may be combined according
 to the SPDX license expression syntax.
 
 ## Description
 
-A LicenseExpression is used by a licensing field for a software package,
+An AnyLicenseInfo is used by a licensing field for a software package,
 file or snippet when its value is not NOASSERTION or NONE. It can be a
 single license (either on the SPDX License List or a custom-defined license);
 a single license with an "or later" operator applied; the foregoing with an
@@ -19,7 +19,7 @@ operators recursively.
 
 ## Metadata
 
-- name: LicenseExpression
+- name: AnyLicenseInfo
 - SubclassOf: LicenseField
 - Instantiability: Abstract
 

--- a/model/Licensing/Classes/ConjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/ConjunctiveLicenseSet.md
@@ -4,19 +4,19 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Portion of a LicenseExpression representing a set of licensing information
+Portion of an AnyLicenseInfo representing a set of licensing information
 where all elements apply.
 
 ## Description
 
 A ConjunctiveLicenseSet indicates that _each_ of its subsidiary
-LicenseExpressions apply. In other words, a ConjunctiveLicenseSet of two or
+AnyLicenseInfos apply. In other words, a ConjunctiveLicenseSet of two or
 more licenses represents a licensing situation where _all_ of the specified
 licenses are to be complied with. It is represented in the SPDX License
 Expression Syntax by the `AND` operator.
 
 It is syntactically correct to specify a ConjunctiveLicenseSet where the
-subsidiary LicenseExpressions may be "incompatible" according to a particular
+subsidiary AnyLicenseInfos may be "incompatible" according to a particular
 interpretation of the corresponding Licenses. The SPDX License Expression
 Syntax does not take into account interpretation of license texts, which is
 left to the consumer of SPDX data to determine for themselves.
@@ -24,11 +24,11 @@ left to the consumer of SPDX data to determine for themselves.
 ## Metadata
 
 - name: ConjunctiveLicenseSet
-- SubclassOf: LicenseExpression
+- SubclassOf: AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties
 
 - member
-  - type: LicenseExpression
+  - type: AnyLicenseInfo
   - minCount: 2

--- a/model/Licensing/Classes/DisjunctiveLicenseSet.md
+++ b/model/Licensing/Classes/DisjunctiveLicenseSet.md
@@ -4,13 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Portion of a LicenseExpression representing a set of licensing information
+Portion of an AnyLicenseInfo representing a set of licensing information
 where only any one of the elements applies.
 
 ## Description
 
 A DisjunctiveLicenseSet indicates that _only one_ of its subsidiary
-LicenseExpressions is required to apply. In other words, a
+AnyLicenseInfos is required to apply. In other words, a
 DisjunctiveLicenseSet of two or more licenses represents a licensing
 situation where _only one_ of the specified licenses are to be complied with.
 A consumer of SPDX data would typically understand this to permit the recipient
@@ -21,11 +21,11 @@ by the `OR` operator.
 ## Metadata
 
 - name: DisjunctiveLicenseSet
-- SubclassOf: LicenseExpression
+- SubclassOf: AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties
 
 - member
-  - type: LicenseExpression
+  - type: AnyLicenseInfo
   - minCount: 2

--- a/model/Licensing/Classes/License.md
+++ b/model/Licensing/Classes/License.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Abstract class for the portion of a LicenseExpression representing a license.
+Abstract class for the portion of an AnyLicenseInfo representing a license.
 
 ## Description
 
@@ -14,7 +14,7 @@ A License represents a license text, whether listed on the SPDX License List
 ## Metadata
 
 - name: License
-- SubclassOf: LicenseExpression
+- SubclassOf: AnyLicenseInfo
 - Instantiability: Abstract
 
 ## Properties

--- a/model/Licensing/Classes/OrLaterOperator.md
+++ b/model/Licensing/Classes/OrLaterOperator.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Portion of a LicenseExpression representing this version, or any later version,
+Portion of an AnyLicenseInfo representing this version, or any later version,
 of the indicated License.
 
 ## Description
 
-An OrLaterOperator indicates that this portion of the LicenseExpression
+An OrLaterOperator indicates that this portion of the AnyLicenseInfo
 represents either (1) the specified version of the corresponding License, or
 (2) any later version of that License. It is represented in the SPDX License
 Expression Syntax by the `+` operator.
@@ -23,7 +23,7 @@ data will need to determine for themselves what meaning to attribute to a
 ## Metadata
 
 - name: OrLaterOperator
-- SubclassOf: LicenseExpression
+- SubclassOf: AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties

--- a/model/Licensing/Classes/WithExceptionOperator.md
+++ b/model/Licensing/Classes/WithExceptionOperator.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 ## Metadata
 
 - name: WithExceptionOperator
-- SubclassOf: LicenseExpression
+- SubclassOf: AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties

--- a/model/Licensing/Properties/member.md
+++ b/model/Licensing/Properties/member.md
@@ -16,4 +16,4 @@ license set.
 
 - name: member
 - Nature: ObjectProperty
-- Range: LicenseExpression
+- Range: AnyLicenseInfo


### PR DESCRIPTION
Fixes #222 

Signed-off-by: Steve Winslow <steve@swinslow.net>