### PR TITLE
Add json-ld serialization examples

### DIFF
--- a/serialization/json.md
+++ b/serialization/json.md
@@ -1,4 +1,26 @@
 # JSON Serialization
 
-Ideally JSON will be very similar to JSON-LD.
+Ideally JSON will be very similar (or even the same) to JSON-LD.
 
+The JSON serialization will consist of two things: A context file and an array of element objects (the "payload").
+
+The context file will be linked via the single property "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json" at top-level of the JSON file.
+You need not care about its specifics, it is simply there to ensure compatibility of JSON and JSON-LD (if you want to know more, see the "about" section below).
+
+The rest of the serialized file will consist of an array of objects under the "@graph" key, also at top-level of the JSON file.
+Each of these objects must have a property "@type", stating its class name which must be an instantiable subclass of Element.
+It also needs a property "@id", which serves to capture the SPDX ID of the Element.
+All other SPDX properties of the Element are stated via key-value pairs, where the key is the name of the property (e.g. "createdBy").
+The type of the value depends on the type of the property in the SPDX model and can be a string, number, array or object.
+Note, though, that inlining of objects is only allowed for "complex data type" classes (CreationInfo, ExternalReference, etc.).
+If the object were an Element, a string containing its ID would be written instead, thereby referencing another object from the same or even another payload.
+
+
+#### About the context file
+The context file is a tool to abbreviate long URIs in keys or vocabulary types.
+This allows for a readable serialized output while still maintaining concise definitions of all properties and classes according to the RDF standard.
+For example, using the context file as a "translation tool", we shorten the property "https://spdx.org/rdf/Core/createdBy" to simply "createdBy".
+The context file will be universal for all SPDX users and is accessible at "https://spdx.github.io/spdx-3-model/rdf/context.json".
+Utilising the context is achieved by adding the property "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json" at top-level of the JSON file.
+The context also serves to omit the @type key in objects where the type is already known from the key of the object.
+For example, the object behind the key "creationInfo" is always of type "CreationInfo", so the key-value pair "@type": "CreationInfo" is implied via the context.

--- a/serialization/json_ld/examples/package.jsonld
+++ b/serialization/json_ld/examples/package.jsonld
@@ -1,0 +1,52 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "@type": "Package",
+      "@id": "https://some.namespace#SPDXRef-Package",
+      "name": "packageName",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": [
+          "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com"
+        ],
+        "profile": [
+          "core",
+          "software"
+        ],
+        "dataLicense": "CC0-1.0"
+      },
+      "summary": "packageSummary",
+      "description": "packageDescription",
+      "comment": "packageComment",
+      "verifiedUsing": [
+        {
+          "@type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
+        },
+                {
+          "@type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "fbea580d286bbbbb41314430d58ba887716a74d7134119c5307cdc9f0c7a4299"
+        }
+      ],
+      "originatedBy": "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com",
+      "packagePurpose": [
+        "SOURCE"
+      ],
+      "packageUrl": "https://some.purl",
+      "externalReference": [
+        {
+          "externalReferenceType": "support",
+          "locator": "https://support.com"
+        }
+      ],
+      "packageVersion": "12.2",
+      "downloadLocation": "https://download.com",
+      "homepage": "https://homepage.com",
+      "release_time": "2022-11-01T00:00:00"
+    }
+  ]
+}

--- a/serialization/json_ld/examples/person.jsonld
+++ b/serialization/json_ld/examples/person.jsonld
@@ -1,0 +1,28 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "https://some.namespace#john_smith",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": [
+          "https://some.namespace#john_smith"
+        ],
+        "profile": [
+          "core"
+        ],
+        "dataLicense": "CC0-1.0"
+      },
+      "name": "John Smith",
+      "externalIdentifier": [
+        {
+          "@type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "john@smith.com"
+        }
+      ]
+    }
+  ]
+}

