### PR TITLE
Json examples based on json-ld

### DIFF
--- a/serialization/json.md
+++ b/serialization/json.md
@@ -6,6 +6,21 @@ The JSON serialization will consist of two things: A context file and an array o
 
 The context file will be linked via the single property "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json" at top-level of the JSON file.
 You need not care about its specifics, it is simply there to ensure compatibility of JSON and JSON-LD (if you want to know more, see the "about" section below).
+However, you can use it to substitute long namespaces with shorter identifiers of your choice. 
+To utilise this feature, add an object to the "@context", the keys of which are the short identifiers you want to use and their values the full namespace.
+For example, you can shorten URIs like "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#SPDXRef-DOCUMENT" to "spdx-example:SPDXRef-DOCUMENT"
+(note the colon) by using the following context, which maps "spdx-example" to the namespace part of the URI:
+```json
+"@context": [
+    "https://spdx.github.io/spdx-3-model/rdf/context.json",
+    {
+      "spdx-example": "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#"
+    }
+]
+```
+Have a look at [this](json%2Fexamples%2Fconverted_from_spdx_2.json) and [this](json%2Fexamples%2Fspdx_document4.json) example to see how this looks in a full serialization.  
+For deserialization, you can check whether a URI has to be expanded by splitting it at the first colon into "prefix:suffix": 
+If the suffix does not start with "//" and the prefix is a key in the context, you replace "prefix:" with the value found under that key.
 
 The rest of the serialized file will consist of an array of objects under the "@graph" key, also at top-level of the JSON file.
 Each of these objects must have a property "@type", stating its class name which must be an instantiable subclass of Element.
@@ -13,7 +28,7 @@ It also needs a property "@id", which serves to capture the SPDX ID of the Eleme
 All other SPDX properties of the Element are stated via key-value pairs, where the key is the name of the property (e.g. "createdBy").
 The type of the value depends on the type of the property in the SPDX model and can be a string, number, array or object.
 Note, though, that inlining of objects is only allowed for "complex data type" classes (CreationInfo, ExternalReference, etc.).
-If the object were an Element, a string containing its ID would be written instead, thereby referencing another object from the same or even another payload.
+If the object were an Element, a string containing its ID would be written instead (which can be subjected to the URI shortening described above), thereby referencing another object from the same or even another payload.
 
 
 #### About the context file

--- a/serialization/json.md
+++ b/serialization/json.md
@@ -23,8 +23,7 @@ For deserialization, you can check whether a URI has to be expanded by splitting
 If the suffix does not start with "//" and the prefix is a key in the context, you replace "prefix:" with the value found under that key.
 
 The rest of the serialized file will consist of an array of objects under the "@graph" key, also at top-level of the JSON file.
-Each of these objects must have a property "@type", stating its class name which must be an instantiable subclass of Element.
-It also needs a property "@id", which serves to capture the SPDX ID of the Element.
+Each of these objects must have a property "type", stating its class name which must be an instantiable subclass of Element.
 All other SPDX properties of the Element are stated via key-value pairs, where the key is the name of the property (e.g. "createdBy").
 The type of the value depends on the type of the property in the SPDX model and can be a string, number, array or object.
 Note, though, that inlining of objects is only allowed for "complex data type" classes (CreationInfo, ExternalReference, etc.).

--- a/serialization/json/EXAMPLES.md
+++ b/serialization/json/EXAMPLES.md
@@ -23,4 +23,5 @@
 - [SpdxDocument1 with two Files](examples/spdx_document1.json)
 - [SpdxDocument2 with two Files](examples/spdx_document2.json) - all in the same payload
 - [SpdxDocument3 with a Package that contains two Files](examples/spdx_document3.json) - all in the same payload
+- [SpdxDocument4](examples/spdx_document4.json) - same as SpdxDocument3 but using the context to shorten URIs
 

--- a/serialization/json/EXAMPLES.md
+++ b/serialization/json/EXAMPLES.md
@@ -25,3 +25,6 @@
 - [SpdxDocument3 with a Package that contains two Files](examples/spdx_document3.json) - all in the same payload
 - [SpdxDocument4](examples/spdx_document4.json) - same as SpdxDocument3 but using the context to shorten URIs
 
+### Full examples
+- [converted SPDX document from SPDX-2.3](examples/converted_from_spdx_2.json) - converted from [this file](https://github.com/spdx/spdx-spec/blob/development/v2.3.1/examples/SPDXJSONExample-v2.3.spdx.json)
+

--- a/serialization/json/EXAMPLES.md
+++ b/serialization/json/EXAMPLES.md
@@ -1,0 +1,26 @@
+### Agents
+- [Agent1](examples/agent1.json)
+- [Person1 with minimal CreationInfo](examples/person1.json) 
+- [Person2 with full CreationInfo](examples/person2.json))
+- [Person3 with no CreationInfo](examples/person3.json) - does this even mean anything?
+- [Organization1](examples/org1.json)
+- [Tool1](examples/tool1.json) - not an Agent
+
+### Annotations
+- [Annotation1](examples/annotation1.json)
+
+### Artifacts
+- [Package1](examples/package1.json)
+- [File1](examples/file1.json)
+
+### Relationships
+- [Relationship1 with Package contains two Files](examples/spdx_document3.json)
+
+### Collections
+- [Sbom1 with two Files](examples/sbom1.json)
+
+### Documents
+- [SpdxDocument1 with two Files](examples/spdx_document1.json)
+- [SpdxDocument2 with two Files](examples/spdx_document2.json) - all in the same payload
+- [SpdxDocument3 with a Package that contains two Files](examples/spdx_document3.json) - all in the same payload
+

--- a/serialization/json/examples/agent1.json
+++ b/serialization/json/examples/agent1.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Agent",
+  "@id": "https://some.namespace#agent1",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "John Smith",
+  "externalIdentifier": [
+    {
+      "externalIdentifierType": "email",
+      "identifier": "info@acme.com"
+    }
+  ]
+}

