### PR TITLE
Core: Change SpdxId to IdProperty

### DIFF
--- a/model/Core/Properties/spdxId.md
+++ b/model/Core/Properties/spdxId.md
@@ -16,6 +16,6 @@ so that relationships between Elements can be clearly articulated.
 ## Metadata
 
 - name: spdxId
-- Nature: DataProperty
+- Nature: IdProperty
 - Range: xsd:anyURI
 


### PR DESCRIPTION
This field is intended to be implemented by the underlying ID property in the serialized format (e.g. "@id" in JSON-LD), so change it to the special "IdProperty" nature so that the model parsing code can recognize this and make the mapping.