### PR TITLE
Correct name property of LicenseExpression

### DIFF
--- a/model/Licensing/Classes/LicenseExpression.md
+++ b/model/Licensing/Classes/LicenseExpression.md
@@ -14,7 +14,7 @@ SPDX License Expressions provide a way for one to construct expressions that mor
 
 ## Metadata
 
-- name: ExtendableLicense
+- name: LicenseExpression
 - SubclassOf: AnyLicenseInfo
 - Instantiability: Concrete
 


### PR DESCRIPTION
This was a copy/paste error from a previous PR.  The name property should be `LicenseExpression` consistent with the header and file name.

Fixes #391