### PR TITLE
add CreationInfo to all Elements in json-ld examples

### DIFF
--- a/serialization/json_ld/examples/agent1.json
+++ b/serialization/json_ld/examples/agent1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/annotation1.json
+++ b/serialization/json_ld/examples/annotation1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/converted_from_spdx_2.json
+++ b/serialization/json_ld/examples/converted_from_spdx_2.json
@@ -7,42 +7,47 @@
   ],
   "@graph": [
     {
+      "@id": "_:creationInfo1",
+      "type": "CreationInfo",
+      "specVersion": "3.0.0",
+      "created": "2010-01-29T18:30:22Z",
+      "createdBy": [
+        "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
+        "spdx-example:SPDXRef-Actor-JaneDoe"
+      ],
+      "createdUsing": [
+        "spdx-example:SPDXRef-Actor-LicenseFind-1.0"
+      ],
+      "profile": [
+        "core",
+        "software",
+        "licensing"
+      ],
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0",
+      "comment": "This is the SPDX-2.3 JSON example converted to SPDX-3.0. As there is currently no closure on how to treat licenses, they are omitted here for now."
+    },
+    {
       "type": "Tool",
       "spdxId": "spdx-example:SPDXRef-Actor-LicenseFind-1.0",
-      "name": "LicenseFind-1.0"
+      "name": "LicenseFind-1.0",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Organization",
       "spdxId": "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
-      "name": "ExampleCodeInspect"
+      "name": "ExampleCodeInspect",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Person",
       "spdxId": "spdx-example:SPDXRef-Actor-JaneDoe",
-      "name": "Jane Doe"
+      "name": "Jane Doe",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "SpdxDocument",
       "spdxId": "spdx-example:SPDXRef-DOCUMENT",
-      "creationInfo": {
-        "type": "CreationInfo",
-        "specVersion": "3.0.0",
-        "created": "2010-01-29T18:30:22Z",
-        "createdBy": [
-          "spdx-example:SPDXRef-Actor-ExampleCodeInspect",
-          "spdx-example:SPDXRef-Actor-JaneDoe"
-        ],
-        "createdUsing": [
-          "spdx-example:SPDXRef-Actor-LicenseFind-1.0"
-        ],
-        "profile": [
-          "core",
-          "software",
-          "licensing"
-        ],
-        "dataLicense": "https://spdx.org/licenses/CC0-1.0",
-        "comment": "This is the SPDX-2.3 JSON example converted to SPDX-3.0. As there is currently no closure on how to treat licenses, they are omitted here for now."
-      },
+      "creationInfo": "_:creationInfo1",
       "name": "SPDX-Tools-v2.0",
       "comment": "This document was created using SPDX 2.0 using licenses from the web site.",
       "element": [
@@ -114,7 +119,8 @@
           "externalIdentifierType": "email",
           "identifier": "jane.doe@example.com"
         }
-      ]
+      ],
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Organization",
@@ -126,7 +132,8 @@
           "externalIdentifierType": "email",
           "identifier": "contact@example.com"
         }
-      ]
+      ],
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Package",
@@ -180,13 +187,15 @@
       "packageVersion": "2.11.1",
       "downloadLocation": "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
       "homepage": "http://ftp.gnu.org/gnu/glibc",
-      "sourceInfo": "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git."
+      "sourceInfo": "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Package",
       "spdxId": "spdx-example:SPDXRef-fromDoap-1",
       "name": "Apache Commons Lang",
-      "homepage": "http://commons.apache.org/proper/commons-lang/"
+      "homepage": "http://commons.apache.org/proper/commons-lang/",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Package",
@@ -195,7 +204,8 @@
       "packageVersion": "3.12.0",
       "downloadLocation": "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
       "packageUrl": "pkg:maven/org.apache.jena/apache-jena@3.12.0",
-      "homepage": "http://www.openjena.org/"
+      "homepage": "http://www.openjena.org/",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Package",
@@ -212,7 +222,8 @@
       "copyrightText": "Copyright Saxonica Ltd",
       "packageVersion": "8.8",
       "downloadLocation": "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
-      "homepage": "http://saxon.sourceforge.net/"
+      "homepage": "http://saxon.sourceforge.net/",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
@@ -239,7 +250,8 @@
           "hashValue": "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
         }
       ],
