### PR TITLE
Add missing software purposes for CDX 1.5 compat

### DIFF
--- a/model/Software/Vocabularies/SoftwarePurpose.md
+++ b/model/Software/Vocabularies/SoftwarePurpose.md
@@ -28,6 +28,7 @@ about the context in which the Element exists.
 - data: Element is data
 - device: the Element refers to a chipset, processor, or electronic board
 - diskImage: the Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc.
+- deviceDriver: Element represents software that controls hardware devices
 - documentation: Element is documentation
 - evidence: the Element is the evidence that a specification or requirement has been fulfilled
 - executable: Element is an Artifact that can be run on a computer
@@ -43,6 +44,7 @@ about the context in which the Element exists.
 - operatingSystem: the Element is an operating system
 - other: the Element doesn't fit into any of the other categories
 - patch: Element contains a set of changes to update, fix, or improve another Element
+- platform: Element represents a runtime environment
 - requirement: the Element provides a requirement needed as input for another Element
 - source: the Element is a single or a collection of source files
 - specification: the Element is a plan, guideline or strategy how to create, perform or analyse an application


### PR DESCRIPTION
This commit adds two new software purposes: `deviceDriver` and `platform` to keep the compatibility of this field with the recent CycloneDX 1.5 release.


/cc @kestewart @rnjudge @JPEWdev

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>