### PR TITLE
Change `purpose` references to `primaryPurpose`

### DIFF
--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -79,7 +79,7 @@ Metadata information that can be added to a package to describe an AI applicatio
   - minCount: 1
 - /Software/Package/packageVersion
   - minCount: 1
-- /Software/SoftwareArtifact/purpose
+- /Software/SoftwareArtifact/primaryPurpose
   - minCount: 1
 - /Core/Artifact/releaseTime
   - minCount: 1

--- a/model/Dataset/Classes/Dataset.md
+++ b/model/Dataset/Classes/Dataset.md
@@ -72,7 +72,7 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - minCount: 1
 - /Software/Package/downloadLocation
   - minCount: 1
-- /Software/SoftwareArtifact/purpose
+- /Software/SoftwareArtifact/primaryPurpose
   - minCount: 1
 - /Core/Artifact/releaseTime
   - minCount: 1


### PR DESCRIPTION
Small fix as `purpose` is now split into `primaryPurpose` and `additionalPurpose`. I changed the reference to the former as having only `additionalPurpose` mandatory wouldn't make much sense to me.