### PR TITLE
Clarify namespacemaps used in SPDX documents and collections

### DIFF
--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -17,8 +17,13 @@ Commonly used when representing a unit of transfer of SPDX Elements.
 - SubclassOf: Bundle
 - Instantiability: Concrete
 
+=======
+## Properties
+
+- originalNamespaces
+  - type: NamespaceMap
+
 ## External properties restrictions
 
 - /Core/Element/name
   - minCount: 1
-

--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -17,7 +17,6 @@ Commonly used when representing a unit of transfer of SPDX Elements.
 - SubclassOf: Bundle
 - Instantiability: Concrete
 
-=======
 ## Properties
 
 - originalNamespaces

--- a/model/Core/Properties/originalNamespaces.md
+++ b/model/Core/Properties/originalNamespaces.md
@@ -1,0 +1,20 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# namespaces
+
+## Summary
+
+Provides a NamespaceMap representing the NamspaceMap used for the original serialization of an SpdxDocument.
+
+## Description
+
+This field is used for providing a reliable mechanism in reproducing an original serialization for a given SPDX Document.
+
+This field is not intended for implementing or representing the NameSpaceMap for all serializations where this SPDX document may be found.
+
+## Metadata
+
+- name: originalNamespaces
+- Nature: DataProperty
+- Range: NamespaceMap
+

--- a/model/Core/Properties/originalNamespaces.md
+++ b/model/Core/Properties/originalNamespaces.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides a NamespaceMap representing the NamspaceMap used for the original serialization of an SpdxDocument.
+Provides a NamespaceMap representing the NamespaceMap used for the original serialization of an SpdxDocument.
 
 ## Description
 

--- a/model/Core/Properties/originalNamespaces.md
+++ b/model/Core/Properties/originalNamespaces.md
@@ -8,9 +8,9 @@ Provides a NamespaceMap representing the NamspaceMap used for the original seria
 
 ## Description
 
-This field is used for providing a reliable mechanism in reproducing an original serialization for a given SPDX Document.
+This field is used for providing the ability to reproduce an original serialization for a given SPDX Document, especially if the serialization format does not natively support namespace mapping.
 
-This field is not intended for implementing or representing the NameSpaceMap for all serializations where this SPDX document may be found.
+This purely optional field is not intended for implementing or representing the NameSpaceMap for all serializations where this SPDX document may be found.
 
 ## Metadata
 


### PR DESCRIPTION
This PR is an attempt to solve issue #390 by making moving the namespaceMap to SPDX Documents rather than all collections and redefining the semantics to be specific to the round-tripping issue for serialization namespaces