--- a/serialization/json/examples/agent1.json
+++ b/serialization/json/examples/agent1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Agent",
-  "@id": "https://some.namespace#agent1",
+  "type": "Agent",
+  "spdxId": "https://some.namespace#agent1",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -12,6 +13,7 @@
   "name": "John Smith",
   "externalIdentifier": [
     {
+      "type": "ExternalIdentifier",
       "externalIdentifierType": "email",
       "identifier": "info@acme.com"
     }

--- a/serialization/json/examples/annotation1.json
+++ b/serialization/json/examples/annotation1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Annotation",
-  "@id": "http://spdx.acme.org/3FA9CB25#annotation34",
+  "type": "Annotation",
+  "spdxId": "http://spdx.acme.org/3FA9CB25#annotation34",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/annotation1.json
+++ b/serialization/json/examples/annotation1.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Annotation",
+  "@id": "http://spdx.acme.org/3FA9CB25#annotation34",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "Acme Corp. Super SBOM-o-lator",
+  "annotationType": "review",
+  "subject": "http://spdx.acme.org/3FA9CB25#person9",
+  "contentType": "text/plain",
+  "statement": "Keanu Reeves is back as cyberpunk icon Neo but fans of the original will find this cynical reboot a bitter pill to swallow."
+}

--- a/serialization/json/examples/converted_from_spdx_2.json
+++ b/serialization/json/examples/converted_from_spdx_2.json
@@ -7,24 +7,25 @@
   ],
   "@graph": [
     {
-      "@type": "Tool",
-      "@id": "spdx-example:SPDXRef-Actor-LicenseFind-1.0",
+      "type": "Tool",
+      "spdxId": "spdx-example:SPDXRef-Actor-LicenseFind-1.0",
       "name": "LicenseFind-1.0"
     },
     {
-      "@type": "Organization",
-      "@id": "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
+      "type": "Organization",
+      "spdxId": "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
       "name": "ExampleCodeInspect"
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-JaneDoe",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-JaneDoe",
       "name": "Jane Doe"
     },
     {
-      "@type": "SpdxDocument",
-      "@id": "spdx-example:SPDXRef-DOCUMENT",
+      "type": "SpdxDocument",
+      "spdxId": "spdx-example:SPDXRef-DOCUMENT",
       "creationInfo": {
+        "type": "CreationInfo",
         "specVersion": "3.0.0",
         "created": "2010-01-29T18:30:22Z",
         "createdBy": [
@@ -84,15 +85,18 @@
       ],
       "namespaces": [
         {
+          "type": "NamespaceMap",
           "prefix": "DocumentRef-spdx-tool-1.2",
           "namespace": "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301#"
         }
       ],
       "imports": [
         {
+          "type": "ExternalMap",
           "externalId": "DocumentRef-spdx-tool-1.2:SPDXRef-DOCUMENT",
           "verifiedUsing": [
             {
+              "type": "Hash",
               "algorithm": "sha1",
               "hashValue": "d6a770ba38583ed4bb4525bd96e50461655d2759"
             }
@@ -101,53 +105,60 @@
       ]
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-JaneDoe-jane.doe@example.com",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-JaneDoe-jane.doe@example.com",
       "name": "Jane Doe",
       "externalIdentifier": [
         {
+          "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
           "identifier": "jane.doe@example.com"
         }
       ]
     },
     {
-      "@type": "Organization",
-      "@id": "spdx-example:SPDXRef-Actor-ExampleCodeInspect-contact@example.com",
+      "type": "Organization",
+      "spdxId": "spdx-example:SPDXRef-Actor-ExampleCodeInspect-contact@example.com",
       "name": "ExampleCodeInspect",
       "externalIdentifier": [
         {
+          "type": "ExternalIdentifier",
           "externalIdentifierType": "email",
           "identifier": "contact@example.com"
         }
       ]
     },
     {
-      "@type": "Package",
-      "@id": "spdx-example:SPDXRef-Package",
+      "type": "Package",
+      "spdxId": "spdx-example:SPDXRef-Package",
       "name": "glibc",
       "summary": "GNU C library.",
       "description": "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "md5",
           "hashValue": "624c1abb3664f4b35547e7c73864ad24"
         },
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "85ed0817af83a24ad8da68c2b5094de69833983c"
         },
         {
+          "type": "Hash",
           "algorithm": "sha256",
           "hashValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
         },
         {
+          "type": "Hash",
           "algorithm": "blake2B384",
           "hashValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
         }
       ],
       "externalIdentifier": [
         {
+          "type": "ExternalIdentifier",
           "externalIdentifierType": "cpe23",
           "identifier": "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
         }
@@ -172,14 +183,14 @@
       "sourceInfo": "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
     },
     {
-      "@type": "Package",
-      "@id": "spdx-example:SPDXRef-fromDoap-1",
+      "type": "Package",
+      "spdxId": "spdx-example:SPDXRef-fromDoap-1",
       "name": "Apache Commons Lang",
       "homepage": "http://commons.apache.org/proper/commons-lang/"
     },
     {
-      "@type": "Package",
-      "@id": "spdx-example:SPDXRef-fromDoap-0",
+      "type": "Package",
+      "spdxId": "spdx-example:SPDXRef-fromDoap-0",
       "name": "Jena",
       "packageVersion": "3.12.0",
       "downloadLocation": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
@@ -187,12 +198,13 @@
       "homepage": "http://www.openjena.org/"
     },
     {
-      "@type": "Package",
-      "@id": "spdx-example:SPDXRef-Saxon",
+      "type": "Package",
+      "spdxId": "spdx-example:SPDXRef-Saxon",
       "name": "Saxon",
       "description": "The Saxon package is a collection of tools for processing XML documents.",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "85ed0817af83a24ad8da68c2b5094de69833983c"
         }
@@ -203,11 +215,12 @@
       "homepage": "http://saxon.sourceforge.net/"
     },
     {
-      "@type": "File",
-      "@id": "spdx-example:SPDXRef-DoapSource",
+      "type": "File",
+      "spdxId": "spdx-example:SPDXRef-DoapSource",
       "name": "./src/org/spdx/parser/DOAPProject.java",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
         }
@@ -215,12 +228,13 @@
       "copyrightText": "Copyright 2010, 2011 Source Auditor Inc."
     },
     {
-      "@type": "File",
-      "@id": "spdx-example:SPDXRef-CommonsLangSrc",
+      "type": "File",
+      "spdxId": "spdx-example:SPDXRef-CommonsLangSrc",
       "name": "./lib-source/commons-lang3-3.1-sources.jar",
       "comment": "This file is used by Jena",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
         }
@@ -228,12 +242,13 @@
       "copyrightText": "Copyright 2001-2011 The Apache Software Foundation"
     },
     {
-      "@type": "File",
-      "@id": "spdx-example:SPDXRef-JenaLib",
+      "type": "File",
+      "spdxId": "spdx-example:SPDXRef-JenaLib",
       "name": "./lib-source/jena-2.6.3-sources.jar",
       "comment": "This file belongs to Jena",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
         }
