### PR TITLE
Update service profile for use case 9

### DIFF
--- a/model/Service/Classes/SoftwareService.md
+++ b/model/Service/Classes/SoftwareService.md
@@ -15,6 +15,9 @@ SoftwareService represents software being licensed, delivered and accessed onlin
 - provider
   - type: Agent
   - minCount: 1
+- serverAuthenticationProtocol
+  - type: AuthenticationProtocolType
+  - minCount: 0
 
 ## Metadata
 

--- a/model/Service/Properties/serverAuthenticationProtocol.md
+++ b/model/Service/Properties/serverAuthenticationProtocol.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# serverAuthenticationProtocol
+
+## Summary
+
+Authentication protocol used by a server.
+
+## Description
+
+Authentication protocols used by a server or a software service to authenticate the server to the consumer.
+
+## Metadata
+
+- name: serverAuthenticationProtocol
+- Nature: ObjectProperty
+- Range: AuthenticationProtocolType

--- a/model/Service/Vocabularies/AuthenticationProtocolType.md
+++ b/model/Service/Vocabularies/AuthenticationProtocolType.md
@@ -1,0 +1,22 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# AuthenticationProtocolType
+
+## Summary
+
+Protocols which support authentication.
+
+## Description
+
+This enumeration provides common protocols used in authentication of servers or services over a network.
+
+## Metadata
+
+- name: AuthenticationProtocolType
+
+## Entries
+
+- tls: Transport Layer Security, or TLS, is a widely adopted security protocol designed to facilitate privacy and data security for communications over the Internet.
+- ocsp: OCSP (Online Certificate Status Protocol) is a common schemes used to maintain the security of a server and other network resources.
+- crl: Certificate Revocation List (CRL) - A CRL is a list of revoked certificates that is downloaded from the Certificate Authority (CA).
+- other: An authentication protocol not covered by one of the other AuthenticationProtocolTypes.


### PR DESCRIPTION
Use case 9: Trust the identity of the service provider (authentication) Property and vocabulary added per the discussion on the software as a service call on 11 March, 2024