### PR TITLE
Fixing typos/syntax errors

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# AI Profile
+# AI
 
 ## Summary
 
@@ -14,3 +14,4 @@ The AI profile namespace defines concepts related to AI application and model ar
 
 - id: https://rdf.spdx.org/v3/AI
 - name: AI
+

--- a/model/Core/Classes/Agent.md
+++ b/model/Core/Classes/Agent.md
@@ -16,5 +16,3 @@ The Agent class represents anything that has the potential to act on a system. T
 - SubclassOf: Element
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Classes/Artifact.md
+++ b/model/Core/Classes/Artifact.md
@@ -17,13 +17,12 @@ such as an electronic file, a software package, a device or an element of data.
 - SubclassOf: Element
 - Instantiability: Abstract
 
-
 ## Properties
 
 - originatedBy
   - type: Agent
   - minCount: 0
-- suppliedBy 
+- suppliedBy
   - type: Agent
   - minCount: 0
   - maxCount: 1

--- a/model/Core/Classes/Bom.md
+++ b/model/Core/Classes/Bom.md
@@ -21,5 +21,3 @@ its composition, licensing information, known quality or security issues, etc.
 - SubclassOf: Bundle
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Classes/ExternalIdentifier.md
+++ b/model/Core/Classes/ExternalIdentifier.md
@@ -16,7 +16,6 @@ that uniquely identifies an Element.
 - name: ExternalIdentifier
 - Instantiability: Concrete
 
-
 ## Properties
 
 - externalIdentifierType

--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -13,13 +13,11 @@ but defined external to that Document.
 The external map provides details about the externally-defined Element
 such as its provenance, where to retrieve it, and how to verify its integrity.
 
-
 ## Metadata
 
 - name: ExternalMap
 - SubclassOf: none
 - Instantiability: Concrete
-
 
 ## Properties
 

--- a/model/Core/Classes/LifecycleScopedRelationship.md
+++ b/model/Core/Classes/LifecycleScopedRelationship.md
@@ -2,6 +2,10 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # LifecycleScopedRelationship
 
+## Summary
+
+TODO
+
 ## Description
 
 TODO

--- a/model/Core/Classes/Organization.md
+++ b/model/Core/Classes/Organization.md
@@ -16,5 +16,3 @@ An Organization is a group of people who work together in an organized way for a
 - SubclassOf: Agent
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Classes/Person.md
+++ b/model/Core/Classes/Person.md
@@ -16,5 +16,3 @@ A Person is an individual human being.
 - SubclassOf: Agent
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Classes/Relationship.md
+++ b/model/Core/Classes/Relationship.md
@@ -11,13 +11,11 @@ Describes a relationship between one or more elements.
 A Relationship is a grouping of characteristics unique to an assertion
 that one Element is related to one or more other Elements in some way.
 
-
 ## Metadata
 
 - name: Relationship
 - SubclassOf: Element
 - Instantiability: Concrete
-
 
 ## Properties
 
@@ -44,3 +42,4 @@ that one Element is related to one or more other Elements in some way.
   - type: DateTime
   - minCount: 0
   - maxCount: 1
+