-      "copyrightText": "Copyright 2001-2011 The Apache Software Foundation"
+      "copyrightText": "Copyright 2001-2011 The Apache Software Foundation",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
@@ -266,7 +278,8 @@
           "algorithm": "sha1",
           "hashValue": "fff4e1c67a2d28fced849ee1bb76e7391b93f125"
         }
-      ]
+      ],
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
@@ -285,7 +298,8 @@
           "hashValue": "624c1abb3664f4b35547e7c73864ad24"
         }
       ],
-      "copyrightText": "Copyright 2008-2010 John Smith"
+      "copyrightText": "Copyright 2008-2010 John Smith",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Snippet",
@@ -300,7 +314,8 @@
       "lineRange": {
         "begin": 5,
         "end": 23
-      }
+      },
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -309,7 +324,8 @@
       "to": [
         "spdx-example:SPDXRef-Package"
       ],
-      "relationshipType": "contains"
+      "relationshipType": "contains",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -318,7 +334,8 @@
       "to": [
         "spdx-example:DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
       ],
-      "relationshipType": "copy"
+      "relationshipType": "copy",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "SoftwareDependencyRelationship",
@@ -328,7 +345,8 @@
         "spdx-example:SPDXRef-Saxon"
       ],
       "relationshipType": "dependsOn",
-      "softwareLinkage": "dynamic"
+      "softwareLinkage": "dynamic",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -337,7 +355,8 @@
       "to": [
         "spdx-example:SPDXRef-Package"
       ],
-      "relationshipType": "contains"
+      "relationshipType": "contains",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -346,7 +365,8 @@
       "to": [
         "spdx-example:SPDXRef-fromDoap-0"
       ],
-      "relationshipType": "specificationFor"
+      "relationshipType": "specificationFor",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -355,7 +375,8 @@
       "to": [
         "spdx-example:SPDXRef-File"
       ],
-      "relationshipType": "generates"
+      "relationshipType": "generates",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -365,7 +386,8 @@
         "spdx-example:SPDXRef-File",
         "spdx-example:SPDXRef-Package"
       ],
-      "relationshipType": "describes"
+      "relationshipType": "describes",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -377,62 +399,72 @@
         "spdx-example:SPDXRef-JenaLib",
         "spdx-example:SPDXRef-DoapSource"
       ],
-      "relationshipType": "contains"
+      "relationshipType": "contains",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Annotation",
       "spdxId": "spdx-example:SPDXRef-Annotation-0",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
-      "statement": "Document level annotation"
+      "statement": "Document level annotation",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Person",
       "spdxId": "spdx-example:SPDXRef-Actor-JoeReviewer",
-      "name": "Joe Reviewer"
+      "name": "Joe Reviewer",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Annotation",
       "spdxId": "spdx-example:SPDXRef-Annotation-1",
       "annotationType": "review",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
-      "statement": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+      "statement": "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Person",
       "spdxId": "spdx-example:SPDXRef-Actor-SuzanneReviewer",
-      "name": "Suzanne Reviewer"
+      "name": "Suzanne Reviewer",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Annotation",
       "spdxId": "spdx-example:SPDXRef-Annotation-2",
       "annotationType": "review",
       "subject": "spdx-example:SPDXRef-DOCUMENT",
-      "statement": "Another example reviewer."
+      "statement": "Another example reviewer.",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Person",
       "spdxId": "spdx-example:SPDXRef-Actor-PackageCommenter",
-      "name": "Package Commenter"
+      "name": "Package Commenter",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Annotation",
       "spdxId": "spdx-example:SPDXRef-Annotation-3",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-Package",
-      "statement": "Package level annotation"
+      "statement": "Package level annotation",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Person",
       "spdxId": "spdx-example:SPDXRef-Actor-FileCommenter",
-      "name": "File Commenter"
+      "name": "File Commenter",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Annotation",
       "spdxId": "spdx-example:SPDXRef-Annotation-4",
       "annotationType": "other",
       "subject": "spdx-example:SPDXRef-File",
-      "statement": "File level annotation"
+      "statement": "File level annotation",
+      "creationInfo": "_:creationInfo1"
     }
   ]
 }

--- a/serialization/json_ld/examples/file1.json
+++ b/serialization/json_ld/examples/file1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core", "software"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/org1.json
+++ b/serialization/json_ld/examples/org1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/package1.json
+++ b/serialization/json_ld/examples/package1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core", "software"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/person1.json
+++ b/serialization/json_ld/examples/person1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/person2.json
+++ b/serialization/json_ld/examples/person2.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "createdUsing": ["https://some.namespace#sbomolator_v2"],
     "profile": ["core"],