@@ -241,28 +256,31 @@
       "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
     },
     {
-      "@type": "File",
-      "@id": "spdx-example:SPDXRef-Specification",
+      "type": "File",
+      "spdxId": "spdx-example:SPDXRef-Specification",
       "name": "./docs/myspec.pdf",
       "comment": "Specification Documentation",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "fff4e1c67a2d28fced849ee1bb76e7391b93f125"
         }
       ]
     },
     {
-      "@type": "File",
-      "@id": "spdx-example:SPDXRef-File",
+      "type": "File",
+      "spdxId": "spdx-example:SPDXRef-File",
       "name": "./package/foo.c",
       "comment": "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
       "verifiedUsing": [
         {
+          "type": "Hash",
           "algorithm": "sha1",
           "hashValue": "d6a770ba38583ed4bb4525bd96e50461655d2758"
         },
         {
+          "type": "Hash",
           "algorithm": "md5",
           "hashValue": "624c1abb3664f4b35547e7c73864ad24"
         }
@@ -270,8 +288,8 @@
       "copyrightText": "Copyright 2008-2010 John Smith"
     },
     {
-      "@type": "Snippet",
-      "@id": "spdx-example:SPDXRef-Snippet",
+      "type": "Snippet",
+      "spdxId": "spdx-example:SPDXRef-Snippet",
       "name": "from linux kernel",
       "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
       "copyrightText": "Copyright 2008-2010 John Smith",
@@ -285,8 +303,8 @@
       }
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-0",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-0",
       "from": "spdx-example:SPDXRef-DOCUMENT",
       "to": [
         "spdx-example:SPDXRef-Package"
@@ -294,8 +312,8 @@
       "relationshipType": "contains"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-1",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-1",
       "from": "spdx-example:SPDXRef-DOCUMENT",
       "to": [
         "spdx-example:DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
@@ -303,8 +321,8 @@
       "relationshipType": "copy"
     },
     {
-      "@type": "SoftwareDependencyRelationship",
-      "@id": "spdx-example:SPDXRef-Relationship-2",
+      "type": "SoftwareDependencyRelationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-2",
       "from": "spdx-example:SPDXRef-Package",
       "to": [
         "spdx-example:SPDXRef-Saxon"
@@ -313,8 +331,8 @@
       "softwareLinkage": "dynamic"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-4",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-4",
       "from": "spdx-example:SPDXRef-JenaLib",
       "to": [
         "spdx-example:SPDXRef-Package"
@@ -322,8 +340,8 @@
       "relationshipType": "contains"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-5",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-5",
       "from": "spdx-example:SPDXRef-Specification",
       "to": [
         "spdx-example:SPDXRef-fromDoap-0"
@@ -331,8 +349,8 @@
       "relationshipType": "specificationFor"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-6",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-6",
       "from": "spdx-example:SPDXRef-fromDoap-0",
       "to": [
         "spdx-example:SPDXRef-File"
@@ -340,8 +358,8 @@
       "relationshipType": "generates"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-8",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-8",
       "from": "spdx-example:SPDXRef-DOCUMENT",
       "to": [
         "spdx-example:SPDXRef-File",
@@ -350,8 +368,8 @@
       "relationshipType": "describes"
     },
     {
-      "@type": "Relationship",
-      "@id": "spdx-example:SPDXRef-Relationship-12",
+      "type": "Relationship",
+      "spdxId": "spdx-example:SPDXRef-Relationship-12",
       "from": "spdx-example:SPDXRef-Package",
       "to": [
         "spdx-example:SPDXRef-Specification",
@@ -362,56 +380,56 @@
       "relationshipType": "contains"
     },
     {
-      "@type": "Annotation",
-      "@id": "spdx-example:SPDXRef-Annotation-0",
+      "type": "Annotation",
+      "spdxId": "spdx-example:SPDXRef-Annotation-0",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
       "statement": "Document level annotation"
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-JoeReviewer",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-JoeReviewer",
       "name": "Joe Reviewer"
     },
     {
-      "@type": "Annotation",
-      "@id": "spdx-example:SPDXRef-Annotation-1",
+      "type": "Annotation",
+      "spdxId": "spdx-example:SPDXRef-Annotation-1",
       "annotationType": "review",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
       "statement": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-SuzanneReviewer",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-SuzanneReviewer",
       "name": "Suzanne Reviewer"
     },
     {
-      "@type": "Annotation",
-      "@id": "spdx-example:SPDXRef-Annotation-2",
+      "type": "Annotation",
+      "spdxId": "spdx-example:SPDXRef-Annotation-2",
       "annotationType": "review",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
       "statement": "Another example reviewer."
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-PackageCommenter",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-PackageCommenter",
       "name": "Package Commenter"
     },
     {
-      "@type": "Annotation",
-      "@id": "spdx-example:SPDXRef-Annotation-3",
+      "type": "Annotation",
+      "spdxId": "spdx-example:SPDXRef-Annotation-3",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-Package",
       "statement": "Package level annotation"
     },
     {
-      "@type": "Person",
-      "@id": "spdx-example:SPDXRef-Actor-FileCommenter",
+      "type": "Person",
+      "spdxId": "spdx-example:SPDXRef-Actor-FileCommenter",
       "name": "File Commenter"
     },
     {
-      "@type": "Annotation",
-      "@id": "spdx-example:SPDXRef-Annotation-4",
+      "type": "Annotation",
+      "spdxId": "spdx-example:SPDXRef-Annotation-4",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-File",
       "statement": "File level annotation"

--- a/serialization/json/examples/converted_from_spdx_2.json
+++ b/serialization/json/examples/converted_from_spdx_2.json
@@ -1,0 +1,420 @@
+{
+  "@context": [
+    "https://spdx.github.io/spdx-3-model/rdf/context.json",
+    {
+      "spdx-example": "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#"
+    }
+  ],
+  "@graph": [
+    {
+      "@type": "Tool",
+      "@id": "spdx-example:SPDXRef-Actor-LicenseFind-1.0",
+      "name": "LicenseFind-1.0"
+    },
+    {
+      "@type": "Organization",
+      "@id": "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
+      "name": "ExampleCodeInspect"
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-JaneDoe",
+      "name": "Jane Doe"
+    },
+    {
+      "@type": "SpdxDocument",
+      "@id": "spdx-example:SPDXRef-DOCUMENT",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2010-01-29T18:30:22Z",
+        "createdBy": [
+          "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
+          "spdx-example:SPDXRef-Actor-JaneDoe"
+        ],
+        "createdUsing": [
+          "spdx-example:SPDXRef-Actor-LicenseFind-1.0"
+        ],
+        "profile": [
+          "core",
+          "software",
+          "licensing"
+        ],
+        "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+        "comment": "This is the SPDX-2.3 JSON example converted to SPDX-3.0. As there is currently no closure on how to treat licenses, they are omitted here for now."
+      },
+      "name": "SPDX-Tools-v2.0",
+      "comment": "This document was created using SPDX 2.0 using licenses from the web site.",
+      "element": [
+        "spdx-example:SPDXRef-Actor-LicenseFind-1.0",
+        "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
+        "spdx-example:SPDXRef-Actor-JaneDoe",
+        "spdx-example:SPDXRef-Actor-JaneDoe-jane.doe@example.com",
+        "spdx-example:SPDXRef-Actor-ExampleCodeInspect-contact@example.com",
+        "spdx-example:SPDXRef-Package",
+        "spdx-example:SPDXRef-fromDoap-1",
+        "spdx-example:SPDXRef-fromDoap-0",
+        "spdx-example:SPDXRef-Saxon",
+        "spdx-example:SPDXRef-DoapSource",
+        "spdx-example:SPDXRef-CommonsLangSrc",
+        "spdx-example:SPDXRef-JenaLib",
+        "spdx-example:SPDXRef-Specification",
+        "spdx-example:SPDXRef-File",
+        "spdx-example:SPDXRef-Snippet",
+        "spdx-example:SPDXRef-Relationship-0",
+        "spdx-example:SPDXRef-Relationship-1",
+        "spdx-example:SPDXRef-Relationship-2",
+        "spdx-example:SPDXRef-Relationship-4",
+        "spdx-example:SPDXRef-Relationship-5",
+        "spdx-example:SPDXRef-Relationship-6",
+        "spdx-example:SPDXRef-Relationship-8",
+        "spdx-example:SPDXRef-Relationship-12",
+        "spdx-example:SPDXRef-Annotation-0",
+        "spdx-example:SPDXRef-Actor-JoeReviewer",
+        "spdx-example:SPDXRef-Annotation-1",
+        "spdx-example:SPDXRef-Actor-SuzanneReviewer",
+        "spdx-example:SPDXRef-Annotation-2",
+        "spdx-example:SPDXRef-Actor-PackageCommenter",
+        "spdx-example:SPDXRef-Annotation-3",
+        "spdx-example:SPDXRef-Actor-FileCommenter",
+        "spdx-example:SPDXRef-Annotation-4"
+      ],
+      "rootElement": [
+        "spdx-example:SPDXRef-File",
+        "spdx-example:SPDXRef-Package"
+      ],
+      "namespaces": [
+        {
+          "prefix": "DocumentRef-spdx-tool-1.2",
+          "namespace": "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301#"
+        }
+      ],
+      "imports": [
+        {
+          "externalId": "DocumentRef-spdx-tool-1.2:SPDXRef-DOCUMENT",
+          "verifiedUsing": [
+            {
+              "algorithm": "sha1",
+              "hashValue": "d6a770ba38583ed4bb4525bd96e50461655d2759"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-JaneDoe-jane.doe@example.com",
+      "name": "Jane Doe",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "email",
+          "identifier": "jane.doe@example.com"
+        }
+      ]
+    },
+    {
+      "@type": "Organization",
+      "@id": "spdx-example:SPDXRef-Actor-ExampleCodeInspect-contact@example.com",
+      "name": "ExampleCodeInspect",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "email",
+          "identifier": "contact@example.com"
+        }
+      ]
+    },
+    {
+      "@type": "Package",
+      "@id": "spdx-example:SPDXRef-Package",
+      "name": "glibc",
+      "summary": "GNU C library.",
+      "description": "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+      "verifiedUsing": [
+        {
+          "algorithm": "md5",
+          "hashValue": "624c1abb3664f4b35547e7c73864ad24"
+        },
+        {
+          "algorithm": "sha1",
+          "hashValue": "85ed0817af83a24ad8da68c2b5094de69833983c"
+        },
+        {
+          "algorithm": "sha256",
+          "hashValue": "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+        },
+        {
+          "algorithm": "blake2B384",
+          "hashValue": "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
+        }
+      ],
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cpe23",
+          "identifier": "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*"
+        }
+      ],
+      "originatedBy": [
+        "spdx-example:SPDXRef-Actor-ExampleCodeInspect-contact@example.com"
+      ],
+      "suppliedBy": [
+        "spdx-example:SPDXRef-Actor-JaneDoe-jane.doe@example.com"
+      ],
+      "builtTime": "2011-01-29T18:30:22Z",
+      "releaseTime": "2012-01-29T18:30:22Z",
+      "validUntilTime": "2014-01-29T18:30:22Z",
+      "purpose": [
+        "source"
+      ],
+      "copyrightText": "Copyright 2008-2010 John Smith",
+      "attributionText": "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.",
+      "packageVersion": "2.11.1",
+      "downloadLocation": "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+      "homepage": "http://ftp.gnu.org/gnu/glibc",
+      "sourceInfo": "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+    },
+    {
+      "@type": "Package",
+      "@id": "spdx-example:SPDXRef-fromDoap-1",
+      "name": "Apache Commons Lang",
+      "homepage": "http://commons.apache.org/proper/commons-lang/"
+    },
+    {
+      "@type": "Package",
+      "@id": "spdx-example:SPDXRef-fromDoap-0",
+      "name": "Jena",
+      "packageVersion": "3.12.0",
+      "downloadLocation": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
+      "packageUrl": "pkg:maven/org.apache.jena/apache-jena@3.12.0",
+      "homepage": "http://www.openjena.org/"
+    },
+    {
+      "@type": "Package",
+      "@id": "spdx-example:SPDXRef-Saxon",
+      "name": "Saxon",
+      "description": "The Saxon package is a collection of tools for processing XML documents.",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "85ed0817af83a24ad8da68c2b5094de69833983c"
+        }
+      ],
+      "copyrightText": "Copyright Saxonica Ltd",
+      "packageVersion": "8.8",
+      "downloadLocation": "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+      "homepage": "http://saxon.sourceforge.net/"
+    },
+    {
+      "@type": "File",
+      "@id": "spdx-example:SPDXRef-DoapSource",
+      "name": "./src/org/spdx/parser/DOAPProject.java",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+        }
+      ],
+      "copyrightText": "Copyright 2010, 2011 Source Auditor Inc."
+    },
+    {
+      "@type": "File",
+      "@id": "spdx-example:SPDXRef-CommonsLangSrc",
+      "name": "./lib-source/commons-lang3-3.1-sources.jar",
+      "comment": "This file is used by Jena",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+        }
+      ],
+      "copyrightText": "Copyright 2001-2011 The Apache Software Foundation"
+    },
+    {
+      "@type": "File",
+      "@id": "spdx-example:SPDXRef-JenaLib",
+      "name": "./lib-source/jena-2.6.3-sources.jar",
+      "comment": "This file belongs to Jena",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+        }
+      ],
+      "copyrightText": "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP"
+    },
+    {
+      "@type": "File",
+      "@id": "spdx-example:SPDXRef-Specification",
+      "name": "./docs/myspec.pdf",
+      "comment": "Specification Documentation",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "fff4e1c67a2d28fced849ee1bb76e7391b93f125"
+        }
+      ]
+    },
+    {
+      "@type": "File",
+      "@id": "spdx-example:SPDXRef-File",
+      "name": "./package/foo.c",
+      "comment": "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+      "verifiedUsing": [
+        {
+          "algorithm": "sha1",
+          "hashValue": "d6a770ba38583ed4bb4525bd96e50461655d2758"
+        },
+        {
+          "algorithm": "md5",
+          "hashValue": "624c1abb3664f4b35547e7c73864ad24"
+        }
+      ],
+      "copyrightText": "Copyright 2008-2010 John Smith"
+    },
+    {
+      "@type": "Snippet",
+      "@id": "spdx-example:SPDXRef-Snippet",
+      "name": "from linux kernel",
+      "comment": "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+      "copyrightText": "Copyright 2008-2010 John Smith",
+      "byteRange": {
+        "begin": 310,
+        "end": 420
+      },
+      "lineRange": {
+        "begin": 5,
+        "end": 23
+      }
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-0",
+      "from": "spdx-example:SPDXRef-DOCUMENT",
+      "to": [
+        "spdx-example:SPDXRef-Package"
+      ],
+      "relationshipType": "contains"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-1",
+      "from": "spdx-example:SPDXRef-DOCUMENT",
+      "to": [
+        "spdx-example:DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+      ],
+      "relationshipType": "copy"
+    },
+    {
+      "@type": "SoftwareDependencyRelationship",
+      "@id": "spdx-example:SPDXRef-Relationship-2",
+      "from": "spdx-example:SPDXRef-Package",
+      "to": [
+        "spdx-example:SPDXRef-Saxon"
+      ],
+      "relationshipType": "dependsOn",
+      "softwareLinkage": "dynamic"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-4",
+      "from": "spdx-example:SPDXRef-JenaLib",
+      "to": [
+        "spdx-example:SPDXRef-Package"
+      ],
+      "relationshipType": "contains"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-5",
+      "from": "spdx-example:SPDXRef-Specification",
+      "to": [
+        "spdx-example:SPDXRef-fromDoap-0"
+      ],
+      "relationshipType": "specificationFor"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-6",
+      "from": "spdx-example:SPDXRef-fromDoap-0",
+      "to": [
+        "spdx-example:SPDXRef-File"
+      ],
+      "relationshipType": "generates"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-8",
+      "from": "spdx-example:SPDXRef-DOCUMENT",
+      "to": [
+        "spdx-example:SPDXRef-File",
+        "spdx-example:SPDXRef-Package"
+      ],
+      "relationshipType": "describes"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "spdx-example:SPDXRef-Relationship-12",
+      "from": "spdx-example:SPDXRef-Package",
+      "to": [
+        "spdx-example:SPDXRef-Specification",
+        "spdx-example:SPDXRef-CommonsLangSrc",
+        "spdx-example:SPDXRef-JenaLib",
+        "spdx-example:SPDXRef-DoapSource"
+      ],
+      "relationshipType": "contains"
+    },
+    {
+      "@type": "Annotation",
+      "@id": "spdx-example:SPDXRef-Annotation-0",
+      "annotationType": "other",
+      "subject": "spdx-example:SPDXRef-DOCUMENT",
+      "statement": "Document level annotation"
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-JoeReviewer",
+      "name": "Joe Reviewer"
+    },
+    {
+      "@type": "Annotation",
+      "@id": "spdx-example:SPDXRef-Annotation-1",
+      "annotationType": "review",
+      "subject": "spdx-example:SPDXRef-DOCUMENT",
+      "statement": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-SuzanneReviewer",
+      "name": "Suzanne Reviewer"
+    },
+    {
+      "@type": "Annotation",
+      "@id": "spdx-example:SPDXRef-Annotation-2",
+      "annotationType": "review",
+      "subject": "spdx-example:SPDXRef-DOCUMENT",
+      "statement": "Another example reviewer."
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-PackageCommenter",
+      "name": "Package Commenter"
+    },
+    {
+      "@type": "Annotation",
+      "@id": "spdx-example:SPDXRef-Annotation-3",
+      "annotationType": "other",
+      "subject": "spdx-example:SPDXRef-Package",
+      "statement": "Package level annotation"
+    },
+    {
+      "@type": "Person",
+      "@id": "spdx-example:SPDXRef-Actor-FileCommenter",
+      "name": "File Commenter"
+    },
+    {
+      "@type": "Annotation",
+      "@id": "spdx-example:SPDXRef-Annotation-4",
+      "annotationType": "other",
+      "subject": "spdx-example:SPDXRef-File",
+      "statement": "File level annotation"
+    }
+  ]
+}

