### PR TITLE
Clarify RelationshipTypes

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -12,74 +12,80 @@ Provides information about the relationship between two Elements.
 For example, you can represent a relationship between two different Files,
 between a Package and a File, between two Packages, or between one SPDXDocument and another SPDXDocument.
 
+Relationship names be descriptive enough to easily deduce the correct direction
+from their name. The best way to do this is to make sure that the relationship
+name completes the sentence:
+
+`from` (is) (a) `RELATIONSHIP` `to`
+
 ## Metadata
 
 - name: RelationshipType
 
 ## Entries
 
-- affects: (Security/VEX) Designates one or more elements as affected by a vulnerability
-- amends: Every `to` Element amends the `from` Element
-- ancestor: Every `to` Element is an ancestor of the `from` Element
-- availableFrom:  This relationship is used to identify additional suppliers where an artifact is available from.
-- buildDependency: Every `to` Element is a build dependency of the `from` Element
-- buildTool: Build tool used to build an Element. This may be used to describe the build tool of a Build instance
+- affects: (Security/VEX) The `from` vulnerability affect each `to` Element
+- amendedBy: The `from` Element is amended by each `to` Element
+- hasAncestor: The `from` Element has ancestor described by each `to` Element
+- availableFrom: The `from` Element is available from the additional supplier described by each `to` Element
+- hasBuildDependencyOn: The `from` Element has a build dependency on each `to` Element
+- usesBuildTool: The `from` Element uses each `to` Element as a build tool
 - coordinatedBy: (Security) Used to identify the vendor, researcher, or consumer agent performing coordination for a vulnerability
-- concludedLicense: The `to` specifices the license the SPDX data creator has concluded as governing the `from` software Artifact.
-- contains: Every `to` Element is contained by the `from` Element
-- configOf: (Build) Configuration information applied to an Element instance during a LifeycleScopeType period.  Example: Build configuration of the build instance
-- copy: Every `to` Element is a copy of the `from` Element
-- dataFile: Every `to` Element is a data file related to the the `from` Element
-- declaredLicense: The `to` license information identifies the license information actually found in the `from` software Artifact, for example as detected by use of automated tooling.
-- dependencyManifest: Every `to` Element is manifest file containing dependency information related to the `from` Element
-- dependsOn: Every `to` Element is a dependecy of the `from` Element
-- descendant: This relationship may be used to describe child builds of a Build instance.
-- describes: Every `to` Element is described by the `from` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property should be used.
-- devDependency: Every `to` Element is a development dependency for the `from` Element
-- devTool: Every `to` Element is a development tool for the `from` Element
-- distributionArtifact: Every `to` Element is an artifact intended for distribution of the `from` Element (e.g. an RPM or archive file)
-- documentation: Every `to` Element is documentation for the `from` Element
-- doesNotAffect: (Security/VEX) Specifies a vulnerability has no impact on one or more elements
-- dynamicLink: Every `to` Element is dynamically linked to the `from` Element
-- example: Every `to` Element is an example for the `from` Element
-- evidenceFor: (Dataset) Every `to` Element is can be considered as evidence for the `from` Element
-- expandedFromArchive: Every `to` Element is an artifact expanded from the `from` archive file
+- hasConcludedLicense: The `from` Software Artifact is concluded by the SPDX data creator to be governed by each `to` license
+- contains: The `from` Element contains each `to` Element
+- configOf: The `from` Element is a configuration applied to each `to` Element during a LifecycleScopeType period
+- copiedTo: The `from` Element has been copied to each `to` Element
+- hasDataFile: The `from` Element treats each `to` Element as a data file
+- hasDeclaredLicense: The `from` Software Artifact was discovered to actually contain each `to` license, for example as detected by use of automated tooling.
+- hasDependencyManifest: The `from` Element has manifest files that contain dependency information in each `to` Element
+- dependsOn: The `from` Element depends on each `to` Element
+- descendantOf: The `from` Element is a descendant of each `to` Element
+- describes: The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property should be used.
+- hasDevDependency: The `from` Element has a development dependency on each `to` Element
+- hasDevTool: The `from` Element uses each `to` Element as a development tool
+- hasDistributionArtifact: The `from` Element is distributed as an artifact in each Element `to`, (e.g. an RPM or archive file)
+- hasDocumentation: The `from` Element is documented by each `to` Element
+- doesNotAffect: (Security/VEX) The `from` Vulnerability has no impact on each `to` Element
+- hasDynamicLink: The `from` Element dynamically links in each `to` Element
+- hasExample: Every `to` Element is an example for the `from` Element (`from` hasExample `to`)
+- hasEvidence: (Dataset) Every `to` Element is considered as evidence for the `from` Element (`from` hasEvidence `to`)
+- expandsTo: The `from` archive expands out as an artifact described by each `to` Element
 - exploitCreatedBy: (Security) Designates an agent has created an exploit against a vulnerability