--- a/serialization/json_ld/examples/relationship1.json
+++ b/serialization/json_ld/examples/relationship1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/sbom1.json
+++ b/serialization/json_ld/examples/sbom1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core", "software"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/spdx_document1.json
+++ b/serialization/json_ld/examples/spdx_document1.json
@@ -5,7 +5,7 @@
   "creationInfo": {
     "type": "CreationInfo",
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core", "software"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/spdx_document2.json
+++ b/serialization/json_ld/examples/spdx_document2.json
@@ -2,16 +2,18 @@
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
   "@graph": [
     {
+      "@id": "_:creationInfo1",
+      "type": "CreationInfo",
+      "specVersion": "3.0.0",
+      "created": "2022-12-01T00:00:00",
+      "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+      "profile": ["core", "software"],
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+    },
+    {
       "type": "SpdxDocument",
       "spdxId": "http://spdx.acme.org/3FA9CB25#spdxdocument159",
-      "creationInfo": {
-        "type": "CreationInfo",
-        "specVersion": "3.0.0",
-        "created": "2022-12-01T00:00:00",
-        "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
-        "profile": ["core", "software"],
-        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
-      },
+      "creationInfo": "_:creationInfo1",
       "name": "Doc 159 - two File elements",
       "element": [
         "https://some.namespace#File1",
@@ -27,7 +29,8 @@
       "name": "model.png",
       "contentType": "image/png",
       "purpose": ["documentation"],
-      "contentIdentifier": "https://github.com/spdx/spdx-3-model/blob/main/model.png"
+      "contentIdentifier": "https://github.com/spdx/spdx-3-model/blob/main/model.png",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
@@ -35,7 +38,8 @@
       "name": "The Software Package Data Exchange® (SPDX®) Specification Version 2.3",
       "contentType": "text/html",
       "purpose": ["documentation"],
-      "contentIdentifier": "https://spdx.github.io/spdx-spec/v2.3/"
+      "contentIdentifier": "https://spdx.github.io/spdx-spec/v2.3/",
+      "creationInfo": "_:creationInfo1"
     }
   ]
 }

--- a/serialization/json_ld/examples/spdx_document2.json
+++ b/serialization/json_ld/examples/spdx_document2.json
@@ -5,7 +5,7 @@
       "@id": "_:creationInfo1",
       "type": "CreationInfo",
       "specVersion": "3.0.0",
-      "created": "2022-12-01T00:00:00",
+      "created": "2022-12-01T00:00:00Z",
       "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
       "profile": ["core", "software"],
       "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/spdx_document3.json
+++ b/serialization/json_ld/examples/spdx_document3.json
@@ -5,7 +5,7 @@
       "@id": "_:creationInfo1",
       "type": "CreationInfo",
       "specVersion": "3.0.0",
-      "created": "2022-12-01T00:00:00",
+      "created": "2022-12-01T00:00:00Z",
       "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
       "profile": ["core", "software"],
       "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/spdx_document3.json
+++ b/serialization/json_ld/examples/spdx_document3.json
@@ -2,16 +2,18 @@
   "@context": "https://spdx.github.io/spdx-3-model/rdf/context.json",
   "@graph": [
     {
+      "@id": "_:creationInfo1",
+      "type": "CreationInfo",
+      "specVersion": "3.0.0",
+      "created": "2022-12-01T00:00:00",
+      "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
+      "profile": ["core", "software"],
+      "dataLicense": "https://spdx.org/licenses/CC0-1.0"
+    },
+    {
       "type": "SpdxDocument",
       "spdxId": "https://some.namespace#spdxdocument159",
-      "creationInfo": {
-        "type": "CreationInfo",
-        "specVersion": "3.0.0",
-        "created": "2022-12-01T00:00:00",
-        "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
-        "profile": ["core", "software"],
-        "dataLicense": "https://spdx.org/licenses/CC0-1.0"
-      },
+      "creationInfo": "_:creationInfo1",
       "name": "Doc 159 - two File elements",
       "element": [
         "https://some.namespace#SPDXRef-Package",
@@ -26,17 +28,20 @@
     {
       "type": "Package",
       "spdxId": "https://some.namespace#SPDXRef-Package",
-      "name": "packageName"
+      "name": "packageName",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
       "spdxId": "https://some.namespace#file1",
-      "name": "file1"
+      "name": "file1",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
       "spdxId": "https://some.namespace#file2",
-      "name": "file2"
+      "name": "file2",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -46,7 +51,8 @@
         "https://some.namespace#file1",
         "https://some.namespace#file2"
       ],
-      "relationshipType": "contains"
+      "relationshipType": "contains",
+      "creationInfo": "_:creationInfo1"
     }
   ]
 }

--- a/serialization/json_ld/examples/spdx_document4.json
+++ b/serialization/json_ld/examples/spdx_document4.json
@@ -9,16 +9,18 @@
   ],
   "@graph": [
     {
+      "@id": "_:creationInfo1",
+      "type": "CreationInfo",
+      "specVersion": "3.0.0",
+      "created": "2022-12-01T00:00:00",
+      "createdBy": ["spdxDev:spdx-dev"],
+      "profile": ["core", "software"],
+      "dataLicense": "spdxLicenses:CC0-1.0"
+    },
+    {
       "type": "SpdxDocument",
       "spdxId": "myNamespace:spdxdocument159",
-      "creationInfo": {
-        "type": "CreationInfo",
-        "specVersion": "3.0.0",
-        "created": "2022-12-01T00:00:00",
-        "createdBy": ["spdxDev:spdx-dev"],
-        "profile": ["core", "software"],
-        "dataLicense": "spdxLicenses:CC0-1.0"
-      },
+      "creationInfo": "_:creationInfo1",
       "name": "Doc 159 - two File elements",
       "element": [
         "myNamespace:SPDXRef-Package",
@@ -33,17 +35,20 @@
     {
       "type": "Package",
       "spdxId": "myNamespace:SPDXRef-Package",
-      "name": "packageName"
+      "name": "packageName",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
       "spdxId": "myNamespace:file1",
-      "name": "file1"
+      "name": "file1",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "File",
       "spdxId": "myNamespace:file2",
-      "name": "file2"
+      "name": "file2",
+      "creationInfo": "_:creationInfo1"
     },
     {
       "type": "Relationship",
@@ -53,7 +58,8 @@
         "myNamespace:file1",
         "myNamespace:file2"
       ],
-      "relationshipType": "contains"
+      "relationshipType": "contains",
+      "creationInfo": "_:creationInfo1"
     }
   ]
 }

