### PR TITLE
Updating the IRIs used in RDF

### DIFF
--- a/serialization/rdf.md
+++ b/serialization/rdf.md
@@ -2,10 +2,19 @@
 
 SPDX data can be serialized in RDF. This can be saved in a variety of formats, like XML, JSON-LD, Turtle, etc.
 
-1. The namespace for SPDX v3 is `http://spdx.org/rdf/v3`
+1. The namespace for SPDX v3 is `https://rdf.spdx.org/v3`
 
-1. IRIs for a class are of the form: `http://spdx.org/rdf/v3/{Namespacename}/{Classname}`
+1. IRIs for a namespace/profile are of the form: `https://rdf.spdx.org/v3/{Namespacename}`
 
-1. IRIs for a property are of the form: `http://spdx.org/rdf/v3/{Namespacename}/{Propertyname}`
+1. IRIs for a class are of the form: `https://rdf.spdx.org/v3/{Namespacename}/{Classname}`
 
-1. IRIs for an enumerated value are of the form: `http://spdx.org/rdf/v3/{Namespacename}/{Classname}/{Valuename}`
+1. IRIs for a property are of the form: `https://rdf.spdx.org/v3/{Namespacename}/{Propertyname}`
+
+1. IRIs for a vocabulary (an enumerated value list) are of the form: `https://rdf.spdx.org/v3/{Namespacename}/{Vocabularyname}`
+
+1. IRIs for an enumerated value are of the form: `https://rdf.spdx.org/v3/{Namespacename}/{Vocabularyname}/{Entryname}`
+
+1. IRIs for an individual value list are of the form: `https://rdf.spdx.org/v3/{Namespacename}/{Individualname}`
+
+Please note that entries appearing in the License List are not under this namespace!
+


### PR DESCRIPTION
This simply updates the documentation on RDF,
to correctly match the IRIs used in the model,
as present in each namespace file.

