### PR TITLE
Fixup various Element properties

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -47,6 +47,7 @@ and inter-relatable content objects.
   - type: IntegrityMethod
 - externalReference
   - type: ExternalReference
+  - minCount: 0
 - externalIdentifier
   - type: ExternalIdentifier
 - extension

--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -41,7 +41,7 @@ and inter-relatable content objects.
   - maxCount: 1
 - creationInfo
   - type: CreationInfo
-  - minCount: 1
+  - minCount: 0
   - maxCount: 1
 - verifiedUsing
   - type: IntegrityMethod

--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -53,4 +53,5 @@ and inter-relatable content objects.
   - minCount: 0
 - extension
   - type: Extension
+  - minCount: 0
 

--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -50,6 +50,7 @@ and inter-relatable content objects.
   - minCount: 0
 - externalIdentifier
   - type: ExternalIdentifier
+  - minCount: 0
 - extension
   - type: Extension
 


### PR DESCRIPTION
Made CreationInfo optional to prevent SBOM bloating see for example https://gist.github.com/meretp/561e4ea963122f5811a147ea056e4d84#file-example-jsonld-L29-L75. CreationInfo should only be mandatory on certain elements such as SPDXDocument, Bundle, etc. 

IMO SPDX should enable linked data format such as JSON-LD and RDF but it must not make it mandatory for JSON and YAML formats. Often heard complaint about SPDX 2.x was that it was too complex/bloated, we should not make the same mistake in SPDX 3.0 but providing something simple for those that just want to exchange data and enable linked data SBOM for parties that want to graph reasoning.

Ping @maxhbr  @jeff-schutt  @puerco - please add your opinion from our discussions here as well.