--- a/model/Core/Classes/SoftwareAgent.md
+++ b/model/Core/Classes/SoftwareAgent.md
@@ -16,5 +16,3 @@ A SoftwareAgent is a software program that is given the authority (similar to a 
 - SubclassOf: Agent
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Classes/Tool.md
+++ b/model/Core/Classes/Tool.md
@@ -16,5 +16,3 @@ A Tool is an element of hardware and/or software utilized to carry out a particu
 - SubclassOf: Element
 - Instantiability: Concrete
 
-## Properties
-

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -32,7 +32,7 @@ ExternalRefType specifies the type of an external reference.
 - funding: A reference to funding information related to a package.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
-- maven-central: A reference to a maven repository artifact.
+- mavenCentral: A reference to a maven repository artifact.
 - metrics: A reference to metrics related to package such as OpenSSF scorecards.
 - npm: A reference to an npm package.
 - nuget: A reference to a nuget package.

--- a/model/Dataset/Properties/sensor.md
+++ b/model/Dataset/Properties/sensor.md
@@ -13,6 +13,7 @@ and its calibration value as a key-value pair.
 
 ## Metadata
 
-- name: sensors
+- name: sensor
 - Nature: ObjectProperty
 - Range: /Core/DictionaryEntry
+

--- a/model/Dataset/Vocabularies/ConfidentialityLevelType.md
+++ b/model/Dataset/Vocabularies/ConfidentialityLevelType.md
@@ -16,8 +16,8 @@ Describes the different confidentiality levels as given by the [Traffic Light Pr
 
 ## Entries
 
-- Red: Data points in the dataset are highly confidential and can only be shared with named recipients.
-- Amber: Data points in the dataset can be shared only with specific organizations and their clients on a need to know basis.
-- Green: Dataset can be shared within a community of peers and partners.
-- Clear: Dataset may be distributed freely, without restriction.
+- red: Data points in the dataset are highly confidential and can only be shared with named recipients.
+- amber: Data points in the dataset can be shared only with specific organizations and their clients on a need to know basis.
+- green: Dataset can be shared within a community of peers and partners.
+- clear: Dataset may be distributed freely, without restriction.
 

--- a/model/Dataset/Vocabularies/DatasetAvailabilityType.md
+++ b/model/Dataset/Vocabularies/DatasetAvailabilityType.md
@@ -16,9 +16,9 @@ Describes the possible types of availability of a dataset, indicating whether th
 
 ## Entries
 
-- Direct-Download: the dataset is publicly available and can be downloaded directly.
-- Scraping-Script: the dataset provider is not making available the underlying data and the dataset must be reassembled, typically using the provided script for scraping the data.
-- Query: the dataset is publicly available, but not all at once, and can only be accessed through queries which return parts of the dataset.
-- Clickthrough: the dataset is not publicly available and can only be accessed after affirmatively accepting terms on a clickthrough webpage.
-- Registration: the dataset is not publicly available and an email registration is required before accessing the dataset, although without an affirmative acceptance of terms.
+- directDownload: the dataset is publicly available and can be downloaded directly.
+- scrapingScript: the dataset provider is not making available the underlying data and the dataset must be reassembled, typically using the provided script for scraping the data.
+- query: the dataset is publicly available, but not all at once, and can only be accessed through queries which return parts of the dataset.
+- clickthrough: the dataset is not publicly available and can only be accessed after affirmatively accepting terms on a clickthrough webpage.
+- registration: the dataset is not publicly available and an email registration is required before accessing the dataset, although without an affirmative acceptance of terms.
 

--- a/model/ExpandedLicensing/Classes/CustomLicense.md
+++ b/model/ExpandedLicensing/Classes/CustomLicense.md
@@ -18,4 +18,3 @@ creator.
 - SubclassOf: License
 - Instantiability: Concrete
 
-## Properties

--- a/model/ExpandedLicensing/Classes/CustomLicenseAddition.md
+++ b/model/ExpandedLicensing/Classes/CustomLicenseAddition.md
@@ -21,4 +21,3 @@ a License, but which is not itself a standalone License.
 - SubclassOf: LicenseAddition
 - Instantiability: Concrete
 
-## Properties

--- a/model/ExpandedLicensing/Classes/ExtendableLicense.md
+++ b/model/ExpandedLicensing/Classes/ExtendableLicense.md
@@ -16,4 +16,3 @@ The WithAdditionOperator can have a License or an OrLaterOperator as the license
 - SubclassOf: /SimpleLicensing/AnyLicenseInfo
 - Instantiability: Abstract
 
-## Properties

--- a/model/ExpandedLicensing/Properties/licenseXml.md
+++ b/model/ExpandedLicensing/Properties/licenseXml.md
@@ -14,6 +14,7 @@ There is also an XML schema available at https://github.com/spdx/license-list-XM
 
 ## Metadata
 
-- name: standardLicenseTemplate
+- name: licenseXml
 - Nature: DataProperty
 - Range: xsd:string
+

--- a/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
@@ -45,4 +45,3 @@ element.
 - SubclassOf: VexVulnAssessmentRelationship
 - Instantiability: Concrete
 
-## Properties

--- a/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
@@ -45,4 +45,3 @@ element.
 - SubclassOf:  VexVulnAssessmentRelationship
 - Instantiability: Concrete
 
-## Properties

--- a/model/Security/Vocabularies/CvssSeverityType.md
+++ b/model/Security/Vocabularies/CvssSeverityType.md
@@ -16,8 +16,9 @@ CvssSeverityType specifies the CVSS severity type, defined in the CVSS specifica
 
 ## Entries
 
-- CRITICAL: When a CVSS score is between 9.0 - 10.0
-- HIGH: When a CVSS score is between 7.0 - 8.9
-- MEDIUM: When a CVSS score is between 4 - 6.9
-- LOW: When a CVSS score is between 0 - 3.9
-- NONE: When a CVSS score is 0
+- critical: When a CVSS score is between 9.0 - 10.0
+- high: When a CVSS score is between 7.0 - 8.9
+- medium: When a CVSS score is between 4 - 6.9
+- low: When a CVSS score is between 0 - 3.9
+- none: When a CVSS score is 0
+

--- a/model/SimpleLicensing/Classes/AnyLicenseInfo.md
+++ b/model/SimpleLicensing/Classes/AnyLicenseInfo.md
@@ -23,4 +23,3 @@ additional text applied; or a set of licenses combined by applying "AND" and
 - SubclassOf: /Core/Element
 - Instantiability: Abstract
 
-## Properties

--- a/model/Software/Classes/SoftwareDependencyRelationship.md
+++ b/model/Software/Classes/SoftwareDependencyRelationship.md
@@ -2,6 +2,10 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 # SoftwareDependencyRelationship
 
+## Summary
+
+TODO
+
 ## Description
 
 TODO


### PR DESCRIPTION
This fixes various issues that the (new) spec-parser points out.

Among them:
- mismatches between "name" property and file name and title
- vocabularies entries not in lowerCamelCase
- missing sections ("Summary" in most/all cases)
- empty sections ("Properties" in most/all cases)
- ... and probably some others I don't remember

