### PR TITLE
Move AnyLicenseInfo to Core

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -15,14 +15,14 @@ The AI profile namespace defines concepts related to AI application and model ar
 - id: https://rdf.spdx.org/v3/AI
 - name: AI
 
-## Profile conformance 
+## Profile conformance
 
 For an element collection to be conformant with this profile,
 the following has to hold:
 
 1. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
    of type `concludedLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and an `/Core/AnyLicenseInfo` as its `to` property.
 2. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
    of type `declaredLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and an `/Core/AnyLicenseInfo` as its `to` property.

--- a/model/Core/Classes/AnyLicenseInfo.md
+++ b/model/Core/Classes/AnyLicenseInfo.md
@@ -20,6 +20,6 @@ additional text applied; or a set of licenses combined by applying "AND" and
 ## Metadata
 
 - name: AnyLicenseInfo
-- SubclassOf: /Core/Element
+- SubclassOf: Element
 - Instantiability: Abstract
 

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -15,14 +15,14 @@ The Dataset namespace defines tbd.
 - id: https://rdf.spdx.org/v3/Dataset
 - name: Dataset
 
-## Profile conformance 
+## Profile conformance
 
 For an element collection to be conformant with this profile,
 the following has to hold:
 
 1. for every `/Dataset/DatasetPackage` there MUST exist exactly one `/Core/Relationship`
    of type `concludedLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and an `/Core/AnyLicenseInfo` as its `to` property.
 2. for every `/Dataset/DatasetPackage` there MUST exist exactly one `/Core/Relationship`
    of type `declaredLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and an `/Core/AnyLicenseInfo` as its `to` property.

--- a/model/ExpandedLicensing/Classes/ConjunctiveLicenseSet.md
+++ b/model/ExpandedLicensing/Classes/ConjunctiveLicenseSet.md
@@ -24,11 +24,11 @@ left to the consumer of SPDX data to determine for themselves.
 ## Metadata
 
 - name: ConjunctiveLicenseSet
-- SubclassOf: /SimpleLicensing/AnyLicenseInfo
+- SubclassOf: /Core/AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties
 
 - member
-  - type: /SimpleLicensing/AnyLicenseInfo
+  - type: /Core/AnyLicenseInfo
   - minCount: 2

--- a/model/ExpandedLicensing/Classes/DisjunctiveLicenseSet.md
+++ b/model/ExpandedLicensing/Classes/DisjunctiveLicenseSet.md
@@ -21,11 +21,11 @@ by the `OR` operator.
 ## Metadata
 
 - name: DisjunctiveLicenseSet
-- SubclassOf: /SimpleLicensing/AnyLicenseInfo
+- SubclassOf: /Core/AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties
 
 - member
-  - type: /SimpleLicensing/AnyLicenseInfo
+  - type: /Core/AnyLicenseInfo
   - minCount: 2

--- a/model/ExpandedLicensing/Classes/ExtendableLicense.md
+++ b/model/ExpandedLicensing/Classes/ExtendableLicense.md
@@ -13,6 +13,6 @@ The WithAdditionOperator can have a License or an OrLaterOperator as the license
 ## Metadata
 
 - name: ExtendableLicense
-- SubclassOf: /SimpleLicensing/AnyLicenseInfo
+- SubclassOf: /Core/AnyLicenseInfo
 - Instantiability: Abstract
 

--- a/model/ExpandedLicensing/Classes/WithAdditionOperator.md
+++ b/model/ExpandedLicensing/Classes/WithAdditionOperator.md
@@ -18,7 +18,7 @@ Syntax by the `WITH` operator.
 ## Metadata
 
 - name: WithAdditionOperator
-- SubclassOf: /SimpleLicensing/AnyLicenseInfo
+- SubclassOf: /Core/AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties

--- a/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
@@ -15,7 +15,7 @@ the SPDX creator has intentionally provided no information (no meaning should be
 ## Metadata
 
 - name: NoAssertionLicense
-- type: /SimpleLicensing/AnyLicenseInfo
+- type: /Core/AnyLicenseInfo
 
 ## Property Values
 

--- a/model/ExpandedLicensing/Individuals/NoneLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoneLicense.md
@@ -14,7 +14,7 @@ NoneLicense should be used if the SPDX creator determines there is no license av
 ## Metadata
 
 - name: NoneLicense
-- type: /SimpleLicensing/AnyLicenseInfo
+- type: /Core/AnyLicenseInfo
 
 ## Property Values
 

--- a/model/ExpandedLicensing/Properties/member.md
+++ b/model/ExpandedLicensing/Properties/member.md
@@ -16,4 +16,4 @@ license set.
 
 - name: member
 - Nature: ObjectProperty
-- Range: /SimpleLicensing/AnyLicenseInfo
+- Range: /Core/AnyLicenseInfo

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -49,14 +49,14 @@ A declaredLicense relationship to NoneLicense indicates that the
 corresponding Package, File or Snippet contains no license information
 whatsoever.
 
-A declaredLicense relationship to NoAssertionLicense 
+A declaredLicense relationship to NoAssertionLicense
 indicates that one of the following applies:
 * the SPDX data creator has attempted to but cannot reach a reasonable
   objective determination;
 * the SPDX data creator has made no attempt to determine this field; or
 * the SPDX data creator has intentionally provided no information (no meaning
   should be implied by doing so).
-  
+
 If a declaredLicense relationship is not present, no assumptions can be made
 about whether or not a declaredLicense exists.
 Note that a missing declaredLicense is not the same as a relationship to NoAssertionLicense
@@ -81,7 +81,7 @@ indicates that one of the following applies:
 * the SPDX data creator has made no attempt to determine this field; or
 * the SPDX data creator has intentionally provided no information (no
   meaning should be implied by doing so).
- 
+
 If a concludedLicense is not present, no assumptions can be made
 about whether or not a concludedLicense exists.
 Note that a missing concludedLicense is not the same as a relationship to a NoAssertionLicense
@@ -109,6 +109,6 @@ the following has to hold:
 
 1. for every `/Software/SoftwareArtifact` there MUST exist exactly one `/Core/Relationship`
    of type `concludedLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and an `/Core/AnyLicenseInfo` as its `to` property.
 
 

--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -15,7 +15,7 @@ SPDX License Expressions provide a way for one to construct expressions that mor
 ## Metadata
 
 - name: LicenseExpression
-- SubclassOf: AnyLicenseInfo
+- SubclassOf: /Core/AnyLicenseInfo
 - Instantiability: Concrete
 
 ## Properties


### PR DESCRIPTION
Moves the AnyLicenseInfo class to core. This makes sense so that specific profiles can implement specific licensing implementations, but other profiles do not need to be aware of them and can use the AnyLicenseInfo from core to refer to a license without any specific implementation.

As an example, SpdxDocument from Core references AnyLicenseInfo, so it shouldn't live in SimpleLicense profile.