--- a/serialization/json/examples/file1.json
+++ b/serialization/json/examples/file1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "File",
-  "@id": "https://some.namespace#file1",
+  "type": "File",
+  "spdxId": "https://some.namespace#file1",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/file1.json
+++ b/serialization/json/examples/file1.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "File",
+  "@id": "https://some.namespace#file1",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core", "software"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "model.png",
+  "contentType": "image/png",
+  "purpose": ["documentation"],
+  "contentIdentifier": "https://github.com/spdx/spdx-3-model/blob/main/model.png",
+  "originatedBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"]
+}

--- a/serialization/json/examples/org1.json
+++ b/serialization/json/examples/org1.json
@@ -1,0 +1,13 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Organization",
+  "@id": "https://spdx.dev/elements/3F26391C#spdx-dev",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "spdx.dev"
+}

--- a/serialization/json/examples/org1.json
+++ b/serialization/json/examples/org1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Organization",
-  "@id": "https://spdx.dev/elements/3F26391C#spdx-dev",
+  "type": "Organization",
+  "spdxId": "https://spdx.dev/elements/3F26391C#spdx-dev",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/package1.json
+++ b/serialization/json/examples/package1.json
@@ -1,0 +1,40 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Package",
+  "@id": "https://some.namespace#SPDXRef-Package",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core", "software"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "packageName",
+  "summary": "packageSummary",
+  "description": "packageDescription",
+  "comment": "packageComment",
+  "packageVersion": "12.2",
+  "downloadLocation": "https://download.com",
+  "packageUrl": "https://some.purl",
+  "homePage": "https://homepage.com",
+  "purpose": ["source"],
+  "contentIdentifier": "urn:spdx.dev:pkg:123456789",
+  "originatedBy": ["https://some.namespace#SPDXRef-Agent-creatorName-some@mail.com"],
+  "suppliedBy": "https://some.namespace#john_smith",
+  "verifiedUsing": [
+    {
+      "algorithm": "sha1",
+      "hashValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
+    },
+    {
+      "algorithm": "sha256",
+      "hashValue": "fbea580d286bbbbb41314430d58ba887716a74d7134119c5307cdc9f0c7a4299"
+    }
+  ],
+  "externalReference": [
+    {
+      "externalReferenceType": "securityFix",
+      "locator": "https://support.com"
+    }
+  ]
+}

