### PR TITLE
Change ExternalRef locator to be of type xsd:string

### DIFF
--- a/model/Core/Classes/ExternalRef.md
+++ b/model/Core/Classes/ExternalRef.md
@@ -23,7 +23,7 @@ that provides additional characteristics of an Element.
   - type: ExternalRefType
   - maxCount: 1
 - locator
-  - type: xsd:anyURI
+  - type: xsd:string
 - contentType
   - type: MediaType
   - maxCount: 1

--- a/model/Core/Properties/locator.md
+++ b/model/Core/Properties/locator.md
@@ -14,5 +14,5 @@ A locator provides the location of an external reference.
 
 - name: locator
 - Nature: DataProperty
-- Range: xsd:anyURI
+- Range: xsd:string
 


### PR DESCRIPTION
Partial fix for issue #81

Unlike an `ExternalIdentifier,` the `ExternalRef` locator string does not have a uniqueness requirement and the specific format depends on the  `externalRefType`.

Note that `ExternalIdentifier` already uses a separate property `identifierLocator` which remains of type `xsd:anyURI`

For the type "other", we should allow more arbitrary formats and not constrain it to a URI format.