### PR TITLE
move DateTime, SemVer and MediaType to Datatypes directory

### DIFF
--- a/model/Core/Datatypes/DateTime.md
+++ b/model/Core/Datatypes/DateTime.md
@@ -15,9 +15,6 @@ The specific format is one of the most commonly used ISO-8601 formats.
 ## Metadata
 
 - name: DateTime
-- SubclassOf: xsd:string
-
-## Properties
 
 ## Format
 

--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -8,14 +8,15 @@ Standardized way of indicating the type of content of an Element. A String const
 
 ## Description
 
-The MediaType is a String constrained to the RFC 2046 specification. It provides a standardized
+A MediaType is a string constrained to the RFC 2046 specification. It provides a standardized
 way of indicating the type of content of an Element.
 A list of all possible media types is available at https://www.iana.org/assignments/media-types/media-types.xhtml.
 
 ## Metadata
 
 - name: MediaType
-- SubclassOf: xsd:string
 
-## Properties
+## Format
+
+- pattern: ^[^\/]+\/[^\/]+$
 

--- a/model/Core/Datatypes/SemVer.md
+++ b/model/Core/Datatypes/SemVer.md
@@ -8,15 +8,12 @@ A string constrained to the SemVer 2.0.0 specification.
 
 ## Description
 
-The semantic version is a string
+A semantic version is a string
 that is following the specification of [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## Metadata
 
 - name: SemVer
-- SubclassOf: xsd:string
-
-## Properties
 
 ## Format
 


### PR DESCRIPTION
As discussed during the serialization meeting on July 14, this defines the three "string properties with formatting" as separate datatypes by moving them into a new folder "Datatypes" under Core.