### PR TITLE
Update VexVulnAssessmentRelationship.md

### DIFF
--- a/model/Security/Classes/VexVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexVulnAssessmentRelationship.md
@@ -38,7 +38,7 @@ the document's date must be considered as authoritative.
 
 ## Properties
 
-- vexVersion
+- vexMinRequirementsVersion
   - type: xsd:string
   - minCount: 0
   - maxCount: 1


### PR DESCRIPTION
To be precise, VEX as such does not have a version of its own at least as of now. The version (1.0.0 released in April 2023) is for minimum requirements of data elements. Hence suggest this field to reflect precisely what the version field means.