### PR TITLE
Security: Fix markdown and add external property restriction for "to"

### DIFF
--- a/model/Security/Classes/VulnAssessmentRelationship.md
+++ b/model/Security/Classes/VulnAssessmentRelationship.md
@@ -40,3 +40,7 @@ assessment relationships. It factors out the common properties shared by them.
   - minCount: 0
   - maxCount: 1
 
+## External properties restrictions
+
+- /Core/Relationship/to
+  - minCount: 1

--- a/model/Security/Properties/withdrawnTime.md
+++ b/model/Security/Properties/withdrawnTime.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# withdrawn
+# withdrawnTime
 
 ## Summary
 


### PR DESCRIPTION
Looking at the generated documentation fro the model, I noticed that the property `security:withdrawn` isn't assigned correctly. This was caused by the wrong title in the markdown file for `withdrawnTime`.

The `to` property for `Relationship` is optional since #293. From the descriptions in the security relationships I think the `to` property should be mandatory for all security relationships. 