--- a/serialization/json_ld/examples/spdx_document.jsonld
+++ b/serialization/json_ld/examples/spdx_document.jsonld
@@ -1,0 +1,105 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "@type": "Person",
+      "@id": "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com",
+      "creationInfo": {
+        "@id": "_a",
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": [
+          "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com"
+        ],
+        "profile": [
+          "core",
+          "software"
+        ],
+        "dataLicense": "CC0-1.0"
+      },
+      "name": "creatorName",
+      "externalIdentifier": [
+        {
+          "@type": "ExternalIdentifier",
+          "externalIdentifierType": "email",
+          "identifier": "some@mail.com"
+        }
+      ]
+    },
+    {
+      "@type": "SpdxDocument",
+      "@id": "https://some.namespace#SPDXRef-DOCUMENT",
+      "creationInfo": "_a",
+      "name": "documentName",
+      "comment": "documentComment",
+      "elements": [
+        "https://some.namespace#SPDXRef-DOCUMENT",
+        "https://some.namespace#SBOM",
+        "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com",
+        "https://some.namespace#SPDXRef-Package",
+        "https://some.namespace#SPDXRef-File",
+        "https://some.namespace#SPDXRef-Relationship-0",
+        "https://some.namespace#SPDXRef-Relationship-1"
+      ]
+    },
+    {
+      "@type": "SBOM",
+      "@id": "https://some.namespace#SBOM",
+      "creationInfo": "_a",
+      "name": "SBOM",
+      "elements": [
+        "https://some.namespace#SPDXRef-Package",
+        "https://some.namespace#SPDXRef-File"
+      ]
+    },
+    {
+      "@type": "Package",
+      "@id": "https://some.namespace#SPDXRef-Package",
+      "name": "packageName",
+      "verifiedUsing": [
+        {
+          "@type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
+        }
+      ],
+      "originatedBy": "https://some.namespace#SPDXRef-Actor-creatorName-some@mail.com",
+      "packagePurpose": [
+        "SOURCE"
+      ],
+      "packageVersion": "12.2",
+      "downloadLocation": "https://download.com",
+      "homepage": "https://homepage.com"
+    },
+    {
+      "@type": "File",
+      "@id": "https://some.namespace#SPDXRef-File",
+      "name": "./fileName.py",
+      "verifiedUsing": [
+        {
+          "@type": "Hash",
+          "algorithm": "sha1",
+          "hashValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
+        }
+      ]
+    },
+    {
+      "@type": "Relationship",
+      "@id": "https://some.namespace#SPDXRef-Relationship-0",
+      "fromElement": "https://some.namespace#SPDXRef-DOCUMENT",
+      "to": [
+        "https://some.namespace#SBOM"
+      ],
+      "relationshipType": "ancestor"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "https://some.namespace#SPDXRef-Relationship-1",
+      "fromElement": "https://some.namespace#SPDXRef-Package",
+      "to": [
+        "https://some.namespace#SPDXRef-File"
+      ],
+      "relationshipType": "contains"
+    }
+  ]
+}


### PR DESCRIPTION
As there seems to be some confusion around how json-ld would actually look like, this is an attempt to provide a place for examples on which further discussions can be based.
I'm not sure where the most interest lies, so please tell me which use cases you would like to see further examples on! :)

Validation of json-ld would be performed against a separate SHACL file generated from the specification. This will be automatically added and kept up-to-date once #344 is merged.
Work is also underway to generate a json-schema that will validate json-ld output.

There is still the hope that the json-ld serialization works fine for everyone so that we don't have to invent a separate json (non-json-ld) serialization. If you have any concerns about this, please speak up!
(For clarification: A "json serialization" will _not_ be json-ld in its expanded form, i.e. with the `@context` used to expand all values to their full URIs).


Current drawbacks:
- The `context.json` needs some touch-up, therefore the `@context` url is currently unreachable. This will be fixed soon.
- Serialization of license expressions is still under discussion, therefore I did not include the licensing profile so far.