### PR TITLE
moves PVC to core class

### DIFF
--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -10,9 +10,10 @@ An SPDX version 2.X compatible verification method for software packages.
 
 This verification method is provided for compatibility with SPDX 2.X.
 
-Use of this verification code method is discouraged except for scenarios where the `contentIdentifier` property on `Artifact` can not be used.
+Use of this verification code method is discouraged except for scenarios where the `gitoid` property on `Artifact` can not be used.
 
-This verification method provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX document itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX document. 
+This verification method provides an independently reproducible mechanism identifying specific contents of a package based on the actual files (except the SPDX document itself, if it is included in the package) that make up each package and that correlates to the data in this SPDX document.
+
 This identifier enables a recipient to determine if any file in the original package (that the analysis was done on) has been changed and permits inclusion of an SPDX document as part of a package.
 
 Algorithm:


### PR DESCRIPTION
This change moves the PackageVerificationCode.md to the Core Class.

PackageVerificationCode is a Subclassof: model/Core/IntegrityMethod, which, (as with all Non-Element Classes) is a class defined in model/Core/Classes rather than model/Software/Classes