### PR TITLE
Add an external relationship restriction to Licensing profile

### DIFF
--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -98,3 +98,7 @@ the concludedLicense relationship comment field.
 
 - id: https://rdf.spdx.org/v3/Licensing
 - name: Licensing
+
+## External relationship restrictions
+- fromType: /Core/Artifact
+


### PR DESCRIPTION
This PR adds a concluded license restriction for the Licensing profile.  Note that Issue #463 needs to be fixed before this is merged.