### PR TITLE
model: Core: DateTime: Inherit from xsd:dateTime

### DIFF
--- a/model/Core/Datatypes/DateTime.md
+++ b/model/Core/Datatypes/DateTime.md
@@ -15,7 +15,7 @@ The specific format is one of the most commonly used ISO-8601 formats.
 ## Metadata
 
 - name: DateTime
-- SubclassOf: xsd:string
+- SubclassOf: xsd:dateTimeStamp
 
 ## Format
 


### PR DESCRIPTION
Inherit from xsd:dateTime instead of xsd:string. The XSD definition is compatible with the SPDX definition, and this will allow code generation tools to map the value to a code-native datatype.