### PR TITLE
Make LicenseField inherit from Element

### DIFF
--- a/model/Licensing/Classes/License.md
+++ b/model/Licensing/Classes/License.md
@@ -19,18 +19,6 @@ A License represents a license text, whether listed on the SPDX License List
 
 ## Properties
 
-- licenseComment
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- licenseId
-  - type: xsd:string
-  - minCount: 1
-  - maxCount: 1
-- licenseName
-  - type: xsd:string
-  - minCount: 1
-  - maxCount: 1
 - licenseText
   - type: xsd:string
   - minCount: 1

--- a/model/Licensing/Classes/LicenseAddition.md
+++ b/model/Licensing/Classes/LicenseAddition.md
@@ -25,18 +25,6 @@ or otherwise) which is defined by an SPDX data creator (CustomLicenseAddition).
 
 ## Properties
 
-- additionComment
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- additionId
-  - type: xsd:string
-  - minCount: 1
-  - maxCount: 1
-- additionName
-  - type: xsd:string
-  - minCount: 1
-  - maxCount: 1
 - additionText
   - type: xsd:string
   - minCount: 1

--- a/model/Licensing/Classes/LicenseField.md
+++ b/model/Licensing/Classes/LicenseField.md
@@ -18,7 +18,7 @@ property description.
 ## Metadata
 
 - name: LicenseField
-- SubclassOf: none
+- SubclassOf: /Core/Element
 - Instantiability: Abstract
 
 ## Properties


### PR DESCRIPTION
This pull request make just the changes necessary for `LicenseField` to inherit from `Element`.

This decouples this change from the other changes proposed in PR #297 