### PR TITLE
Rename ExternalReference to ExternalRef

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -45,8 +45,8 @@ and inter-relatable content objects.
   - maxCount: 1
 - verifiedUsing
   - type: IntegrityMethod
-- externalReference
-  - type: ExternalReference
+- externalRef
+  - type: ExternalRef
   - minCount: 0
 - externalIdentifier
   - type: ExternalIdentifier

--- a/model/Core/Classes/ExternalRef.md
+++ b/model/Core/Classes/ExternalRef.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# ExternalReference
+# ExternalRef
 
 ## Summary
 
@@ -13,14 +13,14 @@ that provides additional characteristics of an Element.
 
 ## Metadata
 
-- name: ExternalReference
+- name: ExternalRef
 - SubclassOf: none
 - Instantiability: Concrete
 
 ## Properties
 
-- externalReferenceType
-  - type: ExternalReferenceType
+- externalRefType
+  - type: ExternalRefType
   - maxCount: 1
 - locator
   - type: xsd:anyURI

--- a/model/Core/Properties/externalRef.md
+++ b/model/Core/Properties/externalRef.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalReference
+# externalRef
 
 ## Summary
 
@@ -14,7 +14,7 @@ that provides additional characteristics of an Element.
 
 ## Metadata
 
-- name: externalReference
+- name: externalRef
 - Nature: ObjectProperty
-- Range: ExternalReference
+- Range: ExternalRef
 

--- a/model/Core/Properties/externalRefType.md
+++ b/model/Core/Properties/externalRefType.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalReferenceType
+# externalRefType
 
 ## Summary
 
@@ -8,11 +8,11 @@ Specifies the type of the external reference.
 
 ## Description
 
-An externalReferenceType specifies the type of the external reference.
+An externalRefType specifies the type of the external reference.
 
 ## Metadata
 
-- name: externalReferenceType
+- name: externalRefType
 - Nature: ObjectProperty
-- Range: ExternalReferenceType
+- Range: ExternalRefType
 

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# ExternalReferenceType
+# ExternalRefType
 
 ## Summary
 
@@ -12,7 +12,7 @@ ExteralReferenceType specifies the type of an external reference.
 
 ## Metadata
 
-- name: ExternalReferenceType
+- name: ExternalRefType
 
 ## Entries
 

--- a/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
@@ -29,20 +29,20 @@ A CvssV2VulnAssessmentRelationship relationship describes the determined score a
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "assessedElement": "urn:npm-elliptic-6.5.2",
-  "externalReferences": [
+  "externalRefs": [
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityAdvisory",
+      "@type": "ExternalRef",
+      "externalRefType": "securityAdvisory",
       "locator": "https://nvd.nist.gov/vuln/detail/CVE-2020-28498"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityAdvisory",
+      "@type": "ExternalRef",
+      "externalRefType": "securityAdvisory",
       "locator": "https://snyk.io/vuln/SNYK-JS-ELLIPTIC-1064899"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityFix",
+      "@type": "ExternalRef",
+      "externalRefType": "securityFix",
       "locator": "https://github.com/indutny/elliptic/commit/441b742"
     }
   ],

--- a/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
@@ -32,20 +32,20 @@ Vulnerability Scoring System (CVSS) as defined on
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "assessedElement": "urn:npm-elliptic-6.5.2",
-  "externalReferences": [
+  "externalRefs": [
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityAdvisory",
+      "@type": "ExternalRef",
+      "externalRefType": "securityAdvisory",
       "locator": "https://nvd.nist.gov/vuln/detail/CVE-2020-28498"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityAdvisory",
+      "@type": "ExternalRef",
+      "externalRefType": "securityAdvisory",
       "locator": "https://snyk.io/vuln/SNYK-JS-ELLIPTIC-1064899"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityFix",
+      "@type": "ExternalRef",
+      "externalRefType": "securityFix",
       "locator": "https://github.com/indutny/elliptic/commit/441b742"
     }
   ],

--- a/model/Security/Classes/Vulnerability.md
+++ b/model/Security/Classes/Vulnerability.md
@@ -44,25 +44,25 @@ Specifies a vulnerability and its associated information.
       "identifierLocator": "https://security.snyk.io/vuln/SNYK-JS-ELLIPTIC-1064899"
     }
   ],
-  "externalReferences": [
+  "externalRefs": [
     {
-        "@type": "ExternalReference",
-        "externalReferenceType": "securityAdvisory",
+        "@type": "ExternalRef",
+        "externalRefType": "securityAdvisory",
         "locator": "https://nvd.nist.gov/vuln/detail/CVE-2020-28498"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityAdvisory",
+      "@type": "ExternalRef",
+      "externalRefType": "securityAdvisory",
       "locator": "https://ubuntu.com/security/CVE-2020-28498"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityOther",
+      "@type": "ExternalRef",
+      "externalRefType": "securityOther",
       "locator": "https://github.com/indutny/elliptic/pull/244/commits"
     },
     {
-      "@type": "ExternalReference",
-      "externalReferenceType": "securityOther",
+      "@type": "ExternalRef",
+      "externalRefType": "securityOther",
       "locator": "https://github.com/christianlundkvist/blog/blob/master/2020_05_26_secp256k1_twist_attacks/secp256k1_twist_attacks.md"
     }
   ]


### PR DESCRIPTION
Resolves #234

Fixes an unnecessary incompatibility between SPDX 2.3 and SPDX 3.0 spec versions.