-- fileAdded: Every `to` Element is is a file added to the `from` Element
-- fileDeleted: Every `to` Element is a file deleted from the `from` Element
-- fileModified: Every `to` Element is a modification of the `from` Element
+- hasAddedFile: Every `to` Element is is a file added to the `from` Element (`from` hasAddedFile `to`)
+- hasDeletedFile: Every `to` Element is a file deleted from the `from` Element (`from` hasDeletedFile `to`)
+- modifiedBy: The `from` Element is modified by each `to` Element
 - fixedBy: (Security) Designates a vulnerability has been fixed by an agent
 - fixedIn: (Security/VEX) A vulnerability has been fixed in one or more elements
 - foundBy: (Security) Designates an agent was the original discoverer of a security vulnerability
-- generates: Every `to` Element is generated from the `from` Element
+- generates: The `from` Element generates each `to` Element
 - hasAssessmentFor: (Security) Relates a Vulnerability and an Element with a security assessment.
 - hasAssociatedVulnerability: (Security) Used to associate a security vulnerability with a software artifact
-- hostOf: (Build) The`from` Element in which every instance of the `to` Element during a LifecycleScopeType period runs on.   Example: host that the build runs on for an element.
-- inputOf: (Build) Input to the Element instance during a LifecycleScopeType period.   Example: input to the build instance for an element. 
-- invokedBy: (Build) Every`to` Agent that invoked a `from` Element instance during a LifecycleScopeType period.  Example: Agent that invoked the build for an element
-- metafile: Every `to` Element is is a file containing metadata about the `from` Element
-- onBehalfOf: (Build) Every `to` Agent acting on behalf of another `from` Agent during a LifecycleScopeType period
-- optionalComponent: Every `to` Element is an optional component of the `from` Element
-- optionalDependency: Every `to` Element is an optional dependency of the `from` Element
-- other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationhip types
-- outputOf: (Build) `from` Element that is output `to` the Element instance during a LifecycleScopeType period.  Example: output of the build instance
-- packages: Every `to` Element is a packaged form of the `from` Element
-- patch: Every `to` Element is a patch for the `from` Element
-- prerequisite: Every `to` Element is a prerequisite of the `from` Element
-- providedDependency: Every `to` Element is a dependency not included in the distributed artifact but is assumed to be provided the `from` Element
+- hasHost: The `from` Build was run on the `to` Element during a LifecycleScopeType period (e.g. The host that the build runs on)
+- hasInputs: The `from` Build has each `to` Elements as an input during a LifecycleScopeType period.
+- invokedBy: The `from` Build was invoked by the `to` Agent during a LifecycleScopeType period.
+- hasMetafile: metafile: Every `to` Element is is a file containing metadata about the `from` Element (`from` hasMetafile `to`)
+- delegatedTo: The `from` Agent is delegated to each `to` Agent during a LifecycleScopeType period, (e.g. `to` is acting on behalf of `from`)
+- hasOptionalComponent: Every `to` Element is an optional component of the `from` Element (`from` hasOptionalComponent` `to`)
+- hasOptionalDependency: Every `to` Element is an optional dependency of the `from` Element (`from` hasOptionalDependency` `to`)
+- other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationhip types (this relationship is directionless)
+- hasOutputs: The `from` Build element generates each `to` Element as an output during a LifecycleScopeType period.
+- packagedBy: Every `to` Element is a packaged form of the `from` Element (`from` packagedBy `to`)
+- patchedBy: Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`)
+- hasPrerequsite: The `from` Element has a prerequsite on each `to` Element
+- hasProvidedDependency: The `from` Element has a dependency on each `to` Element, but dependency is not in the distributed artifact, but assumed to be provided
 - publishedBy: (Security) Designates the agent that made a vulnerability record available for public use or reference
-- reportedBy: (Security) Designates the agent that first reported a vulnerability to the project, vendor, or tracking database for formal identification 
+- reportedBy: (Security) Designates the agent that first reported a vulnerability to the project, vendor, or tracking database for formal identification
 - republishedBy: (Security) Designates the agent that tracked, aggregated, and/or enriched vulnerability details to improve context (i.e. NVD)
-- requirementFor: Every `to` Element is required for the `from` Element
-- runtimeDependency: Every `to` Element is a runtime dependency for the `from` Element
-- serializedInArtifact: The from SPDXDocument can be found in a serialized form in each to Artifact
-- specificationFor: Every `to` Element is a specification for the `from` Element
-- staticLink: Every `to` Element is statically linked to the `from` Element
-- test: Every `to` Element is a test artifact for the `from` Element
-- testCase: Every `to` Element is a test case for the `from` Element
-- testDependency: Every `to` Element is a test dependency for the `from` Element
-- testTool: Every `to` Element is a test tool for the `from` Element
+- hasRequirement: The `from` Element has a requirement on each `to` Element
+- hasRuntimeDependency: The `from` Element has a runtime dependency on each `to` Element
+- serializedInArtifact: The `from` SPDXDocument can be found in a serialized form in each `to` Artifact
+- hasSpecification: Every `to` Element is a specification for the `from` Element (`from` hasSpecification `to`)
+- hasStaticLink: The `from` Element statically links in each `to` Element
+- hasTest: Every `to` Element is a test artifact for the `from` Element (`from` hasTest `to`)
+- hasTestCase: Every `to` Element is a test case for the `from` Element (`from` hasTestCase `to`)
+- hasTestDependency: The `from` Element has a test dependency on each `to` Element
+- hasTestTool: The `from` Element uses each `to` Element as a test tool
 - testedOn: (AI, Dataset) The `from` Element has been tested on the `to` Element
 - trainedOn: (AI, Dataset) The `from` Element has been trained by the `to` Element(s)
 - underInvestigationFor: (Security/VEX) The impact of a vulnerability is being investigated
-- variant: Every `to` Element is a variant the `from` Element
+- hasVariant: Every `to` Element is a variant the `from` Element (`from` hasVariant `to`)


### PR DESCRIPTION
The current wording of RelationshipTypes is very difficult to understand and use correctly. It is very difficult to determine the directionality of relationships, and often the documentation is difficult to parse as its inverted from the expected directionality.

The renames most relationship types to complete the sentence: `from` (is) (a) `RELATIONSHIP` `to`

Also, as much as possible the documentation is worded so that `from` comes before `to` to further reduce confusion

All relationships are renamed assuming that the text description is the authoritative description of the direction, not the name of the relationship itself. This means existing implementation should be able to find and replace with the new names and still be correct (assuming they were able to figure them out in the first place).

For the sake of easier diffing, the relationships are not sorted based on their new names.

Many of the security relationship were not clearly documented enough to determine the correct directionality and still need to be addressed

Props to AI & Dataset for giving clear relationships that didn't need modified.

Closes #534
Closes #533