--- a/serialization/json/examples/package1.json
+++ b/serialization/json/examples/package1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Package",
-  "@id": "https://some.namespace#SPDXRef-Package",
+  "type": "Package",
+  "spdxId": "https://some.namespace#SPDXRef-Package",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -16,25 +17,28 @@
   "packageVersion": "12.2",
   "downloadLocation": "https://download.com",
   "packageUrl": "https://some.purl",
-  "homePage": "https://homepage.com",
+  "homepage": "https://homepage.com",
   "purpose": ["source"],
   "contentIdentifier": "urn:spdx.dev:pkg:123456789",
   "originatedBy": ["https://some.namespace#SPDXRef-Agent-creatorName-some@mail.com"],
-  "suppliedBy": "https://some.namespace#john_smith",
+  "suppliedBy": ["https://some.namespace#john_smith"],
   "verifiedUsing": [
     {
+      "type": "Hash",
       "algorithm": "sha1",
       "hashValue": "71c4025dd9897b364f3ebbb42c484ff43d00791c"
     },
     {
+      "type": "Hash",
       "algorithm": "sha256",
       "hashValue": "fbea580d286bbbbb41314430d58ba887716a74d7134119c5307cdc9f0c7a4299"
     }
   ],
   "externalReference": [
     {
+      "type": "ExternalReference",
       "externalReferenceType": "securityFix",
-      "locator": "https://support.com"
+      "locator": ["https://support.com"]
     }
   ]
 }