--- a/serialization/json_ld/examples/spdx_document4.json
+++ b/serialization/json_ld/examples/spdx_document4.json
@@ -12,7 +12,7 @@
       "@id": "_:creationInfo1",
       "type": "CreationInfo",
       "specVersion": "3.0.0",
-      "created": "2022-12-01T00:00:00",
+      "created": "2022-12-01T00:00:00Z",
       "createdBy": ["spdxDev:spdx-dev"],
       "profile": ["core", "software"],
       "dataLicense": "spdxLicenses:CC0-1.0"

--- a/serialization/json_ld/examples/tool1.json
+++ b/serialization/json_ld/examples/tool1.json
@@ -4,7 +4,7 @@
   "spdxId": "https://some.namespace#sbomolator_v2",
   "creationInfo": {
     "specVersion": "3.0.0",
-    "created": "2022-12-01T00:00:00",
+    "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
     "profile": ["core"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"

--- a/serialization/json_ld/examples/two_sboms.json
+++ b/serialization/json_ld/examples/two_sboms.json
@@ -7,7 +7,7 @@
       "creationInfo": {
         "type": "CreationInfo",
         "specVersion": "3.0.0",
-        "created": "2022-12-01T00:00:00",
+        "created": "2022-12-01T00:00:00Z",
         "createdBy": ["https://my_namespace.com/creator1"],
         "profile": ["core", "software"],
         "dataLicense": "https://spdx.org/licenses/CC0-1.0"
@@ -27,7 +27,7 @@
       "creationInfo": {
         "type": "CreationInfo",
         "specVersion": "3.0.0",
-        "created": "2022-12-01T00:00:00",
+        "created": "2022-12-01T00:00:00Z",
         "createdBy": ["https://my_namespace.com/creator1"],
         "profile": ["core", "software"],
         "dataLicense": "https://spdx.org/licenses/CC0-1.0"


### PR DESCRIPTION
CreationInfo has been made mandatory again in #401, so the examples have to be updated.

This uses the de-duplication method of extracting the CreationInfo as a blank node.