### PR TITLE
delete unnecessary external property restriction

### DIFF
--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -81,8 +81,6 @@ Metadata information that can be added to a package to describe an AI applicatio
   - minCount: 1
 - /Software/SoftwareArtifact/purpose
   - minCount: 1
-- /Core/Relationship/relationshipType
-  - minCount: 1
 - /Core/Artifact/releaseTime
   - minCount: 1
 


### PR DESCRIPTION
While working on the implementation in the Python tools I noticed this unnecessary external property restriction. 