### PR TITLE
Added dataset types vocabulary

### DIFF
--- a/model/Dataset/Classes/Dataset.md
+++ b/model/Dataset/Classes/Dataset.md
@@ -19,9 +19,8 @@ Metadata information that can be added to a dataset that may be used in a softwa
 ## Properties
 
 - datasetType
-  - type: xsd:string
+  - type: DatasetType
   - minCount: 1
-  - maxCount: 1
 - dataCollectionProcess
   - type: xsd:string
   - minCount: 0

--- a/model/Dataset/Properties/datasetType.md
+++ b/model/Dataset/Properties/datasetType.md
@@ -8,10 +8,10 @@ Describes the type of the given dataset.
 
 ## Description
 
-Type describes the datatype contained in the dataset. For example a dataset can be a image dataset or a text dataset or sometimes a multimodal dataset that contains multiple types of data
+Type describes the datatype contained in the dataset. For example a dataset can be an image dataset for computer vision applications, a text dataset such as the contents of a book or Wikipedia article, or sometimes a multimodal dataset that contains multiple types of data.
 
 ## Metadata
 
 - name: datasetType
 - Nature: DataProperty
-- Range: xsd:string
+- Range: DatasetType

--- a/model/Dataset/Vocabularies/DatasetType.md
+++ b/model/Dataset/Vocabularies/DatasetType.md
@@ -1,0 +1,32 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# DatasetType
+
+## Summary
+
+Enumeration of dataset types.
+
+## Description
+
+Describes the different structures of data within a given dataset. A dataset can have multiple types of data, or even a single type of data but still match multiple types, for example sensor data could also be timeseries or labeled image data could also be considered categorical.
+
+## Metadata
+
+- name: DatasetType
+
+## Entries
+
+- structured: data is stored in tabular format or retrieved from a relational database.
+- numeric: data consists only of numeric entries.
+- text: data consists of unstructured text, such as a book, wikipedia article (without images), or transcript.
+- categorical: data that is classified into a discrete number of categories, such as the eye color of a population of people.
+- graph: data is in the form of a graph where entries are somehow related to each other through edges, such a social network of friends.
+- timeseries: data is recorded in an ordered sequence of timestamped entries, such as the price of a stock over the course of a day.
+- timestamp: data is recorded with a timestamp for each entry, but not necessarily ordered or at specific intervals, such as when a taxi ride starts and ends.
+- sensor: data is recorded from a physical sensor, such as a thermometer reading or biometric device.
+- image: data is a collection of images such as pictures of animals.
+- syntactic: data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing.
+- audio: data is audio based, such as a collection of music from the 80s.
+- video: data is video based, such as a collection of movie clips featuring Tom Hanks.
+- other: data is of a type not included in this list.
+- noAssertion: data type is not known.


### PR DESCRIPTION
Closes #363 

This PR introduces a new vocabulary that can be used to describe types of a dataset in a concrete way. Now, instead of a string to describe a `datasetType`, users can choose from the selection for the type(s) that describe their dataset, making it easier for tools to generate and parse standardized dataset types. See #363 for how we got this list of types. Of course users can always specify "Other" if their type isn't included, or "noAssertion" if they don't know the type. I tried to include real-life examples for each entry, but am open to other suggestions for examples!