### PR TITLE
Remove redefinition of `name` property in `SpdxDocument`

### DIFF
--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -17,13 +17,6 @@ Commonly used when representing a unit of transfer of SPDX Elements.
 - SubclassOf: Bundle
 - Instantiability: Concrete
 
-## Properties
-
-- name
-  - type: xsd:string
-  - minCount: 1
-  - maxCount: 1
-
 ## External properties restrictions
 
 - /Core/Element/name


### PR DESCRIPTION
This only served to set `minCount: 1`, which is already handled by the "External properties restrictions" section.