### PR TITLE
Remove relationshipType from subclasses

### DIFF
--- a/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
@@ -43,8 +43,6 @@ to the affects relationship type.
 - Instantiability: Concrete
 
 ## Properties
-- relationshipType
-  - type: /Core/relationshipType
 - actionStatement
   - type: xsd:string
   - minCount: 0

--- a/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
@@ -46,5 +46,3 @@ element.
 - Instantiability: Concrete
 
 ## Properties
-- relationshipType
-  - type: /Core/relationshipType

--- a/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
@@ -53,8 +53,6 @@ for VEX.
 
 ## Properties
 
-- relationshipType
-  - type: /Core/relationshipType
 - justification
   - type: justification
   - minCount: 0

--- a/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
@@ -46,6 +46,3 @@ element.
 - Instantiability: Concrete
 
 ## Properties
-
-- relationshipType
-  - type: /Core/relationshipType


### PR DESCRIPTION
The property relationshipType is defined in the ancestor class core/Relationship and does not need to be repeated in the sub-classes.