### PR TITLE
Validating PRs via new parser

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,21 @@
+name: validate PR
+
+on:
+  pull-request
+
+jobs:
+  doit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+            python-version: "3.12"
+      - name: get spec-parser
+        run: |
+          git clone --depth=1 --single-branch --branch=main https://github.com/spdx/spec-parser/ /tmp/spec-parser
+          python /tmp/spec-parser/main.py -h
+      - name: run spec-parser to validate
+        run: |
+          python /tmp/spec-parser/main.py -n model


### PR DESCRIPTION
Adds an action to validate proposed PRs by using the new spec-parser

Presumably the previous workflow can be deleted, but this is not done here.
