### PR TITLE
Consistent naming for packageUrl

### DIFF
--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -22,7 +22,7 @@ ExteralIdentifierType specifies the type of an external identifier.
 - email: https://datatracker.ietf.org/doc/html/rfc3696#section-3
 - gitoid: https://www.iana.org/assignments/uri-schemes/prov/gitoid Gitoid stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and a gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent the software [Artifact ID](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#artifact-id) or the [OmniBOR Identifier](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#omnibor-identifier) for the software artifact's associated [OmniBOR Document](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#omnibor-document); this ambiguity exists because the OmniBOR Document is itself an artifact, and the gitoid of that artifact is its valid identifier. Omnibor is a minimalistic schema to describe software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#artifact-dependency-graph-adg). Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3.0 SoftwareArtifact's ContentIdentifier property. Gitoids calculated on the OmniBOR Document (OmniBOR Identifiers) should be recorded in the SPDX 3.0 Element's ExternalIdentifier property. 
 - other: Used when the type doesn't match any of the other options.
-- pkgUrl: https://github.com/package-url/purl-spec
+- packageUrl: https://github.com/package-url/purl-spec
 - securityOther: Used when there is a security related identifier of unspecified type.
 - swhid: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
 - swid: https://www.ietf.org/archive/id/draft-ietf-sacm-coswid-21.html#section-2.3


### PR DESCRIPTION
There were references to both `packageUrl` and `pkgUrl` in the spec which were both referencing https://github.com/package-url/purl-spec. This commit changes the model to only use `packageUrl` for consistency.

Resolves #493