### PR TITLE
Element: Add NodeKind IRI

### DIFF
--- a/model/Core/Classes/Element.md
+++ b/model/Core/Classes/Element.md
@@ -20,6 +20,7 @@ and inter-relatable content objects.
 - name: Element
 - SubclassOf: none
 - Instantiability: Abstract
+- NodeKind: IRI
 
 ## Properties
 


### PR DESCRIPTION
Sets the NodeKind for elements to be an IRI. This prevents them from being able to use blank nodes in the SHACL model.

Requires https://github.com/spdx/spec-parser/pull/107