### PR TITLE
Update LifecycleScopeType.md

### DIFF
--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -17,7 +17,7 @@ This enumeration summarizes common phases when dependency and other relationship
 ## Entries
 
 - design: A relationship has specific context implications during an element's design.
-- development: A relationship has specific context implications during development of an element. 
+- development: A relationship has specific context implications during development phase of an element. 
 - build: A relationship has specific context implications during an element's build, during development.
 - test: A relationship has specific context implications during an element's testing, during development.
 - runtime: A relationship has specific context implications when an element is executing. 

--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -19,6 +19,6 @@ This enumeration summarizes common phases when dependency and other relationship
 - design: A relationship has specific context implications during an element's design.
 - development: A relationship has specific context implications during development phase of an element. 
 - build: A relationship has specific context implications during an element's build phase, during development.
-- test: A relationship has specific context implications during an element's testing, during development.
+- test: A relationship has specific context implications during an element's testing phase, during development.
 - runtime: A relationship has specific context implications when an element is executing. 
 - other: A relationship has other specific context information necessary to capture that the above set of enumerations does not handle.

--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -20,5 +20,5 @@ This enumeration summarizes common phases when dependency and other relationship
 - development: A relationship has specific context implications during development phase of an element. 
 - build: A relationship has specific context implications during an element's build phase, during development.
 - test: A relationship has specific context implications during an element's testing phase, during development.
-- runtime: A relationship has specific context implications when an element is executing. 
+- runtime: A relationship has specific context implications during the execution phase of an element.
 - other: A relationship has other specific context information necessary to capture that the above set of enumerations does not handle.

--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-TODO
+Provide an enumerated set of software lifecycle phases that can provide context to relationships.
 
 ## Description
 
-TODO
+This enumeration summarizes common phases when dependency and other relationships, have different implications, based on their context.  For example,  a build dependency, may have different implications than a runtime dependency.
 
 ## Metadata
 
@@ -16,9 +16,9 @@ TODO
 
 ## Entries
 
-- design: TODOdescription
-- build: TODOdescription
-- development: TODOdescription
-- test: TODOdescription
-- runtime: TODOdescription
-- other: TODOdescription
+- design: A relationship has specific context implications during an element's design.
+- development: A relationship has specific context implications during development of an element. 
+- build: A relationship has specific context implications during an element's build, during development.
+- test: A relationship has specific context implications during an element's testing, during development.
+- runtime: A relationship has specific context implications when an element is executing. 
+- other: A relationship has other specific context information necessary to capture that the above set of enumerations does not handle.

--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -18,7 +18,7 @@ This enumeration summarizes common phases when dependency and other relationship
 
 - design: A relationship has specific context implications during an element's design.
 - development: A relationship has specific context implications during development phase of an element. 
-- build: A relationship has specific context implications during an element's build, during development.
+- build: A relationship has specific context implications during an element's build phase, during development.
 - test: A relationship has specific context implications during an element's testing, during development.
 - runtime: A relationship has specific context implications when an element is executing. 
 - other: A relationship has other specific context information necessary to capture that the above set of enumerations does not handle.


### PR DESCRIPTION
Update the descriptions for the LifecycleScopedRelationship Enumerations.  

Note that this parameterizes historical relationships, like DEV_DEPENDENCY_OF, BUILD_DEPENENCY_OF, RUNTIME_DEPENDENCY_OF, etc. and pelaces them with depends_on with this lifecycleScopeType.

Signed-off-by: Kate Stewart <kstewart@linuxfoundation.org>