### PR TITLE
Security: Simplify assessment relationships

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -68,11 +68,7 @@ Build Profile specific RelationshipType descriptions can be found [here](https:/
 - buildHostOf: Element in which the build instance runs on
 - hasAssociatedVulnerability: (Security) Used to associate a security vulnerability with a software artifact
 - coordinatedBy: (Security) Used to identify the vendor, researcher, or consumer agent performing coordination for a vulnerability
-- hasCvssV2AssessmentFor: (Security) Specifies a CVSS V2 assessment of a vulnerability
-- hasCvssV3AssessmentFor: (Security) Specifies a CVSS V3 assessment of a vulnerability
-- hasEpssAssessmentFor: (Security) Specifies a EPSS assessment of a vulnerability
-- hasExploitCatalogAssessmentFor: (Security) Specifies a exploit catalog assessment of a vulnerability
-- hasSsvcAssessmentFor: (Security) Specifies a SSVC assessment of a vulnerability
+- hasAssessmentFor: (Security) Relates a Vulnerability and an Element with a security assessment.
 - exploitCreatedBy: (Security) Designates an agent has created an exploit against a vulnerability
 - fixedBy: (Security) Designates a vulnerability has been fixed by an agent
 - foundBy: (Security) Designates an agent was the original discoverer of a security vulnerability

--- a/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
@@ -13,7 +13,8 @@ A CvssV2VulnAssessmentRelationship relationship describes the determined score a
 
 **Constraints**
 
-The value of severity must be one of 'low', 'medium' or 'high'
+- The value of severity must be one of 'low', 'medium' or 'high'
+- The relationship type must be set to hasAssessmentFor.
 
 **Syntax**
 
@@ -21,7 +22,7 @@ The value of severity must be one of 'low', 'medium' or 'high'
 {
   "@type": "CvssV2VulnAssessmentRelationship",
   "@id": "urn:spdx.dev:cvssv2-cve-2020-28498",
-  "relationshipType": "hasCvssV2AssessmentFor",
+  "relationshipType": "hasAssessmentFor",
   "score": 4.3,
   "vector": "(AV:N/AC:M/Au:N/C:P/I:N/A:N)",
   "severity": "low",

--- a/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
@@ -15,8 +15,9 @@ Vulnerability Scoring System (CVSS) as defined on
 
 **Constraints**
 
-The value of severity must be one of 'none', 'low', 'medium', 'high' or 'critical'.
-Absence of the property shall be interpreted as 'none'.
+- The value of severity must be one of 'none', 'low', 'medium', 'high' or 'critical'.
+- Absence of the property shall be interpreted as 'none'.
+- The relationship type must be set to hasAssessmentFor.
 
 **Syntax**
 
@@ -24,7 +25,7 @@ Absence of the property shall be interpreted as 'none'.
 {
   "@type": "CvssV3VulnAssessmentRelationship",
   "@id": "urn:spdx.dev:cvssv3-cve-2020-28498",
-  "relationshipType": "hasCvssV3AssessmentFor",
+  "relationshipType": "hasAssessmentFor",
   "severity": "medium",
   "score": 6.8,
   "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N",

--- a/model/Security/Classes/EpssVulnAssessmentRelationship.md
+++ b/model/Security/Classes/EpssVulnAssessmentRelationship.md
@@ -13,13 +13,17 @@ probability that a vulnerability will be exploited in the wild using the Exploit
 Prediction Scoring System (EPSS) as defined on 
 [https://www.first.org/epss/model](https://www.first.org/epss/model).
 
+**Constraints**
+
+- The relationship type must be set to hasAssessmentFor.
+
 **Syntax**
 
 ```json
 {
   "@type": "EpssVulnAssessmentRelationship",
   "@id": "urn:spdx.dev:epss-1",
-  "relationshipType": "hasEpssAssessmentFor",
+  "relationshipType": "hasAssessmentFor",
   "probability": 80,
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],

--- a/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
+++ b/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
@@ -13,13 +13,17 @@ listed in any exploit catalog such as the CISA Known Exploited Vulnerabilities
 Catalog (KEV) 
 [https://www.cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog).
 
+**Constraints**
+
+- The relationship type must be set to hasAssessmentFor.
+
 **Syntax**
 
 ```json
 {
   "@type": "ExploitCatalogVulnAssessmentRelationship",
   "@id": "urn:spdx.dev:exploit-catalog-1",
-  "relationshipType": "hasExploitCatalogAssessmentFor",
+  "relationshipType": "hasAssessmentFor",
   "catalogType": "kev",
   "locator": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
   "exploited": "true",

--- a/model/Security/Classes/SsvcVulnAssessmentRelationship.md
+++ b/model/Security/Classes/SsvcVulnAssessmentRelationship.md
@@ -13,13 +13,17 @@ Stakeholder-Specific Vulnerability Categorization (SSVC) decision tree as
 defined on [https://www.cisa.gov/stakeholder-specific-vulnerability-categorization-ssvc](https://www.cisa.gov/stakeholder-specific-vulnerability-categorization-ssvc).
 It is intended to communicate the results of using the CISA SSVC Calculator.
 
+**Constraints**
+
+- The relationship type must be set to hasAssessmentFor.
+
 **Syntax**
 
 ```json
 {
   "@type": "SsvcVulnAssessmentRelationship",
   "@id": "urn:spdx.dev:ssvc-1",
-  "relationshipType": "hasSsvcAssessmentFor",
+  "relationshipType": "hasAssessmentFor",
   "decisionType": "act",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],


### PR DESCRIPTION
As discussed in https://github.com/spdx/spdx-3-model/issues/331 we are considering simplifying the security relationships to a single `hasAssessmentFor`.

This PR removes the following relationship types and updates the markdowns to use `hasAssessmentFor` while introducing it into the core vocabulary:

- hasCvssV2AssessmentFor
- hasCvssV3AssessmentFor
- hasEpssAssessmentFor
- hasExploitCatalogAssessmentFor
- hasSsvcAssessmentFor

/cc @tsteenbe @rnjudge @jeff-schutt

closes #331