### PR TITLE
Create standard.md

### DIFF
--- a/model/Core/Classes/Artifact.md
+++ b/model/Core/Classes/Artifact.md
@@ -38,3 +38,6 @@ such as an electronic file, a software package, a device or an element of data.
   - type: DateTime
   - minCount: 0
   - maxCount: 1
+- standard
+  - type: xsd:string
+  - minCount: 0 

--- a/model/Core/Properties/standard.md
+++ b/model/Core/Properties/standard.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# standard
+
+## Summary
+
+The relevant standards that may apply to an artifact.
+
+## Description
+
+Various standards may be relevant to useful to capture for specific artifacts. 
+
+## Metadata
+
+- name: hashValue
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/Core/Properties/standard.md
+++ b/model/Core/Properties/standard.md
@@ -12,6 +12,6 @@ Various standards may be relevant to useful to capture for specific artifacts.
 
 ## Metadata
 
-- name: hashValue
+- name: standard
 - Nature: DataProperty
 - Range: xsd:string


### PR DESCRIPTION
Standards are being captured today in SPDX 2.3 in a comment field, and the AI, Dataset, and Usage profile all want to capture them as well.   Moving this as an optional field on artifact, so that there is a standard way to capture this relevant information.