### PR TITLE
Adds IRIs to individual licenses

### DIFF
--- a/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
@@ -16,6 +16,7 @@ the SPDX creator has intentionally provided no information (no meaning should be
 
 - name: NoAssertionLicense
 - type: IndividualLicensingInfo
+- IRI: https://rdf.spdx.org/v3/Licensing/NoAssertion
 
 ## Property Values
 

--- a/model/ExpandedLicensing/Individuals/NoneLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoneLicense.md
@@ -15,6 +15,7 @@ NoneLicense should be used if the SPDX creator determines there is no license av
 
 - name: NoneLicense
 - type: IndividualLicensingInfo
+- IRI: https://rdf.spdx.org/v3/Licensing/None
 
 ## Property Values
 


### PR DESCRIPTION
This adds specific IRIs to the individuals in the licensing domain.

This is following up on https://github.com/spdx/spdx-3-model/pull/588#issuecomment-1917924971.

Please note that every class, property, individual, etc. already has an IRI (automatically generated, present in the generated files). The addition of explicit IRIs for Individuals allows us to choose custom ones, which are simpler.