### PR TITLE
Fix cardinality of (primary)Purpose

### DIFF
--- a/model/Software/Classes/SoftwareArtifact.md
+++ b/model/Software/Classes/SoftwareArtifact.md
@@ -23,9 +23,10 @@ such as a package, a file, or a snippet.
   - type: xsd:anyURI
   - minCount: 0
   - maxCount: 1
-- purpose
+- primaryPurpose
   - type: SoftwarePurpose
   - minCount: 0
+  - maxCount: 1
 - concludedLicense
   - type: /Licensing/LicenseField
   - minCount: 0

--- a/model/Software/Properties/primaryPurpose.md
+++ b/model/Software/Properties/primaryPurpose.md
@@ -12,7 +12,7 @@ purpose provides information about the primary purpose of the software artifact.
 
 ## Metadata
 
-- name: purpose
+- name: primaryPurpose
 - Nature: DataProperty
 - Range: SoftwarePurpose
 


### PR DESCRIPTION
Fixes #133

This PR just renames purpose to primaryPurpose and changes the cardinality to 0..1 to be consistent with SPDX 2.3 and support the CycloneDX translation.