### PR TITLE
Add Time to build time properties for consistency

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -46,11 +46,11 @@ Note that buildStart and buildEnd are optional, and may be omitted to simplify c
 - parameters
   - type: /Core/DictionaryEntry
   - minCount: 0
-- buildStart
+- buildStartTime
   - type: /Core/DateTime
   - minCount: 0
   - maxCount: 1
-- buildEnd
+- buildEndTime
   - type: /Core/DateTime
   - minCount: 0
   - maxCount: 1

--- a/model/Build/Properties/buildEndTime.md
+++ b/model/Build/Properties/buildEndTime.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# buildEnd
+# buildEndTime
 
 ## Summary
 
@@ -8,10 +8,10 @@ Property that describes the time at which a build stops.
 
 ## Description
 
-buildEnd describes the time at which a build stops or finishes. This value is typically recorded by the builder.
+buildEndTime describes the time at which a build stops or finishes. This value is typically recorded by the builder.
 
 ## Metadata
 
-- name: buildEnd
+- name: buildEndTime
 - Nature: DataProperty
 - Range: /Core/DateTime

--- a/model/Build/Properties/buildStartTime.md
+++ b/model/Build/Properties/buildStartTime.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# buildStart
+# buildStartTime
 
 ## Summary
 
@@ -8,10 +8,10 @@ Property describing the start time of a build.
 
 ## Description
 
-buildStart is the time at which a build is triggered. The builder typically records this value.
+buildStartTime is the time at which a build is triggered. The builder typically records this value.
 
 ## Metadata
 
-- name: buildStart
+- name: buildStartTime
 - Nature: DataProperty
 - Range: /Core/DateTime


### PR DESCRIPTION
Most time related fields in the spec end with Time.