### PR TITLE
creation info required fields

### DIFF
--- a/model/Core/Classes/CreationInfo.md
+++ b/model/Core/Classes/CreationInfo.md
@@ -29,6 +29,7 @@ The dateTime created is often the date of last change (e.g., a git commit date),
   - maxCount: 1
 - created
   - type: DateTime
+  - minCount: 1
   - maxCount: 1
 - createdBy
   - type: Agent
@@ -41,5 +42,6 @@ The dateTime created is often the date of last change (e.g., a git commit date),
   - minCount: 1
 - dataLicense
   - type: xsd:string
+  - minCount: 1
   - maxCount: 1
 


### PR DESCRIPTION
`created` and `dataLicense` are required, as described in Issue #393.  Partially fixed by PR #420.  This finishes the fix.