### PR TITLE
Generalize contentIdentifier for SoftwareArtifact integrity verification

### DIFF
--- a/model/Software/Classes/ContentIdentifier.md
+++ b/model/Software/Classes/ContentIdentifier.md
@@ -1,0 +1,30 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ContentIdentifier
+
+## Summary
+
+A canonical, unique, immutable identifier
+
+## Description
+
+A ContentIdentifier is a canonical, unique, immutable identifier of the content of a software artifact, such as a package, a file, or a snippet.
+It can be used for verifying its identity and integrity.
+
+## Metadata
+
+- name: ContentIdentifier
+- SubclassOf: /Core/IntegrityMethod
+- Instantiability: Concrete
+
+## Properties
+
+- contentIdentifierValue
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- contentIdentifierType
+  - type: ContentIdentifierType
+  - minCount: 1
+  - maxCount: 1
+

--- a/model/Software/Classes/SoftwareArtifact.md
+++ b/model/Software/Classes/SoftwareArtifact.md
@@ -20,9 +20,7 @@ such as a package, a file, or a snippet.
 ## Properties
 
 - contentIdentifier
-  - type: xsd:anyURI
-  - minCount: 0
-  - maxCount: 1
+  - type: ContentIdentifier
 - primaryPurpose
   - type: SoftwarePurpose
   - minCount: 0

--- a/model/Software/Properties/contentIdentifier.md
+++ b/model/Software/Properties/contentIdentifier.md
@@ -4,25 +4,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides a place to record the canonical, unique, immutable identifier for each software artifact using the artifact's gitoid.
+A canonical, unique, immutable identifier of the artifact content, that can be used for verifying its identity and integrity.
 
 ## Description
 
-The contentIdentifier provides a canonical, unique, immutable artifact identifier for each software artifact. SPDX 3.0 describes software artifacts as Snippet, File, or Package Elements. The ContentIdentifier can be calculated for any software artifact and can be recorded for any of these SPDX 3.0 Elements using Omnibor, an attempt to standardize how software artifacts are identified independent of which programming language, version control system, build tool, package manager, or software distribution mechanism is in use.  
-
-The contentIdentifier is defined as the [Git Object Identifier](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) (gitoid) of type `blob` of the software artifact. The use of a git-based version control system is not necessary to calculate a contentIdentifier for any software artifact.
-
-The gitoid is expressed in the ContentIdentifier property by using the IANA [gitoid URI scheme](https://www.iana.org/assignments/uri-schemes/prov/gitoid).
-
-```
-Scheme syntax: gitoid":"<git object type>":"<hash algorithm>":"<hash value>
-```
-
-The OmniBOR ID for the OmniBOR Document associated with a software artifact should not be recorded in this field. Rather, OmniBOR IDs should be recorded in the SPDX Element's ExternalIdentifier property. See [https://omnibor.io](https://omnibor.io) for more details.
+A contentIdentifier is a canonical, unique, immutable identifier of the content of a software artifact, such as a package, a file, or a snippet.
+It can be used for verifying its identity and integrity.
 
 ## Metadata
 
 - name: contentIdentifier
 - Nature: DataProperty
-- Range: xsd:anyURI
+- Range: ContentIdentifier
 

--- a/model/Software/Properties/contentIdentifierType.md
+++ b/model/Software/Properties/contentIdentifierType.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# contentIdentifierType
+
+## Summary
+
+Specifies the type of the content identifier.
+
+## Description
+
+An contentIdentifierType specifies the type of the content identifier.
+
+## Metadata
+
+- name: contentIdentifierType
+- Nature: ObjectProperty
+- Range: ContentIdentifierType
+

--- a/model/Software/Properties/contentIdentifierValue.md
+++ b/model/Software/Properties/contentIdentifierValue.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# contentIdentifierValue
+
+## Summary
+
+Specifies the value of the content identifier.
+
+## Description
+
+A contentIdentifierValue specifies the value of a content identifier.
+
+## Metadata
+
+- name: contentIdentifierValue
+- Nature: DataProperty
+- Range: xsd:string
+

--- a/model/Software/Vocabularies/ContentIdentifierType.md
+++ b/model/Software/Vocabularies/ContentIdentifierType.md
@@ -1,0 +1,21 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ContentIdentifierType
+
+## Summary
+
+Specifies the type of a content identifier.
+
+## Description
+
+ContentIdentifierType specifies the type of a content identifier.
+
+## Metadata
+
+- name: ContentIdentifierType
+
+## Entries
+
+- gitoid: https://www.iana.org/assignments/uri-schemes/prov/gitoid Gitoid stands for [Git Object ID](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects) and a gitoid of type blob is a unique hash of a binary artifact. A gitoid may represent the software [Artifact ID](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#artifact-id) or the [OmniBOR Identifier](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#omnibor-identifier) for the software artifact's associated [OmniBOR Document](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#omnibor-document); this ambiguity exists because the OmniBOR Document is itself an artifact, and the gitoid of that artifact is its valid identifier. Omnibor is a minimalistic schema to describe software [Artifact Dependency Graphs](https://github.com/omnibor/spec/blob/main/spec/SPEC.md#artifact-dependency-graph-adg). Gitoids calculated on software artifacts (Snippet, File, or Package Elements) should be recorded in the SPDX 3.0 SoftwareArtifact's ContentIdentifier property. Gitoids calculated on the OmniBOR Document (OmniBOR Identifiers) should be recorded in the SPDX 3.0 Element's ExternalIdentifier property. 
+- swhid: SoftWare Hash IDentifier, persistent intrinsic identifiers for digital artifacts. The syntax of the identifiers is defined in the [SWHID specification](https://www.swhid.org/specification/v1.1/4.Syntax) and they typically look like `swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2`.
+


### PR DESCRIPTION
Adds a general contentIdentifier type system to support various types.

Note that the actual value of an identifier (`contentIdentifierValue` in a `ContentIdentifier`) is defined to be of type `xsd:string`. The two current available types both produce `xsd:anyURI` but maybe we want to keep our options open for the future.

The description of the types was copied from `/Core/ExternalIdentifierType`; I simplifies the `swhid` entry since we only consider content in this context.

