### PR TITLE
[WIP] AI: Rename energyConsumption to trainingEnergyConsumption (+suggested unit?)

### DIFF
--- a/model.drawio
+++ b/model.drawio
@@ -1719,7 +1719,7 @@
         <mxCell id="96wljPxh_fQPzhBJDJxU-11" value="+ Core/Artifact/releaseTime: DateTime[1]" style="text;strokeColor=none;fillColor=#E1D5E7;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="96wljPxh_fQPzhBJDJxU-1" vertex="1">
           <mxGeometry y="146" width="413.51" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="96wljPxh_fQPzhBJDJxU-7" value="+ energyConsumption: String[0..1]" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="96wljPxh_fQPzhBJDJxU-1" vertex="1">
+        <mxCell id="96wljPxh_fQPzhBJDJxU-7" value="+ trainingEnergyConsumption: String[0..1]" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="96wljPxh_fQPzhBJDJxU-1" vertex="1">
           <mxGeometry y="176" width="413.51" height="30" as="geometry" />
         </mxCell>
         <mxCell id="96wljPxh_fQPzhBJDJxU-20" value="+ standardCompliance: String[0..*]" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="96wljPxh_fQPzhBJDJxU-1" vertex="1">

--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -18,7 +18,7 @@ Metadata information that can be added to a package to describe an AI applicatio
 
 ## Properties
 
-- energyConsumption
+- trainingEnergyConsumption
   - type: xsd:string
   - minCount: 0
   - maxCount: 1

--- a/model/AI/Properties/trainingEnergyConsumption.md
+++ b/model/AI/Properties/trainingEnergyConsumption.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# energyConsumption
+# trainingEnergyConsumption
 
 ## Summary
 
@@ -11,11 +11,11 @@ Indicates the amount of energy consumed to train the AI model.
 A free-form text captures known or estimated energy consumption for the training of the AI model.
 
 In case not known, the estimation could be based on information about computational resources used
-(e.g. number of floating point operations – FLOPs), training time, type and quantity of processing units,
-and other relevant details related to the training.
+(e.g. number of floating point operations – FLOPs), training time, type and quantity of processing
+units, and other relevant details related to the training.
 
 ## Metadata
 
-- name: energyConsumption
+- name: trainingEnergyConsumption
 - Nature: DataProperty
 - Range: xsd:string


### PR DESCRIPTION
- To fix #677 
  - See also Points (2)(d) and (2)(e) in Annex IXa Section 1 and Point (c) in Annex IXc in the [provisional agreement of the EU AI Act](https://www.europarl.europa.eu/meetdocs/2014_2019/plmrep/COMMITTEES/CJ40/AG/2024/02-13/1296003EN.pdf).
- Do we need a suggested unit of energy in the description?
  - For example,
    - Kilowatt-hour (kW-h) -- a non-SI unit, a common billing unit for electrical energy
    - Megajoule (MJ) -- a SI unit, 1 J is 1 Watt-second, 1 KW-h is 3.6 MJ.
