### PR TITLE
In EpssVulnAssessmentRelationship.md, remove 'from', 'to', and 'suppliedBy' in syntax

### DIFF
--- a/model/Security/Classes/EpssVulnAssessmentRelationship.md
+++ b/model/Security/Classes/EpssVulnAssessmentRelationship.md
@@ -25,9 +25,6 @@ An EpssVulnAssessmentRelationship relationship describes the likelihood or proba
   "relationshipType": "hasAssessmentFor",
   "probability": 0.00105,
   "percentile": 0.42356,
-  "from": "urn:spdx.dev:vuln-cve-2020-28498",
-  "to": ["urn:product-acme-application-1.3"],
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
   "publishedTime": "2023-10-05T00:00:30Z"
 }
 ```


### PR DESCRIPTION
I propose that we remove the following three lines from the syntax:

"from": "urn:spdx.dev:vuln-cve-2020-28498",
  "to": ["urn:product-acme-application-1.3"],
  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],

The 'from' and 'to' do not seem to indicate meaningful semantics here. On fields about vulnerability, they could indicate the time period between which the assessment is valid, but not sure what is being indicated in EPSS context.

'suppliedBy' would always be the EPSS group of FIRST.org, so I don't see a need for explicitly calling it out.