### PR TITLE
change # to / and add root .md for dataset profile

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -12,5 +12,5 @@ The AI profile namespace defines concepts related to AI application and model ar
 
 ## Metadata
 
-- id: https://rdf.spdx.org/v3#AI
+- id: https://rdf.spdx.org/v3/AI
 - name: AI

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -12,5 +12,5 @@ The Build namespace defines concepts related to building of artifacts.
 
 ## Metadata
 
-- id: https://rdf.spdx.org/v3#Build
+- id: https://rdf.spdx.org/v3/Build
 - name: Build

--- a/model/Core/Core.md
+++ b/model/Core/Core.md
@@ -12,6 +12,6 @@ The Core namespace defines foundational concepts serving as the basis for all SP
 
 ## Metadata
 
-- id: https://rdf.spdx.org/v3#Core
+- id: https://rdf.spdx.org/v3/Core
 - name: Core
 

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# Dataset
+
+## Summary
+
+Everything having to do with datasets.
+
+## Description
+
+The Dataset namespace defines tbd.
+
+## Metadata
+
+- id: https://rdf.spdx.org/v3/Dataset
+- name: Dataset
+

--- a/model/Software/Software.md
+++ b/model/Software/Software.md
@@ -12,6 +12,6 @@ The Software namespace defines concepts related to software artifacts.
 
 ## Metadata
 
-- id: https://rdf.spdx.org/v3#Software
+- id: https://rdf.spdx.org/v3/Software
 - name: Software
 


### PR DESCRIPTION
This changes the ids in the root md files to the convention used in the generated spec and adds a `Dataset.md`.