### PR TITLE
Add licenseListVersion to LicenseExpression

### DIFF
--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -25,6 +25,7 @@ SPDX License Expressions provide a way for one to construct expressions that mor
   - maxCount: 1
 - licenseListVersion
   - type: xsd:string
+  - maxCount: 1
 - customIdToUri
   - type: /Core/DictionaryEntry
   - minCount: 0

--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -23,6 +23,8 @@ SPDX License Expressions provide a way for one to construct expressions that mor
   - type: xsd:string
   - minCount: 1
   - maxCount: 1
+- licenseListVersion
+  - type: xsd:string
 - customIdToUri
   - type: /Core/DictionaryEntry
   - minCount: 0

--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -24,7 +24,7 @@ SPDX License Expressions provide a way for one to construct expressions that mor
   - minCount: 1
   - maxCount: 1
 - licenseListVersion
-  - type: xsd:string
+  - type: /Core/SemVer
   - maxCount: 1
 - customIdToUri
   - type: /Core/DictionaryEntry

--- a/model/SimpleLicensing/Properties/licenseListVersion.md
+++ b/model/SimpleLicensing/Properties/licenseListVersion.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# licenseListVersion
+
+## Summary
+
+The version of the SPDX License List used when the license expression was created.
+
+## Description
+
+Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide consumers with the version of the SPDX License List used. This anticipates that in the future, license expression might have used a version of the SPDX License List that is older than the then current one.
+
+## Metadata
+
+- name: licenseListVersion
+- Nature: DataProperty
+- Range: xsd:string
+

--- a/model/SimpleLicensing/Properties/licenseListVersion.md
+++ b/model/SimpleLicensing/Properties/licenseListVersion.md
@@ -16,5 +16,5 @@ The specified version of the SPDX License List must include all listed licenses 
 
 - name: licenseListVersion
 - Nature: DataProperty
-- Range: xsd:string
+- Range: /Core/SemVer
 

--- a/model/SimpleLicensing/Properties/licenseListVersion.md
+++ b/model/SimpleLicensing/Properties/licenseListVersion.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The version of the SPDX License List used when the license expression was created.
+The version of the SPDX License List used in the license expression.
 
 ## Description
 
-Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide consumers with the version of the SPDX License List used. This anticipates that in the future, license expression might have used a version of the SPDX License List that is older than the then current one.
+Recognizing that licenses are added to the SPDX License List with each subsequent version, the intent is to provide consumers with the version of the SPDX License List used. 
+This anticipates that in the future, license expression might have used a version of the SPDX License List that is older than the then current one.
+The specified version of the SPDX License List must include all listed licenses and exceptions referenced in the expression.
 
 ## Metadata
 


### PR DESCRIPTION
Fixes #131

This adds the `licenseListVersion` which in 2.3 was at the document level to the `licenseExpression`.

This is alternative solution to PR #480 