### PR TITLE
Create Support Level to associate different types of support with an artifact. 

### DIFF
--- a/model/Core/Classes/Artifact.md
+++ b/model/Core/Classes/Artifact.md
@@ -40,4 +40,7 @@ such as an electronic file, a software package, a device or an element of data.
   - maxCount: 1
 - standard
   - type: xsd:string
+  - minCount: 0
+- supportLevel
+  - type: SupportType
   - minCount: 0 

--- a/model/Core/Properties/supportLevel
+++ b/model/Core/Properties/supportLevel
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# supportLevel
+
+## Summary
+
+Specifies the level of support associated with an artifact.
+
+## Description
+
+supportLevel provides an indication of what support expectations that the supplier of an artifact is providing to the user. 
+
+## Metadata
+
+- name: supportType
+- Nature: DataProperty
+- Range: SupportType

--- a/model/Core/Vocabularies/SupportType.md
+++ b/model/Core/Vocabularies/SupportType.md
@@ -1,0 +1,22 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# SupportType
+
+## Summary
+
+Indicates the type of support that is associated with an artifact.
+
+## Description
+SupportType is an enumeration of the various types of support commonly found for artifacts in the software supply chain. Specific details of what that support entails are provided by agreements between the producer and consumer of the artifact. 
+
+## Metadata
+
+- name: SupportType
+
+## Entries
+- development - the artifact is in active development and is not considered ready for formal support from the supplier.
+- support - the artifact has been released, and is supported from the supplier.   There is a validUntilDate that can provide additional information about the duration of support.
+- limitedSupport - the artifact has been released, and there is limited support available from the supplier. There is a validUntilDate that can provide additional information about the duration of support.
+- endOfSupport - there is a defined end of support for the artifact from the supplier.  This may also be referred to as end of life. There is a validUntilDate that can be used to signal when support ends for the artifact. 
+- noSupport - there is no support for the artifact from the supplier, consumer assumes any support obligations.
+- noAssertion - no assertion about the type of support is made.   This is considered the default if no other support type is used.


### PR DESCRIPTION
The support available for a software artifact is a factor increasingly being used in risk assessment.  equirement of listing the support type available.   This set of enumerations has been based on the enumerations in ["Managing Legacy Technology Security (HIC-MaLTS)" from the Healthcare & Public Health Sector Coordinating Councils](https://healthsectorcouncil.org/wp-content/uploads/2023/03/Health-Industry-Cybersecurity-Managing-Legacy-Technology-Security-HIC-MaLTS.pdf), with additional categories being added after discussion with the AI & Data profile working groups.   It can be applied to software components, AI/ML trained models and datasets; in the medical industry as well as other industries. 

Signed-off-by: Kate Stewart <kstewart@linuxfoundation.org>