### PR TITLE
add list of serialization use cases

### DIFF
--- a/serialization/README.md
+++ b/serialization/README.md
@@ -6,8 +6,35 @@ _TBD_
 
 ## Serialization formats
 
-The files in this directory provide some notes on the specific serialiation formats.
+The files in this directory provide some notes on the specific serialization formats.
 
-The notes are nunbered for easier referencing -- the order is **not** significant.
+The notes are numbered for easier referencing -- the order is **not** significant.
 
+## Use cases
 
+Examples of how to serialize the following cases:
+- Person
+- Agent
+- Annotation
+- File
+- Package
+- Package with ExternalIdentifier
+- Package with ExternalReference
+- Relationship with Package contains two Files
+- Relationship with time properties
+- SBOM with two Files
+- SpdxDocument with two Files
+- SpdxDocument with NamespaceMap
+- SpdxDocument with ExternalMap
+- Person with no CreationInfo
+- Person with minimal CreationInfo
+- Person with full CreationInfo
+- Bundle
+- two Persons
+- Bundle of two Persons
+
+- security use cases here
+
+- licensing use cases here
+
+- build use cases here


### PR DESCRIPTION
As discussed in today's serialization meeting, it will be helpful to have a list of use cases that elucidate how serializations will work in action. Examples for these use cases will be included in sub-directories of the different serialization formats.

The current list is only concerned with `Core` and `Software`.
We would be happy if other profiles could contribute use cases they have been or still are struggling with.