### PR TITLE
Remove hash algorithms with no description

### DIFF
--- a/model/Core/Vocabularies/HashAlgorithm.md
+++ b/model/Core/Vocabularies/HashAlgorithm.md
@@ -38,6 +38,3 @@ and is a one-way function, that is, a function which is practically infeasible t
 - sha3_512: sha3 with a digest length of 512 https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
 - sha384: secure hashing algorithm with a digest length of 384 https://www.rfc-editor.org/rfc/rfc4634
 - sha512: secure hashing algorithm with a digest length of 512 https://www.rfc-editor.org/rfc/rfc4634
-- spdxPvcSha1: TODOdescription
-- spdxPvcSha256: TODOdescription
-- sphincsPlus: TODOdescription


### PR DESCRIPTION
The hash algorithms have only "TODO" for comments. I could not find any record of these in the minutes and no one has volunteered to fill in the description, so this PR deletes these algorithms from the model.

If anyone would like to add them back, please add them with a description as a separate pull request.