### PR TITLE
[3.0] AI: Update safetyRiskAssessment property desc to refer to general risk assessment

### DIFF
--- a/model/AI/Properties/safetyRiskAssessment.md
+++ b/model/AI/Properties/safetyRiskAssessment.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Categorizes safety risk impact of AI software.
+Categorizes general safety risk assessment of the AI software.
 
 ## Description
 
-Categorizes the safety risk impact of the AI software.
+Categorizes general safety risk assessment of the AI software.
 
 Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
 

--- a/model/AI/Properties/safetyRiskAssessment.md
+++ b/model/AI/Properties/safetyRiskAssessment.md
@@ -4,15 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Categorizes general safety risk assessment of the AI software.
+Categorizes general safety risk assessment of the AI system.
 
 ## Description
 
-Categorizes general safety risk assessment of the AI software.
+Categorizes general safety risk assessment of the AI system.
 
 Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
 
-Please be noted that this categorization is different from the one proposed in the provisional agreement of the European Union AI Act.
+It is important to note that this categorization differs from the one proposed in the EU AI Act's provisional agreement.
 
 ## Metadata
 

--- a/model/AI/Properties/safetyRiskAssessment.md
+++ b/model/AI/Properties/safetyRiskAssessment.md
@@ -8,8 +8,11 @@ Categorizes safety risk impact of AI software.
 
 ## Description
 
-SafetyRiskAssessment categorizes the safety risk impact of the AI software
-in accordance with Article 20 of [EC Regulation No 765/2008](https://ec.europa.eu/docsroom/documents/17107/attachments/1/translations/en/renditions/pdf). 
+Categorizes the safety risk impact of the AI software.
+
+Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
+
+Please be noted that this categorization is different from the one proposed in the provisional agreement of the European Union AI Act.
 
 ## Metadata
 

--- a/model/AI/Vocabularies/SafetyRiskAssessmentType.md
+++ b/model/AI/Vocabularies/SafetyRiskAssessmentType.md
@@ -8,8 +8,9 @@ Categories of safety risk impact of the application.
 
 ## Description
 
-Lists the different safety risk type values that can be used to describe the safety risk of AI software
-according to [Article 20 of Regulation 765/2008/EC](https://ec.europa.eu/docsroom/documents/17107/attachments/1/translations/en/renditions/pdf).
+Lists the different safety risk type values that can be used to describe the safety risk of AI software.
+
+Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
 
 ## Metadata
 
@@ -18,6 +19,6 @@ according to [Article 20 of Regulation 765/2008/EC](https://ec.europa.eu/docsroo
 ## Entries
 
 - serious: The highest level of risk posed by an AI software.
-- high: The second-highest level of risk posed by an AI software. 
-- medium: The third-highest level of risk posed by an AI software. 
+- high: The second-highest level of risk posed by an AI software.
+- medium: The third-highest level of risk posed by an AI software.
 - low: Low/no risk is posed by the AI software.

--- a/model/AI/Vocabularies/SafetyRiskAssessmentType.md
+++ b/model/AI/Vocabularies/SafetyRiskAssessmentType.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Categorizes general safety risk assessment of an AI software.
+Specifies the safety risk assessment type.
 
 ## Description
 

--- a/model/AI/Vocabularies/SafetyRiskAssessmentType.md
+++ b/model/AI/Vocabularies/SafetyRiskAssessmentType.md
@@ -8,7 +8,7 @@ Specifies the safety risk assessment type.
 
 ## Description
 
-Lists the different general safety risk type values that can be used to describe the general safety risk of an AI software.
+Lists the different general safety risk type values that can be used to describe the general safety risk of an AI system.
 
 Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
 
@@ -18,7 +18,7 @@ Using categorization according to the [EU general risk assessment methodology](h
 
 ## Entries
 
-- serious: The highest level of risk posed by an AI software.
-- high: The second-highest level of risk posed by an AI software.
-- medium: The third-highest level of risk posed by an AI software.
-- low: Low/no risk is posed by the AI software.
+- serious: The highest level of risk posed by an AI system.
+- high: The second-highest level of risk posed by an AI system.
+- medium: The third-highest level of risk posed by an AI system.
+- low: Low/no risk is posed by the AI system.

--- a/model/AI/Vocabularies/SafetyRiskAssessmentType.md
+++ b/model/AI/Vocabularies/SafetyRiskAssessmentType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Categories of safety risk impact of the application.
+Categorizes general safety risk assessment of an AI software.
 
 ## Description
 
-Lists the different safety risk type values that can be used to describe the safety risk of AI software.
+Lists the different general safety risk type values that can be used to describe the general safety risk of an AI software.
 
 Using categorization according to the [EU general risk assessment methodology](https://ec.europa.eu/docsroom/documents/17107) which implements Article 20 of Regulation (EC) No 765/2008 and is intended to assist authorities when they assess general product safety compliance.
 


### PR DESCRIPTION
Change description text for risk categories to refer to EU General Risk Assessment Methodology, not EU AI Act - as agreed in SPDX AI Team Meeting 2024-03-20.

See more analysis and discussions in #650.