### PR TITLE
Reference License Expressions annex and cleanup

### DIFF
--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -8,9 +8,16 @@ An SPDX Element containing an SPDX license expression string.
 
 ## Description
 
-Often a single license can be used to represent the licensing terms of a source code or binary file, but there are situations where a single license identifier is not sufficient. A common example is when software is offered under a choice of one or more licenses (e.g., GPL-2.0-only OR BSD-3-Clause). Another example is when a set of licenses is needed to represent a binary program constructed by compiling and linking two (or more) different source files each governed by different licenses (e.g., LGPL-2.1-only AND BSD-3-Clause).
+A LicenseExpression enables the representation, in a single string, of a
+combination of one or more licenses, together with additions such as license
+exceptions.
 
-SPDX License Expressions provide a way for one to construct expressions that more accurately represent the licensing terms typically found in open source software source code. A license expression could be a single license identifier found on the SPDX License List; a user defined license reference denoted by the LicenseRef-idString; a license identifier combined with an SPDX exception; or some combination of license identifiers, license references and exceptions constructed using a small set of defined operators (e.g., AND, OR, WITH and +). We provide the definition of what constitutes a valid SPDX License Expression in this section.
+The syntax for a LicenseExpression string is set forth in the SPDX License
+Expressions annex to the SPDX Specification. A LicenseExpression string is
+not valid if it does not conform to the grammar set forth in that annex.
+
+The ExpandedLicensing profile can be used to represent the complete parsed
+license expression as a combination of license objects.
 
 ## Metadata
 

--- a/model/SimpleLicensing/Properties/customIdToUri.md
+++ b/model/SimpleLicensing/Properties/customIdToUri.md
@@ -9,9 +9,9 @@ Maps a LicenseRef or AdditionRef string for a Custom License or a Custom License
 ## Description
 
 Within a License Expression, references can be made to a Custom License or a Custom License Addition.
-The License Expression syntax dictates any refence starting with a "LicenseRef-" or "AdditionRef-" refers to license or addition text not found in the SPDX list of licenses.
+The License Expression syntax dictates any reference starting with a "LicenseRef-" or "AdditionRef-" refers to license or addition text not found in the official SPDX License List.
 These custom licenses must be a CustomLicense, a CustomLicenseAddtion, or a SimpleLicensingText which are identified with a unique URI identifier.
-The key for the DictionaryEntry is the string used in the license expression and the value is the URI for the corrosponding CustomLicense, CustomLicenseAddition, or SimpleLicensingText.
+The key for the DictionaryEntry is the string used in the license expression and the value is the URI for the corresponding CustomLicense, CustomLicenseAddition, or SimpleLicensingText.
 
 
 ## Metadata

--- a/model/SimpleLicensing/Properties/licenseExpression.md
+++ b/model/SimpleLicensing/Properties/licenseExpression.md
@@ -8,9 +8,16 @@ A string in the license expression format.
 
 ## Description
 
-Often a single license can be used to represent the licensing terms of a source code or binary file, but there are situations where a single license identifier is not sufficient. A common example is when software is offered under a choice of one or more licenses (e.g., GPL-2.0-only OR BSD-3-Clause). Another example is when a set of licenses is needed to represent a binary program constructed by compiling and linking two (or more) different source files each governed by different licenses (e.g., LGPL-2.1-only AND BSD-3-Clause).
+A licenseExpression enables the representation, in a single string, of a
+combination of one or more licenses, together with additions such as license
+exceptions.
 
-SPDX License Expressions provide a way for one to construct expressions that more accurately represent the licensing terms typically found in open source software source code. A license expression could be a single license identifier found on the SPDX License List; a user defined license reference denoted by the LicenseRef-idString; a license identifier combined with an SPDX exception; or some combination of license identifiers, license references and exceptions constructed using a small set of defined operators (e.g., AND, OR, WITH and +). We provide the definition of what constitutes a valid an SPDX License Expression in this section.
+The syntax for a LicenseExpression string is set forth in the SPDX License
+Expressions annex to the SPDX Specification. A LicenseExpression string is
+not valid if it does not conform to the grammar set forth in that annex.
+
+The ExpandedLicensing profile can be used to represent the complete parsed
+license expression as a combination of license objects.
 
 ## Metadata
 

--- a/model/SimpleLicensing/SimpleLicensing.md
+++ b/model/SimpleLicensing/SimpleLicensing.md
@@ -13,7 +13,7 @@ It also provides the base abstract class, AnyLicenseInfo, used for references to
 The SimpleLicensingText class provides a place to record any license text found that does not match a license
 on the SPDX license list.
 
-The ExpandingLicensing profile can be used to represent the complete parsed license expressions.
+The ExpandedLicensing profile can be used to represent the complete parsed license expressions.
 
 ## Metadata
 


### PR DESCRIPTION
The primary change in this commit is to reference the SPDX License Expressions annex (currently Annex D) in the LicenseExpression- related class and property definitions.

This is to avoid repeated text, and also to make it clear that license expression strings must conform to the license expression syntax in order to be valid.

This commit also fixes a couple of minor typos in the prior descriptions in SimpleLicensing.

Fixes #440 

Fixes #445

Signed-off-by: Steve Winslow <steve@swinslow.net>