--- a/serialization/json/examples/person1.json
+++ b/serialization/json/examples/person1.json
@@ -1,0 +1,19 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Person",
+  "@id": "https://some.namespace#john_smith",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "John Smith",
+  "externalIdentifier": [
+    {
+      "externalIdentifierType": "email",
+      "identifier": "john@smith.com"
+    }
+  ]
+}

--- a/serialization/json/examples/person1.json
+++ b/serialization/json/examples/person1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Person",
-  "@id": "https://some.namespace#john_smith",
+  "type": "Person",
+  "spdxId": "https://some.namespace#john_smith",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -12,6 +13,7 @@
   "name": "John Smith",
   "externalIdentifier": [
     {
+      "type": "ExternalIdentifier",
       "externalIdentifierType": "email",
       "identifier": "john@smith.com"
     }

--- a/serialization/json/examples/person2.json
+++ b/serialization/json/examples/person2.json
@@ -1,0 +1,21 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Person",
+  "@id": "http://spdx.acme.org/3FA9CB25#person2",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "createdUsing": ["https://some.namespace#sbomolator_v2"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+    "comment": "Source: payroll list, 20221130"
+  },
+  "name": "Alice Stone",
+  "externalIdentifier": [
+    {
+      "externalIdentifierType": "email",
+      "identifier": "Alice.Stone@acme.com"
+    }
+  ]
+}

--- a/serialization/json/examples/person2.json
+++ b/serialization/json/examples/person2.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Person",
-  "@id": "http://spdx.acme.org/3FA9CB25#person2",
+  "type": "Person",
+  "spdxId": "http://spdx.acme.org/3FA9CB25#person2",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -14,6 +15,7 @@
   "name": "Alice Stone",
   "externalIdentifier": [
     {
+      "type": "ExternalIdentifier",
       "externalIdentifierType": "email",
       "identifier": "Alice.Stone@acme.com"
     }

--- a/serialization/json/examples/person3.json
+++ b/serialization/json/examples/person3.json
@@ -1,0 +1,12 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Person",
+  "@id": "http://spdx.acme.org/3FA9CB25#person3",
+  "name": "Nigel Thornberry",
+  "externalIdentifier": [
+    {
+      "externalIdentifierType": "email",
+      "identifier": "nigel3@outlook.com"
+    }
+  ]
+}

--- a/serialization/json/examples/person3.json
+++ b/serialization/json/examples/person3.json
@@ -1,10 +1,11 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Person",
-  "@id": "http://spdx.acme.org/3FA9CB25#person3",
+  "type": "Person",
+  "spdxId": "http://spdx.acme.org/3FA9CB25#person3",
   "name": "Nigel Thornberry",
   "externalIdentifier": [
     {
+      "type": "ExternalIdentifier",
       "externalIdentifierType": "email",
       "identifier": "nigel3@outlook.com"
     }

--- a/serialization/json/examples/relationship1.json
+++ b/serialization/json/examples/relationship1.json
@@ -14,5 +14,6 @@
   "to": [
     "https://some.namespace#file1",
     "https://some.namespace#file2"
-  ]
+  ],
+  "relationshipType": "contains"
 }

--- a/serialization/json/examples/relationship1.json
+++ b/serialization/json/examples/relationship1.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Relationship",
+  "@id": "https://some.namespace#relationship1",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "from": "https://some.namespace#SPDXRef-Package",
+  "to": [
+    "https://some.namespace#file1",
+    "https://some.namespace#file2"
+  ]
+}

--- a/serialization/json/examples/relationship1.json
+++ b/serialization/json/examples/relationship1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Relationship",
-  "@id": "https://some.namespace#relationship1",
+  "type": "Relationship",
+  "spdxId": "https://some.namespace#relationship1",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/sbom1.json
+++ b/serialization/json/examples/sbom1.json
@@ -1,0 +1,20 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Sbom",
+  "@id": "https://some.namespace#SBOM",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core", "software"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "sbomType": "TBD",
+  "element": [
+    "https://some.namespace#File1",
+    "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3"
+  ],
+  "rootElement": [
+    "https://some.namespace#File1"
+  ]
+}

