### PR TITLE
The CI run should also commit the json model dump to gh-pages

### DIFF
--- a/.github/workflows/spec-parser.yml
+++ b/.github/workflows/spec-parser.yml
@@ -36,6 +36,7 @@ jobs:
               --gen-md \
               --gen-refs \
               --gen-rdf \
+              --json-dump \
               --out-dir /tmp/spec-parser.out \
               ../model
 
@@ -87,13 +88,14 @@ jobs:
           cp /tmp/spec-parser.out/model.ttl .
           cp /tmp/spec-parser.out/model.jsonld .
           cp /tmp/spec-parser.out/context.json .
+          cp /tmp/spec-parser.out/model_dump.json .
 
           rm -rf /auto-generated/
           cp -r /tmp/auto-generated/ .
 
           if [ -n "$(git status -s -- "auto-generated/" "*.ttl" "*.jsonld" "*.json")" ]
           then
-            git add model.ttl model.jsonld context.json auto-generated/
+            git add model.ttl model.jsonld context.json model_dump.json auto-generated/
             git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" commit -s -m "Automated Upload" --author "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
             git push origin
           fi

--- a/serialization/json_ld/examples/spdx_document1.json
+++ b/serialization/json_ld/examples/spdx_document1.json
@@ -7,7 +7,7 @@
     "specVersion": "3.0.0",
     "created": "2022-12-01T00:00:00Z",
     "createdBy": ["https://spdx.dev/elements/3F26391C#spdx-dev"],
-    "profile": ["core", "software"],
+    "profile": ["https://spdx.org/profiles/core", "https://spdx.org/profiles/software"],
     "dataLicense": "https://spdx.org/licenses/CC0-1.0"
   },
   "name": "Doc 159 - two File elements",


### PR DESCRIPTION
The spec parser can generate a json representation of the content of the md files. This is for example used in https://github.com/spdx/tools-python/pull/726 and it would be helpful if the CI here would generate and persist these files.