### PR TITLE
Rename externalId to externalSpdxId

### DIFF
--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -23,7 +23,7 @@ such as its provenance, where to retrieve it, and how to verify its integrity.
 
 ## Properties
 
-- externalId
+- externalSpdxId
   - type: xsd:anyURI
   - minCount: 1
   - maxCount: 1

--- a/model/Core/Properties/externalSpdxId.md
+++ b/model/Core/Properties/externalSpdxId.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# externalId
+# externalSpdxId
 
 ## Summary
 
@@ -8,11 +8,10 @@ Identifies an external Element used within a Document but defined external to th
 
 ## Description
 
-ExternalId identifies an external Element used within a Document but defined external to that Document.
+ExternalSpdxId identifies an external Element used within a Document but defined external to that Document.
 
 ## Metadata
 
-- name: externalId
+- name: externalSpdxId
 - Nature: DataProperty
 - Range: xsd:anyURI
-


### PR DESCRIPTION
Implements the decision in the tech call on 17 October 2023 to reduce confusion between the `externalId` and `externalIdentifier` properties.

This pull request replaces https://github.com/spdx/spdx-3-model/pull/492