### PR TITLE
Add cve & securityOther as ExternalIdentifierType

### DIFF
--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -18,10 +18,12 @@ ExteralIdentifierType specifies the type of an external identifier.
 
 - cpe22: https://cpe.mitre.org/files/cpe-specification_2.2.pdf
 - cpe23: https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
+- cve: An identifier for a specific software flaw defined within the official CVE Dictionary and that conforms to the CVE specification as defined by https://csrc.nist.gov/glossary/term/cve_id.
 - email: https://datatracker.ietf.org/doc/html/rfc3696#section-3
 - gitoid: gitoid stands for Git Object ID. A gitoid of typeblob is a unique hash of a software artifact. Git relies on a Merkle Tree to index stored objects. See https://git-scm.com/book/en/v2/Git-Internals-Git-Objects. GitBOM is an amalgam of the terms "Git" and "SBOM". GitBOM is a minimalistic schema to describe software dependency graphs using a Merkle Tree, and is inspired by Git. A gitoid may refer to either the software artifact or its GitBOM document; this ambiguity exists because the GitBOM document is itself an artifact, and the gitoid of that artifact is its valid locator.
 - other: Used when the type doesn't match any of the other options.
 - pkgUrl: https://github.com/package-url/purl-spec
+- securityOther: Used when there is a security related identifier of unspecified type.
 - swhid: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
 - swid: https://www.ietf.org/archive/id/draft-ietf-sacm-coswid-21.html#section-2.3
 - urlScheme: the scheme used in order to locate a resource https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml


### PR DESCRIPTION
This adds cve and securityOther entries as ExternalIdentifierType(s) to be consistent with the current security model[1]

[1]https://raw.githubusercontent.com/spdx/spdx-3-model/main/model-security-profile.png

Resolves #316