### PR TITLE
add json-ld context to gh-pages

### DIFF
--- a/json_ld/context.json
+++ b/json_ld/context.json
@@ -1,0 +1,745 @@
+{
+    "ai": "https://spdx.org/rdf/AI/",
+    "build": "https://spdx.org/rdf/Build/",
+    "core": "https://spdx.org/rdf/Core/",
+    "dataset": "https://spdx.org/rdf/Dataset/",
+    "expandedlicense": "https://spdx.org/rdf/ExpandedLicense/",
+    "licensing": "https://spdx.org/rdf/Licensing/",
+    "ns0": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "security": "https://spdx.org/rdf/Security/",
+    "sh": "http://www.w3.org/ns/shacl#",
+    "software": "https://spdx.org/rdf/Software/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "AIPackage": "ai:AIPackage",
+    "Build": "build:Build",
+    "Annotation": "core:Annotation",
+    "AnonymousPayload": "core:AnonymousPayload",
+    "Organization": "core:Organization",
+    "Person": "core:Person",
+    "SoftwareAgent": "core:SoftwareAgent",
+    "SpdxDocument": "core:SpdxDocument",
+    "Dataset": "dataset:Dataset",
+    "ConjunctiveLicenseSet": "expandedlicense:ConjunctiveLicenseSet",
+    "DisjunctiveLicenseSet": "expandedlicense:DisjunctiveLicenseSet",
+    "ExtendableLicense": "expandedlicense:ExtendableLicense",
+    "subjectAddition": {
+        "@id": "expandedlicense:subjectAddition",
+        "@type": "expandedlicense:LicenseAddition"
+    },
+    "subjectLicense": {
+        "@id": "expandedlicense:subjectLicense",
+        "@type": "licensing:License"
+    },
+    "CustomLicense": "licensing:CustomLicense",
+    "CustomLicenseAddition": "licensing:CustomLicenseAddition",
+    "LicenseExpression": "licensing:LicenseExpression",
+    "ListedLicense": "licensing:ListedLicense",
+    "ListedLicenseException": "licensing:ListedLicenseException",
+    "OrLaterOperator": "licensing:OrLaterOperator",
+    "WithAdditionOperator": "licensing:WithAdditionOperator",
+    "additionComment": {
+        "@id": "licensing:additionComment",
+        "@type": "xsd:string"
+    },
+    "additionId": {
+        "@id": "licensing:additionId",
+        "@type": "xsd:string"
+    },
+    "additionName": {
+        "@id": "licensing:additionName",
+        "@type": "xsd:string"
+    },
+    "licenseComment": {
+        "@id": "licensing:licenseComment",
+        "@type": "xsd:string"
+    },
+    "licenseId": {
+        "@id": "licensing:licenseId",
+        "@type": "xsd:string"
+    },
+    "licenseName": {
+        "@id": "licensing:licenseName",
+        "@type": "xsd:string"
+    },
+    "seeAlso": {
+        "@id": "licensing:seeAlso",
+        "@type": "xsd:anyURI"
+    },
+    "CvssV2VulnAssessmentRelationship": "security:CvssV2VulnAssessmentRelationship",
+    "CvssV3VulnAssessmentRelationship": "security:CvssV3VulnAssessmentRelationship",
+    "EpssVulnAssessmentRelationship": "security:EpssVulnAssessmentRelationship",
+    "ExploitCatalogVulnAssessmentRelationship": "security:ExploitCatalogVulnAssessmentRelationship",
+    "SsvcVulnAssessmentRelationship": "security:SsvcVulnAssessmentRelationship",
+    "VexAffectedVulnAssessmentRelationship": "security:VexAffectedVulnAssessmentRelationship",
+    "VexFixedVulnAssessmentRelationship": "security:VexFixedVulnAssessmentRelationship",
+    "VexNotAffectedVulnAssessmentRelationship": "security:VexNotAffectedVulnAssessmentRelationship",
+    "VexUnderInvestigationVulnAssessmentRelationship": "security:VexUnderInvestigationVulnAssessmentRelationship",
+    "Vulnerability": "security:Vulnerability",
+    "File": "software:File",
+    "Sbom": "software:Sbom",
+    "Snippet": "software:Snippet",
+    "SoftwareDependencyRelationship": "software:SoftwareDependencyRelationship",
+    "autonomyType": {
+        "@id": "ai:autonomyType",
+        "@type": "ai:PresenceType"
+    },
+    "domain": {
+        "@id": "ai:domain",
+        "@type": "xsd:string"
+    },
+    "energyConsumption": {
+        "@id": "ai:energyConsumption",
+        "@type": "xsd:string"
+    },
+    "hyperparameter": {
+        "@id": "ai:hyperparameter",
+        "@type": "core:DictionaryEntry"
+    },
+    "informationAboutApplication": {
+        "@id": "ai:informationAboutApplication",
+        "@type": "xsd:string"
+    },
+    "informationAboutTraining": {
+        "@id": "ai:informationAboutTraining",
+        "@type": "xsd:string"
+    },
+    "limitation": {
+        "@id": "ai:limitation",
+        "@type": "xsd:string"
+    },
+    "metric": {
+        "@id": "ai:metric",
+        "@type": "core:DictionaryEntry"
+    },
+    "metricDecisionThreshold": {
+        "@id": "ai:metricDecisionThreshold",
+        "@type": "core:DictionaryEntry"
+    },
+    "modelDataPreprocessing": {
+        "@id": "ai:modelDataPreprocessing",
+        "@type": "xsd:string"
+    },
+    "modelExplainability": {
+        "@id": "ai:modelExplainability",
+        "@type": "xsd:string"
+    },
+    "safetyRiskAssessment": {
+        "@id": "ai:safetyRiskAssessment",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "ai:SafetyRiskAssessmentType/"
+        }
+    },
+    "sensitivePersonalInformation": {
+        "@id": "dataset:sensitivePersonalInformation",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "dataset:PresenceType/"
+        }
+    },
+    "standardCompliance": {
+        "@id": "ai:standardCompliance",
+        "@type": "xsd:string"
+    },
+    "typeOfModel": {
+        "@id": "ai:typeOfModel",
+        "@type": "xsd:string"
+    },
+    "buildEndTime": {
+        "@id": "build:buildEndTime",
+        "@type": "core:DateTime"
+    },
+    "buildId": {
+        "@id": "build:buildId",
+        "@type": "xsd:string"
+    },
+    "buildStartTime": {
+        "@id": "build:buildStartTime",
+        "@type": "core:DateTime"
+    },
+    "buildType": {
+        "@id": "build:buildType",
+        "@type": "xsd:anyURI"
+    },
+    "configSourceDigest": {
+        "@id": "build:configSourceDigest",
+        "@type": "core:Hash"
+    },
+    "configSourceEntrypoint": {
+        "@id": "build:configSourceEntrypoint",
+        "@type": "xsd:string"
+    },
+    "configSourceUri": {
+        "@id": "build:configSourceUri",
+        "@type": "xsd:anyURI"
+    },
+    "environment": {
+        "@id": "build:environment",
+        "@type": "core:DictionaryEntry"
+    },
+    "parameters": {
+        "@id": "build:parameters",
+        "@type": "core:DictionaryEntry"
+    },
+    "Artifact": "core:Artifact",
+    "Bom": "core:Bom",
+    "ElementCollection": "core:ElementCollection",
+    "LifecycleScopedRelationship": "core:LifecycleScopedRelationship",
+    "algorithm": {
+        "@id": "core:algorithm",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:HashAlgorithm/"
+        }
+    },
+    "annotationType": {
+        "@id": "core:annotationType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:AnnotationType/"
+        }
+    },
+    "begin": {
+        "@id": "core:begin",
+        "@type": "xsd:positiveInteger"
+    },
+    "builtTime": {
+        "@id": "core:builtTime",
+        "@type": "core:DateTime"
+    },
+    "completeness": {
+        "@id": "core:completeness",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:RelationshipCompleteness/"
+        }
+    },
+    "context": {
+        "@id": "core:context",
+        "@type": "xsd:string"
+    },
+    "created": {
+        "@id": "core:created",
+        "@type": "core:DateTime"
+    },
+    "createdBy": {
+        "@id": "core:createdBy",
+        "@type": "@id"
+    },
+    "createdUsing": {
+        "@id": "core:createdUsing",
+        "@type": "core:Tool"
+    },
+    "dataLicense": {
+        "@id": "core:dataLicense",
+        "@type": "xsd:string"
+    },
+    "definingDocument": {
+        "@id": "core:definingDocument",
+        "@type": "xsd:anyURI"
+    },
+    "description": {
+        "@id": "core:description",
+        "@type": "xsd:string"
+    },
+    "element": {
+        "@id": "core:element",
+        "@type": "@id"
+    },
+    "end": {
+        "@id": "core:end",
+        "@type": "xsd:positiveInteger"
+    },
+    "endTime": {
+        "@id": "core:endTime",
+        "@type": "core:DateTime"
+    },
+    "externalId": {
+        "@id": "core:externalId",
+        "@type": "xsd:anyURI"
+    },
+    "externalIdentifier": {
+        "@id": "core:externalIdentifier",
+        "@type": "core:ExternalIdentifier"
+    },
+    "externalIdentifierType": {
+        "@id": "core:externalIdentifierType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:ExternalIdentifierType/"
+        }
+    },
+    "externalReference": {
+        "@id": "core:externalReference",
+        "@type": "core:ExternalReference"
+    },
+    "externalReferenceType": {
+        "@id": "core:externalReferenceType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:ExternalReferenceType/"
+        }
+    },
+    "from": {
+        "@id": "core:from",
+        "@type": "@id"
+    },
+    "hashValue": {
+        "@id": "core:hashValue",
+        "@type": "xsd:string"
+    },
+    "identifier": {
+        "@id": "core:identifier",
+        "@type": "xsd:string"
+    },
+    "identifierLocator": {
+        "@id": "core:identifierLocator",
+        "@type": "xsd:anyURI"
+    },
+    "issuingAuthority": {
+        "@id": "core:issuingAuthority",
+        "@type": "xsd:anyURI"
+    },
+    "key": {
+        "@id": "core:key",
+        "@type": "xsd:string"
+    },
+    "locationHint": {
+        "@id": "core:locationHint",
+        "@type": "xsd:anyURI"
+    },
+    "locator": {
+        "@id": "core:locator",
+        "@type": "xsd:anyURI"
+    },
+    "namespace": {
+        "@id": "core:namespace",
+        "@type": "xsd:anyURI"
+    },
+    "originatedBy": {
+        "@id": "core:originatedBy",
+        "@type": "@id"
+    },
+    "prefix": {
+        "@id": "core:prefix",
+        "@type": "xsd:string"
+    },
+    "profile": {
+        "@id": "core:profile",
+        "@type": "@vocab",
+        "@context": {
+            "core": "https://spdx.org/rdf/Core/ProfileIdentifierType/core",
+            "software": "https://spdx.org/rdf/Core/ProfileIdentifierType/software",
+            "licensing": "https://spdx.org/rdf/Core/ProfileIdentifierType/licensing",
+            "security": "https://spdx.org/rdf/Core/ProfileIdentifierType/security",
+            "build": "https://spdx.org/rdf/Core/ProfileIdentifierType/build",
+            "ai": "https://spdx.org/rdf/Core/ProfileIdentifierType/ai",
+            "dataset": "https://spdx.org/rdf/Core/ProfileIdentifierType/dataset",
+            "usage": "https://spdx.org/rdf/Core/ProfileIdentifierType/usage",
+            "extension": "https://spdx.org/rdf/Core/ProfileIdentifierType/extension"
+        }
+    },
+    "relationshipType": {
+        "@id": "core:relationshipType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:RelationshipType/"
+        }
+    },
+    "releaseTime": {
+        "@id": "core:releaseTime",
+        "@type": "core:DateTime"
+    },
+    "rootElement": {
+        "@id": "core:rootElement",
+        "@type": "@id"
+    },
+    "scope": {
+        "@id": "core:scope",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "core:LifecycleScopeType/"
+        }
+    },
+    "spdxId": "@id",
+    "specVersion": {
+        "@id": "core:specVersion",
+        "@type": "core:SemVer"
+    },
+    "standard": {
+        "@id": "core:standard",
+        "@type": "xsd:string"
+    },
+    "startTime": {
+        "@id": "core:startTime",
+        "@type": "core:DateTime"
+    },
+    "statement": {
+        "@id": "core:statement",
+        "@type": "xsd:string"
+    },
+    "subject": {
+        "@id": "core:subject",
+        "@type": "@id"
+    },
+    "summary": {
+        "@id": "core:summary",
+        "@type": "xsd:string"
+    },
+    "suppliedBy": {
+        "@id": "core:suppliedBy",
+        "@type": "@id"
+    },
+    "to": {
+        "@id": "core:to",
+        "@type": "@id"
+    },
+    "validUntilTime": {
+        "@id": "core:validUntilTime",
+        "@type": "core:DateTime"
+    },
+    "value": {
+        "@id": "core:value",
+        "@type": "xsd:string"
+    },
+    "anonymizationMethodUsed": {
+        "@id": "dataset:anonymizationMethodUsed",
+        "@type": "xsd:string"
+    },
+    "confidentialityLevel": {
+        "@id": "dataset:confidentialityLevel",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "dataset:ConfidentialityLevelType/"
+        }
+    },
+    "dataCollectionProcess": {
+        "@id": "dataset:dataCollectionProcess",
+        "@type": "xsd:string"
+    },
+    "dataPreprocessing": {
+        "@id": "dataset:dataPreprocessing",
+        "@type": "xsd:string"
+    },
+    "datasetAvailability": {
+        "@id": "dataset:datasetAvailability",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "dataset:DatasetAvailabilityType/"
+        }
+    },
+    "datasetNoise": {
+        "@id": "dataset:datasetNoise",
+        "@type": "xsd:string"
+    },
+    "datasetSize": {
+        "@id": "dataset:datasetSize",
+        "@type": "xsd:nonNegativeInteger"
+    },
+    "datasetType": {
+        "@id": "dataset:datasetType",
+        "@type": "dataset:DatasetType"
+    },
+    "datasetUpdateMechanism": {
+        "@id": "dataset:datasetUpdateMechanism",
+        "@type": "xsd:string"
+    },
+    "intendedUse": {
+        "@id": "dataset:intendedUse",
+        "@type": "xsd:string"
+    },
+    "knownBias": {
+        "@id": "dataset:knownBias",
+        "@type": "xsd:string"
+    },
+    "additionText": {
+        "@id": "licensing:additionText",
+        "@type": "xsd:string"
+    },
+    "isDeprecatedAdditionId": {
+        "@id": "licensing:isDeprecatedAdditionId",
+        "@type": "xsd:boolean"
+    },
+    "isDeprecatedLicenseId": {
+        "@id": "licensing:isDeprecatedLicenseId",
+        "@type": "xsd:boolean"
+    },
+    "isFsfLibre": {
+        "@id": "licensing:isFsfLibre",
+        "@type": "xsd:boolean"
+    },
+    "isOsiApproved": {
+        "@id": "licensing:isOsiApproved",
+        "@type": "xsd:boolean"
+    },
+    "licenseExpression": {
+        "@id": "licensing:licenseExpression",
+        "@type": "xsd:string"
+    },
+    "licenseText": {
+        "@id": "licensing:licenseText",
+        "@type": "xsd:string"
+    },
+    "standardAdditionTemplate": {
+        "@id": "licensing:standardAdditionTemplate",
+        "@type": "xsd:string"
+    },
+    "standardLicenseHeader": {
+        "@id": "licensing:standardLicenseHeader",
+        "@type": "xsd:string"
+    },
+    "standardLicenseTemplate": {
+        "@id": "licensing:standardLicenseTemplate",
+        "@type": "xsd:string"
+    },
+    "actionStatement": {
+        "@id": "security:actionStatement",
+        "@type": "xsd:string"
+    },
+    "actionStatementTime": {
+        "@id": "security:actionStatementTime",
+        "@type": "core:DateTime"
+    },
+    "assessedElement": {
+        "@id": "security:assessedElement",
+        "@type": "@id"
+    },
+    "catalogType": {
+        "@id": "security:catalogType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "security:ExploitCatalogType/"
+        }
+    },
+    "decisionType": {
+        "@id": "security:decisionType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "security:SsvcDecisionType/"
+        }
+    },
+    "exploited": {
+        "@id": "security:exploited",
+        "@type": "xsd:boolean"
+    },
+    "impactStatement": {
+        "@id": "security:impactStatement",
+        "@type": "xsd:string"
+    },
+    "impactStatementTime": {
+        "@id": "security:impactStatementTime",
+        "@type": "core:DateTime"
+    },
+    "justificationType": {
+        "@id": "security:justificationType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "security:VexJustificationType/"
+        }
+    },
+    "probability": {
+        "@id": "security:probability",
+        "@type": "xsd:decimal"
+    },
+    "statusNotes": {
+        "@id": "security:statusNotes",
+        "@type": "xsd:string"
+    },
+    "vexVersion": {
+        "@id": "security:vexVersion",
+        "@type": "xsd:string"
+    },
+    "additionalPurpose": {
+        "@id": "software:additionalPurpose",
+        "@type": "software:SoftwarePurpose"
+    },
+    "attributionText": {
+        "@id": "software:attributionText",
+        "@type": "xsd:string"
+    },
+    "byteRange": {
+        "@id": "software:byteRange",
+        "@type": "core:PositiveIntegerRange"
+    },
+    "concludedLicense": {
+        "@id": "software:concludedLicense",
+        "@type": "licensing:AnyLicenseInfo"
+    },
+    "conditionality": {
+        "@id": "software:conditionality",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "software:DependencyConditionalityType/"
+        }
+    },
+    "contentIdentifier": {
+        "@id": "software:contentIdentifier",
+        "@type": "xsd:anyURI"
+    },
+    "contentType": {
+        "@id": "core:contentType",
+        "@type": "core:MediaType"
+    },
+    "copyrightText": {
+        "@id": "software:copyrightText",
+        "@type": "xsd:string"
+    },
+    "declaredLicense": {
+        "@id": "software:declaredLicense",
+        "@type": "licensing:AnyLicenseInfo"
+    },
+    "downloadLocation": {
+        "@id": "software:downloadLocation",
+        "@type": "xsd:anyURI"
+    },
+    "homePage": {
+        "@id": "software:homePage",
+        "@type": "xsd:anyURI"
+    },
+    "lineRange": {
+        "@id": "software:lineRange",
+        "@type": "core:PositiveIntegerRange"
+    },
+    "packageUrl": {
+        "@id": "software:packageUrl",
+        "@type": "xsd:anyURI"
+    },
+    "packageVersion": {
+        "@id": "software:packageVersion",
+        "@type": "xsd:string"
+    },
+    "primaryPurpose": {
+        "@id": "software:primaryPurpose",
+        "@type": "software:SoftwarePurpose"
+    },
+    "sbomType": {
+        "@id": "software:sbomType",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "software:SBOMType/"
+        }
+    },
+    "softwareLinkage": {
+        "@id": "software:softwareLinkage",
+        "@type": "@vocab",
+        "@context": {
+            "@vocab": "software:SoftwareDependencyLinkType/"
+        }
+    },
+    "sourceInfo": {
+        "@id": "software:sourceInfo",
+        "@type": "xsd:string"
+    },
+    "Bundle": "core:Bundle",
+    "ExternalIdentifier": "core:ExternalIdentifier",
+    "ExternalReference": "core:ExternalReference",
+    "Hash": "core:Hash",
+    "Payload": "core:Payload",
+    "Relationship": "core:Relationship",
+    "SemVer": "core:SemVer",
+    "Tool": "core:Tool",
+    "name": {
+        "@id": "core:name",
+        "@type": "xsd:string"
+    },
+    "verifiedUsing": {
+        "@id": "core:verifiedUsing",
+        "@type": "core:IntegrityMethod"
+    },
+    "member": {
+        "@id": "expandedlicense:member",
+        "@type": "licensing:AnyLicenseInfo"
+    },
+    "deprecatedVersion": {
+        "@id": "licensing:deprecatedVersion",
+        "@type": "xsd:string"
+    },
+    "listVersionAdded": {
+        "@id": "licensing:listVersionAdded",
+        "@type": "xsd:string"
+    },
+    "obsoletedBy": {
+        "@id": "licensing:obsoletedBy",
+        "@type": "xsd:string"
+    },
+    "modifiedTime": {
+        "@id": "security:modifiedTime",
+        "@type": "core:DateTime"
+    },
+    "publishedTime": {
+        "@id": "security:publishedTime",
+        "@type": "core:DateTime"
+    },
+    "score": {
+        "@id": "security:score",
+        "@type": "xsd:string"
+    },
+    "vector": {
+        "@id": "security:vector",
+        "@type": "xsd:string"
+    },
+    "withdrawnTime": {
+        "@id": "security:withdrawnTime",
+        "@type": "core:DateTime"
+    },
+    "Package": "software:Package",
+    "creationInfo": {
+        "@id": "core:creationInfo",
+        "@type": "core:CreationInfo"
+    },
+    "imports": {
+        "@id": "core:imports",
+        "@type": "core:ExternalMap"
+    },
+    "namespaces": {
+        "@id": "core:namespaces",
+        "@type": "core:NamespaceMap"
+    },
+    "LicenseAddition": "licensing:LicenseAddition",
+    "severity": {
+        "@id": "security:severity",
+        "@type": "xsd:string"
+    },
+    "SoftwareArtifact": "software:SoftwareArtifact",
+    "AnnotationType": "core:AnnotationType",
+    "CreationInfo": "core:CreationInfo",
+    "ExternalMap": "core:ExternalMap",
+    "IntegrityMethod": "core:IntegrityMethod",
+    "NamespaceMap": "core:NamespaceMap",
+    "PositiveIntegerRange": "core:PositiveIntegerRange",
+    "License": "licensing:License",
+    "ExploitCatalogType": "security:ExploitCatalogType",
+    "VexVulnAssessmentRelationship": "security:VexVulnAssessmentRelationship",
+    "MediaType": "core:MediaType",
+    "RelationshipCompleteness": "core:RelationshipCompleteness",
+    "comment": {
+        "@id": "core:comment",
+        "@type": "xsd:string"
+    },
+    "SafetyRiskAssessmentType": "ai:SafetyRiskAssessmentType",
+    "ConfidentialityLevelType": "dataset:ConfidentialityLevelType",
+    "SsvcDecisionType": "security:SsvcDecisionType",
+    "VulnAssessmentRelationship": "security:VulnAssessmentRelationship",
+    "SoftwareDependencyLinkType": "software:SoftwareDependencyLinkType",
+    "PresenceType": "ai:PresenceType",
+    "DatasetAvailabilityType": "dataset:DatasetAvailabilityType",
+    "VexJustificationType": "security:VexJustificationType",
+    "DependencyConditionalityType": "software:DependencyConditionalityType",
+    "LifecycleScopeType": "core:LifecycleScopeType",
+    "SBOMType": "software:SBOMType",
+    "Agent": "core:Agent",
+    "ProfileIdentifierType": "core:ProfileIdentifierType",
+    "DictionaryEntry": "core:DictionaryEntry",
+    "AnyLicenseInfo": "licensing:AnyLicenseInfo",
+    "ExternalIdentifierType": "core:ExternalIdentifierType",
+    "DatasetType": "dataset:DatasetType",
+    "Element": "core:Element",
+    "HashAlgorithm": "core:HashAlgorithm",
+    "DateTime": "core:DateTime",
+    "SoftwarePurpose": "software:SoftwarePurpose",
+    "ExternalReferenceType": "core:ExternalReferenceType",
+    "RelationshipType": "core:RelationshipType",
+    "type": "@type"
+}


### PR DESCRIPTION
This adds the current state of the context for JSON-LD to the gh-pages, so that we have a URL and more central place to reference it.