### PR TITLE
Update ExternalMap and relationships to reference Artifacts

### DIFF
--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -31,5 +31,5 @@ such as its provenance, where to retrieve it, and how to verify its integrity.
   - type: xsd:anyURI
   - maxCount: 1
 - definingDocument
-  - type: xsd:anyURI
+  - type: Artifact
   - maxCount: 1

--- a/model/Core/Properties/definingDocument.md
+++ b/model/Core/Properties/definingDocument.md
@@ -4,15 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Artifact containing SPDX data which defines one or more SPDX elements.
+Artifact representing a serialization instance of SPDX data containing the definition of a particular Element.
 
 ## Description
 
-A definingDocument property is used to link an Element identifier to an Artifact which contains the definition for the Element.
+A definingDocument property is used to link the Element identifier for an Element defined external to a given SpdxDocument to an Artifact Element representing the SPDX serialization instance which contains the definition for the Element.
 
 ## Metadata
 
 - name: definingDocument
 - Nature: ObjectProperty
 - Range: Artifact
-

--- a/model/Core/Properties/definingDocument.md
+++ b/model/Core/Properties/definingDocument.md
@@ -4,15 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-URI for an SPDX document which defines an SPDX element.
+Artifact containing SPDX data which defines one or more SPDX elements.
 
 ## Description
 
-A definingDocument property is used to link an Element identifier to an SpdxDocument which contains the definition for the Element.
+A definingDocument property is used to link an Element identifier to an Artifact which contains the definition for the Element.
 
 ## Metadata
 
 - name: definingDocument
-- Nature: DataProperty
-- Range: xsd:anyURI
+- Nature: ObjectProperty
+- Range: Artifact
 

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -72,7 +72,7 @@ between a Package and a File, between two Packages, or between one SPDXDocument 
 - republishedBy: (Security) Designates the agent that tracked, aggregated, and/or enriched vulnerability details to improve context (i.e. NVD)
 - requirementFor: Every `to` Element is required for the `from` Element
 - runtimeDependency: Every `to` Element is a runtime dependency for the `from` Element
-- spdxDocumentForArtfact: Every `to` Element is an SpdxDocument representing the logical serialization metadata for the `from`  Artifact containing the serliazed data
+- serializedInArtifact: The from SPDXDocument can be found in a serialized form in each to Artifact
 - specificationFor: Every `to` Element is a specification for the `from` Element
 - staticLink: Every `to` Element is statically linked to the `from` Element
 - test: Every `to` Element is a test artifact for the `from` Element

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -72,7 +72,7 @@ between a Package and a File, between two Packages, or between one SPDXDocument 
 - republishedBy: (Security) Designates the agent that tracked, aggregated, and/or enriched vulnerability details to improve context (i.e. NVD)
 - requirementFor: Every `to` Element is required for the `from` Element
 - runtimeDependency: Every `to` Element is a runtime dependency for the `from` Element
-- serializedArtifactFor: Every `to` Element is an artifact serialized from the `from` SpdxDocument Element
+- spdxDocumentForArtfact: Every `to` Element is an SpdxDocument representing the logical serialization metadata for the `from`  Artifact containing the serliazed data
 - specificationFor: Every `to` Element is a specification for the `from` Element
 - staticLink: Every `to` Element is statically linked to the `from` Element
 - test: Every `to` Element is a test artifact for the `from` Element

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -72,6 +72,7 @@ between a Package and a File, between two Packages, or between one SPDXDocument 
 - republishedBy: (Security) Designates the agent that tracked, aggregated, and/or enriched vulnerability details to improve context (i.e. NVD)
 - requirementFor: Every `to` Element is required for the `from` Element
 - runtimeDependency: Every `to` Element is a runtime dependency for the `from` Element
+- serializedArtifactFor: Every `to` Element is an artifact serialized from the `from` SpdxDocument Element
 - specificationFor: Every `to` Element is a specification for the `from` Element
 - staticLink: Every `to` Element is statically linked to the `from` Element
 - test: Every `to` Element is a test artifact for the `from` Element


### PR DESCRIPTION
Per the decision in the serialization team, change the type of the definingDocument to Artifact and create a relationshipType to link the definingDocument to the SpdxDocument