### PR TITLE
Indicate maxCount for Artifact's `suppliedBy`

### DIFF
--- a/model/Core/Classes/Artifact.md
+++ b/model/Core/Classes/Artifact.md
@@ -26,6 +26,7 @@ such as an electronic file, a software package, a device or an element of data.
 - suppliedBy 
   - type: Agent
   - minCount: 0
+  - maxCount: 1
 - builtTime
   - type: DateTime
   - minCount: 0


### PR DESCRIPTION
An Artifact's `suppliedBy` property has a cardinality of [0..1]. This was decided on at the March 21, 2023 tech call [1]. This PR indicates this cardinality by adding a maxCount to the property which was previously missing.

[1]https://github.com/spdx/meetings/blob/main/tech/2023-03-21.md#supplier-property

Resolves #437