### PR TITLE
fix references to LicenseField

### DIFF
--- a/model/Software/Properties/concludedLicense.md
+++ b/model/Software/Properties/concludedLicense.md
@@ -42,4 +42,4 @@ retain the license choice or identify which license was chosen.
 
 - name: concludedLicense
 - Nature: ObjectProperty
-- Range: LicenseField
+- Range: /Licensing/LicenseField

--- a/model/Software/Properties/declaredLicense.md
+++ b/model/Software/Properties/declaredLicense.md
@@ -54,4 +54,4 @@ indicates that one of the following applies:
 
 - name: declaredLicense
 - Nature: ObjectProperty
-- Range: LicenseField
+- Range: /Licensing/LicenseField


### PR DESCRIPTION
Working with the `spec-parser` and the generated model.ttl file I noticed these incorrect references. 