### PR TITLE
Automatically generate the Ontospy documentation

### DIFF
--- a/.github/workflows/spec-parser.yml
+++ b/.github/workflows/spec-parser.yml
@@ -11,6 +11,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -39,18 +43,37 @@ jobs:
         with:
           name: model.ttl
           path: /tmp/spec-parser.out/model.ttl
+          
+      - name: get Ontospy
+        run: |
+          git clone --depth=1 --single-branch --branch=master https://github.com/lambdamusic/Ontospy.git
+          cd Ontospy
+          python3 -m pip install -r requirements.txt
+          python3 -m pip install -e .
+      - name: generate docs with Ontospy
+        run : |
+          cd Ontospy
+          mkdir -p /tmp/auto-generated
+          ontospy gendocs -o /tmp/auto-generated --type 2 --title SPDX-3.0 /tmp/spec-parser.out/model.ttl
+          mkdir -p /tmp/auto-generated/one_pager
+          ontospy gendocs -o /tmp/auto-generated/one_pager --type 1 --title SPDX-3.0 /tmp/spec-parser.out/model.ttl
 
       - uses: actions/upload-artifact@v3
         with:
-          name: spec-parser.out
-          path: /tmp/spec-parser.out
-
-      - uses: cachix/install-nix-action@v19
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - run: nix-shell '<nixpkgs>' --fallback -p apache-jena --run "riot --out=jsonld /tmp/spec-parser.out/model.ttl" > /tmp/spec-parser.out/model.jsonld
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: model.jsonld
-          path: /tmp/spec-parser.out/model.jsonld
+          name: auto-generated
+          path: /tmp/auto-generated
+          
+      - name: commit changes to branch
+        if: github.ref_name == 'main'
+        run: |
+          git fetch 
+          git checkout gh-pages
+          rm -rf /auto-generated/
+          cp /tmp/spec-parser.out/model.ttl .
+          cp -r /tmp/auto-generated/ .
+          if [ -n "$(git status -s -- "auto-generated/" "*.ttl")" ]
+          then
+            git add model.ttl auto-generated/ 
+            git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" commit -s -m "Automated Upload" --author "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+            git push origin
+          fi


### PR DESCRIPTION
With this PR the GitHub Action is updated to automatically generate the html documentation and push the documentation (as multi-page and one-page document) as well as the generated `model.ttl` to the `gh-pages` branch. According to #140 the model.ttl should be pushed to a `generated` branch. To keep things simple I suggest to put everything that is automatically generated in the gh-pages branch, if you disagree I can adapt the PR to only push the generated documentation and we can add another workflow to push the `model.ttl` in another PR.

There is one open PR in the `spec-parser` to be able to fill the `Usage` table for each class with the corresponding properties. (https://github.com/spdx/spec-parser/pull/52). As this is already done in the documentation available via the `gh-pages` branch now, this PR should be merged once this feature is available in the `spec-parser`, so I'll leave this PR as a draft for the time being.

The workflow will only run on main and only push to the gh-pages branch if there were any changes to the generated documentation. Addditionally the generated-documentation will be put in a folder named `auto-generated` to mark these files as automatically generated. 

