### PR TITLE
Mandatory creationInfo

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -41,7 +41,7 @@ and inter-relatable content objects.
   - maxCount: 1
 - creationInfo
   - type: CreationInfo
-  - minCount: 0
+  - minCount: 1
   - maxCount: 1
 - verifiedUsing
   - type: IntegrityMethod


### PR DESCRIPTION
PR #273 was merged into the model without significant discussion at either the tech team or serialization subteam, and with a rationale that needs to be validated.

Since the beginning of SPDX v3 we have designed the model without in-depth discussion of serialization, leading to an implicit assumption that the model is serialization-independent.  273 violates that assumption, so now we need discuss and agree on what the model represents: 

1) Elements after they have been read into an application, or
2) Elements before they have been read into an application

The model diagram shows that every element must have creationInfo:

![image](https://github.com/spdx/spdx-3-model/assets/19152940/c9fd09dd-fd3d-4776-8d41-ed372e88c843)

which represents the "meaning" of Element - no element can exist unless it has been created, and every application must be able to know the creationInfo of every Element it processes.  To make it optional says that there is a use case in which having an Element but not knowing how it was created makes sense.

This PR reverts creationInfo minCount back to 1 to align with the diagram and the use-case-based understanding that Elements must have creationInfo.  It is a call for discussion and consensus-based decision on whether the model represents use cases (logical Elements) or serialized data, and therefore whether the model is independent of serialization.

