### PR TITLE
Create SpdxId type for spdxId property

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -24,7 +24,7 @@ and inter-relatable content objects.
 ## Properties
 
 - spdxId
-  - type: xsd:anyURI
+  - type: SpdxId
   - minCount: 1
   - maxCount: 1
 - name

--- a/model/Core/Classes/SpdxId.md
+++ b/model/Core/Classes/SpdxId.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# SpdxId
+
+## Summary
+
+An Element Identifier
+
+## Description
+
+The Element spdxId property is an IRI that uniquely identifies an Element instance. 
+
+## Metadata
+
+- name: SemVer
+- SubclassOf: xsd:anyURI
+
+## Properties

--- a/model/Core/Classes/SpdxId.md
+++ b/model/Core/Classes/SpdxId.md
@@ -8,11 +8,12 @@ An Element Identifier
 
 ## Description
 
-The Element spdxId property is an IRI that uniquely identifies an Element instance. 
+The Element spdxId property is an IRI that uniquely identifies an Element instance.
+The SpdxId type distinguishes IRIs that are Element identifiers from IRIs used for other purposes.
 
 ## Metadata
 
-- name: SemVer
+- name: SpdxId
 - SubclassOf: xsd:anyURI
 
 ## Properties


### PR DESCRIPTION
Using a semantic type for Element identifiers enables software to distinguish between IRIs used as Element IDs and IRIs used for other purposes such as Package download location, package URL, and home page.

This allows NamespaceMap to be applied to serialized Element IDs such as Relationship to and from without affecting other IRI properties.