--- a/serialization/json/examples/sbom1.json
+++ b/serialization/json/examples/sbom1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Sbom",
-  "@id": "https://some.namespace#SBOM",
+  "type": "Sbom",
+  "spdxId": "https://some.namespace#SBOM",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/spdx_document1.json
+++ b/serialization/json/examples/spdx_document1.json
@@ -1,8 +1,9 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "SpdxDocument",
-  "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+  "type": "SpdxDocument",
+  "spdxId": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
   "creationInfo": {
+    "type": "CreationInfo",
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],

--- a/serialization/json/examples/spdx_document1.json
+++ b/serialization/json/examples/spdx_document1.json
@@ -1,0 +1,20 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "SpdxDocument",
+  "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core", "software"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "Doc 159 - two File elements",
+  "element": [
+    "https://some.namespace#File1",
+    "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3"
+  ],
+  "rootElement": [
+    "https://some.namespace#File1"
+  ]
+}

--- a/serialization/json/examples/spdx_document2.json
+++ b/serialization/json/examples/spdx_document2.json
@@ -1,0 +1,40 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "@type": "SpdxDocument",
+      "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+        "profile": ["core", "software"],
+        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+      },
+      "name": "Doc 159 - two File elements",
+      "element": [
+        "https://some.namespace#File1",
+        "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3"
+      ],
+      "rootElement": [
+        "https://some.namespace#File1"
+      ]
+    },
+    {
+      "@type": "File",
+      "@id": "https://some.namespace#file1",
+      "name": "model.png",
+      "contentType": "image/png",
+      "purpose": ["documentation"],
+      "contentIdentifier": "https://github.com/spdx/spdx-3-model/blob/main/model.png"
+    },
+    {
+      "@type": "File",
+      "@id": "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3",
+      "name": "The Software Package Data Exchange® (SPDX®) Specification Version 2.3",
+      "contentType": "text/html",
+      "purpose": ["documentation"],
+      "contentIdentifier": "https://spdx.github.io/spdx-spec/v2.3/"
+    }
+  ]
+}

--- a/serialization/json/examples/spdx_document2.json
+++ b/serialization/json/examples/spdx_document2.json
@@ -2,9 +2,10 @@
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
   "@graph": [
     {
-      "@type": "SpdxDocument",
-      "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+      "type": "SpdxDocument",
+      "spdxId": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
       "creationInfo": {
+        "type": "CreationInfo",
         "specVersion": "3.0.0",
         "created": "2022-12-01T00:00:00",
         "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -21,16 +22,16 @@
       ]
     },
     {
-      "@type": "File",
-      "@id": "https://some.namespace#file1",
+      "type": "File",
+      "spdxId": "https://some.namespace#file1",
       "name": "model.png",
       "contentType": "image/png",
       "purpose": ["documentation"],
       "contentIdentifier": "https://github.com/spdx/spdx-3-model/blob/main/model.png"
     },
     {
-      "@type": "File",
-      "@id": "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3",
+      "type": "File",
+      "spdxId": "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3",
       "name": "The Software Package Data Exchange® (SPDX®) Specification Version 2.3",
       "contentType": "text/html",
       "purpose": ["documentation"],

--- a/serialization/json/examples/spdx_document3.json
+++ b/serialization/json/examples/spdx_document3.json
@@ -3,7 +3,7 @@
   "@graph": [
     {
       "@type": "SpdxDocument",
-      "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+      "@id": "https://some.namespace#spdxdocument159",
       "creationInfo": {
         "specVersion": "3.0.0",
         "created": "2022-12-01T00:00:00",

--- a/serialization/json/examples/spdx_document3.json
+++ b/serialization/json/examples/spdx_document3.json
@@ -1,0 +1,50 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "@type": "SpdxDocument",
+      "@id": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+        "profile": ["core", "software"],
+        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+      },
+      "name": "Doc 159 - two File elements",
+      "element": [
+        "https://some.namespace#SPDXRef-Package",
+        "https://some.namespace#File1",
+        "https://spdx.dev/elements/3F26391C#spdx-spec-v2.3",
+        "https://some.namespace#relationship1"
+      ],
+      "rootElement": [
+        "https://some.namespace#SPDXRef-Package"
+      ]
+    },
+    {
+      "@type": "Package",
+      "@id": "https://some.namespace#SPDXRef-Package",
+      "name": "packageName"
+    },
+    {
+      "@type": "File",
+      "@id": "https://some.namespace#file1",
+      "name": "file1"
+    },
+    {
+      "@type": "File",
+      "@id": "https://some.namespace#file2",
+      "name": "file2"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "https://some.namespace#relationship1",
+      "from": "https://some.namespace#SPDXRef-Package",
+      "to": [
+        "https://some.namespace#file1",
+        "https://some.namespace#file2"
+      ]
+    }
+  ]
+}

--- a/serialization/json/examples/spdx_document3.json
+++ b/serialization/json/examples/spdx_document3.json
@@ -45,7 +45,8 @@
       "to": [
         "https://some.namespace#file1",
         "https://some.namespace#file2"
-      ]
+      ],
+      "relationshipType": "contains"
     }
   ]
 }

