### PR TITLE
Security: Add descriptions and summary to actionStatementTime

### DIFF
--- a/model/Security/Properties/actionStatementTime.md
+++ b/model/Security/Properties/actionStatementTime.md
@@ -4,11 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Records the time when a recommended action was communicated in a VEX statement 
+to mitigate a vulnerability.
 
 ## Description
 
-TODO
+When a VEX statement communicates an affected status, the author MUST
+include an action statement with a recommended action to help mitigate the
+vulnerability's impact. The actionStatementTime property records the time
+when the action statement was first communicated.
 
 ## Metadata
 


### PR DESCRIPTION
This PR completes the summary and description of the VEX actionStatementTime

/cc @jeff-schutt @rnjudge @tsteenbe 

Part of #367


Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>
