### PR TITLE
set `maxCount: 1` for specVersion, created and dataLicense

### DIFF
--- a/model/Core/Classes/CreationInfo.md
+++ b/model/Core/Classes/CreationInfo.md
@@ -21,12 +21,14 @@ The dateTime created is often the date of last change (e.g., a git commit date),
 
 - specVersion
   - type: SemVer
+  - maxCount: 1
 - comment
   - type: xsd:string
   - minCount: 0
   - maxCount: 1
 - created
   - type: DateTime
+  - maxCount: 1
 - createdBy
   - type: Agent
   - minCount: 1
@@ -38,4 +40,5 @@ The dateTime created is often the date of last change (e.g., a git commit date),
   - minCount: 1
 - dataLicense
   - type: xsd:string
+  - maxCount: 1
 


### PR DESCRIPTION
According to [this comment](https://github.com/spdx/spdx-3-model/issues/393#issuecomment-1602463064), the default for `maxCount` is `*`. This means that `specVersion`, `created` and `dataLicense` in the `CreationInfo` class do not have the right multiplicity, as there can't be more than one of these.