--- a/serialization/json/examples/spdx_document3.json
+++ b/serialization/json/examples/spdx_document3.json
@@ -2,9 +2,10 @@
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
   "@graph": [
     {
-      "@type": "SpdxDocument",
-      "@id": "https://some.namespace#spdxdocument159",
+      "type": "SpdxDocument",
+      "spdxId": "https://some.namespace#spdxdocument159",
       "creationInfo": {
+        "type": "CreationInfo",
         "specVersion": "3.0.0",
         "created": "2022-12-01T00:00:00",
         "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
@@ -23,23 +24,23 @@
       ]
     },
     {
-      "@type": "Package",
-      "@id": "https://some.namespace#SPDXRef-Package",
+      "type": "Package",
+      "spdxId": "https://some.namespace#SPDXRef-Package",
       "name": "packageName"
     },
     {
-      "@type": "File",
-      "@id": "https://some.namespace#file1",
+      "type": "File",
+      "spdxId": "https://some.namespace#file1",
       "name": "file1"
     },
     {
-      "@type": "File",
-      "@id": "https://some.namespace#file2",
+      "type": "File",
+      "spdxId": "https://some.namespace#file2",
       "name": "file2"
     },
     {
-      "@type": "Relationship",
-      "@id": "https://some.namespace#relationship1",
+      "type": "Relationship",
+      "spdxId": "https://some.namespace#relationship1",
       "from": "https://some.namespace#SPDXRef-Package",
       "to": [
         "https://some.namespace#file1",

--- a/serialization/json/examples/spdx_document4.json
+++ b/serialization/json/examples/spdx_document4.json
@@ -9,9 +9,10 @@
   ],
   "@graph": [
     {
-      "@type": "SpdxDocument",
-      "@id": "myNamespace:spdxdocument159",
+      "type": "SpdxDocument",
+      "spdxId": "myNamespace:spdxdocument159",
       "creationInfo": {
+        "type": "CreationInfo",
         "specVersion": "3.0.0",
         "created": "2022-12-01T00:00:00",
         "createdBy": ["spdxDev:spdx-dev"],
@@ -30,23 +31,23 @@
       ]
     },
     {
-      "@type": "Package",
-      "@id": "myNamespace:SPDXRef-Package",
+      "type": "Package",
+      "spdxId": "myNamespace:SPDXRef-Package",
       "name": "packageName"
     },
     {
-      "@type": "File",
-      "@id": "myNamespace:file1",
+      "type": "File",
+      "spdxId": "myNamespace:file1",
       "name": "file1"
     },
     {
-      "@type": "File",
-      "@id": "myNamespace:file2",
+      "type": "File",
+      "spdxId": "myNamespace:file2",
       "name": "file2"
     },
     {
-      "@type": "Relationship",
-      "@id": "myNamespace:relationship1",
+      "type": "Relationship",
+      "spdxId": "myNamespace:relationship1",
       "from": "myNamespace:SPDXRef-Package",
       "to": [
         "myNamespace:file1",

--- a/serialization/json/examples/spdx_document4.json
+++ b/serialization/json/examples/spdx_document4.json
@@ -52,7 +52,8 @@
       "to": [
         "myNamespace:file1",
         "myNamespace:file2"
-      ]
+      ],
+      "relationshipType": "contains"
     }
   ]
 }

--- a/serialization/json/examples/spdx_document4.json
+++ b/serialization/json/examples/spdx_document4.json
@@ -1,0 +1,57 @@
+{
+  "@context": [
+    "https://spdx.github.io/spdx-3-model/rdf/context.json",
+    {
+      "myNamespace": "https://some.namespace#",
+      "spdxDev": "https://spdx.dev/elements/3F26391C#",
+      "spdxLicenses": "https://spdx.org/licenses/"
+    }
+  ],
+  "@graph": [
+    {
+      "@type": "SpdxDocument",
+      "@id": "myNamespace:spdxdocument159",
+      "creationInfo": {
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": ["spdxDev:spdx-dev"],
+        "profile": ["core", "software"],
+        "dataLicense": "spdxLicenses:CC0-1.0"
+      },
+      "name": "Doc 159 - two File elements",
+      "element": [
+        "myNamespace:SPDXRef-Package",
+        "myNamespace:File1",
+        "spdxDev:spdx-spec-v2.3",
+        "myNamespace:relationship1"
+      ],
+      "rootElement": [
+        "myNamespace:SPDXRef-Package"
+      ]
+    },
+    {
+      "@type": "Package",
+      "@id": "myNamespace:SPDXRef-Package",
+      "name": "packageName"
+    },
+    {
+      "@type": "File",
+      "@id": "myNamespace:file1",
+      "name": "file1"
+    },
+    {
+      "@type": "File",
+      "@id": "myNamespace:file2",
+      "name": "file2"
+    },
+    {
+      "@type": "Relationship",
+      "@id": "myNamespace:relationship1",
+      "from": "myNamespace:SPDXRef-Package",
+      "to": [
+        "myNamespace:file1",
+        "myNamespace:file2"
+      ]
+    }
+  ]
+}

--- a/serialization/json/examples/tool1.json
+++ b/serialization/json/examples/tool1.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
-  "@type": "Tool",
-  "@id": "https://some.namespace#sbomolator_v2",
+  "type": "Tool",
+  "spdxId": "https://some.namespace#sbomolator_v2",
   "creationInfo": {
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00",

--- a/serialization/json/examples/tool1.json
+++ b/serialization/json/examples/tool1.json
@@ -1,0 +1,13 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@type": "Tool",
+  "@id": "https://some.namespace#sbomolator_v2",
+  "creationInfo": {
+    "specVersion": "3.0.0",
+    "created": "2022-12-01T00:00:00",
+    "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+    "profile": ["core"],
+    "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+  },
+  "name": "Acme Corp. Super SBOM-o-lator"
+}

--- a/serialization/json/examples/two_sboms.json
+++ b/serialization/json/examples/two_sboms.json
@@ -1,0 +1,45 @@
+{
+  "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
+  "@graph": [
+    {
+      "type": "Sbom",
+      "spdxId": "http://my_namespace.com/sbom1",
+      "creationInfo": {
+        "type": "CreationInfo",
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": ["https://my_namespace.com/creator1"],
+        "profile": ["core", "software"],
+        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+      },
+      "name": "My SBOM",
+      "element": [
+        "https://some.namespace#File1",
+        "https://my_namespace/my_file"
+      ],
+      "rootElement": [
+        "https://some.namespace#File1"
+      ]
+    },
+    {
+      "type": "Sbom",
+      "spdxId": "http://my_namespace.com/sbom2",
+      "creationInfo": {
+        "type": "CreationInfo",
+        "specVersion": "3.0.0",
+        "created": "2022-12-01T00:00:00",
+        "createdBy": ["https://my_namespace.com/creator1"],
+        "profile": ["core", "software"],
+        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+      },
+      "name": "My other SBOM",
+      "element": [
+        "https://some.namespace#File1",
+        "https://my_namespace/my_other_file"
+      ],
+      "rootElement": [
+        "https://some.namespace#File1"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds json examples for some of the current use cases.

Most of these have the same data as those in #375 (I also borrowed the table of contents, thanks @davaya 👍🏽 ), but different formatting. This formatting has the advantage that the examples are compatible with json-ld, so that we wouldn't need two different serializations. The only overhead is the single context line at the start, which I don't believe will be a problem.

In addition to the examples in #375, I also included two examples with multiple elements in the same serialization/payload. Currently, these assume that the CreationInfo of Elements is inherited from the Collection they are part of.