### PR TITLE
Change subclassOf: none to subclassOf: owl:Thing

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -18,7 +18,7 @@ and inter-relatable content objects.
 ## Metadata
 
 - name: Element
-- SubclassOf: none
+- SubclassOf: owl:Thing
 - Instantiability: Abstract
 
 ## Properties

--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -17,7 +17,7 @@ such as its provenance, where to retrieve it, and how to verify its integrity.
 ## Metadata
 
 - name: ExternalMap
-- SubclassOf: none
+- SubclassOf: owl:Thing
 - Instantiability: Concrete
 
 

--- a/model/Core/Classes/ExternalReference.md
+++ b/model/Core/Classes/ExternalReference.md
@@ -14,7 +14,7 @@ that provides additional characteristics of an Element.
 ## Metadata
 
 - name: ExternalReference
-- SubclassOf: none
+- SubclassOf: owl:Thing
 - Instantiability: Concrete
 
 ## Properties

--- a/model/Core/Classes/PositiveIntegerRange.md
+++ b/model/Core/Classes/PositiveIntegerRange.md
@@ -14,7 +14,7 @@ PositiveIntegerRange is a tuple of two positive integers that define a range.
 ## Metadata
 
 - name: PositiveIntegerRange
-- SubclassOf: none
+- SubclassOf: owl:Thing
 - Instantiability: Concrete
 
 ## Properties


### PR DESCRIPTION
The current model generates an OWL document with an unknown superclass/subclass reference to "none" which is not valid or at least not expected.  owl:Thing is the expected subclassOf reference.  From the OWL spec: 'Every individual in the OWL world is a member of the class owl:Thing.'