### PR TITLE
model: Fix several properties to use ObjectProperty instead of DataProperty

### DIFF
--- a/model/Core/Properties/supportLevel.md
+++ b/model/Core/Properties/supportLevel.md
@@ -13,5 +13,5 @@ supportLevel provides an indication of what support expectations that the suppli
 ## Metadata
 
 - name: supportLevel
-- Nature: DataProperty
+- Nature: ObjectProperty
 - Range: SupportType

--- a/model/Dataset/Properties/datasetAvailability.md
+++ b/model/Dataset/Properties/datasetAvailability.md
@@ -13,5 +13,5 @@ Some datasets are publicly available and can be downloaded directly. Others are 
 ## Metadata
 
 - name: datasetAvailability
-- Nature: DataProperty
+- Nature: ObjectProperty
 - Range: DatasetAvailabilityType

--- a/model/Dataset/Properties/datasetType.md
+++ b/model/Dataset/Properties/datasetType.md
@@ -13,5 +13,5 @@ Type describes the datatype contained in the dataset. For example a dataset can 
 ## Metadata
 
 - name: datasetType
-- Nature: DataProperty
+- Nature: ObjectProperty
 - Range: DatasetType

--- a/model/Security/Properties/severity.md
+++ b/model/Security/Properties/severity.md
@@ -13,5 +13,5 @@ The severity field provides a human readable string of the resulting numerical C
 ## Metadata
 
 - name: severity
-- Nature: DataProperty
+- Nature: ObjectProperty
 - Range: CvssSeverityType


### PR DESCRIPTION
ObjectProperty must be used for vocabularies instead of DataProperty