### PR TITLE
add machine learning model as a software purpose

### DIFF
--- a/model/Software/Vocabularies/SoftwarePurpose.md
+++ b/model/Software/Vocabularies/SoftwarePurpose.md
@@ -36,6 +36,7 @@ about the context in which the Element exists.
 - install: the Element is used to install software on disk
 - library: the Element is a software library
 - manifest: the Element is a software manifest
+- mlModel: the Element is a machine learning model
 - module: the Element is a module of a piece of software
 - operatingSystem: the Element is an operating system
 - other: the Element doesn't fit into any of the other categories


### PR DESCRIPTION
Closes #361 by adding a new software purpose to describe ML Models. It uses the industry-standard term "ML Model" to describe the same. 

This was discussed in the AI+Dataset profile meeting yesterday, 5/31/23