### PR TITLE
Clarify ExternalIdentifier and ExternalRef

### DIFF
--- a/model/Core/Classes/ExternalIdentifier.md
+++ b/model/Core/Classes/ExternalIdentifier.md
@@ -4,16 +4,17 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A reference to a resource outside the scope of SPDX-3.0 content that uniquely identifies an Element.
+A reference to a resource identifier defined outside the scope of SPDX-3.0 content that uniquely identifies an Element.
 
 ## Description
 
 An ExternalIdentifier is a reference to a resource outside the scope of SPDX-3.0 content
-that uniquely identifies an Element.
+that provides a unique key within an established domain that can uniquely identify an Element.
 
 ## Metadata
 
 - name: ExternalIdentifier
+- SubclassOf: none
 - Instantiability: Concrete
 
 ## Properties

--- a/model/Core/Classes/ExternalRef.md
+++ b/model/Core/Classes/ExternalRef.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A reference to a resource outside the scope of SPDX-3.0 content.
+A reference to a resource outside the scope of SPDX-3.0 content related to an Element.
 
 ## Description
 
-An External Reference points to a resource outside the scope of the SPDX-3.0 content
-that provides additional characteristics of an Element.
+An External Reference points to a general resource outside the scope of the SPDX-3.0 content
+that provides additional context, characteristics or related information about an Element.
 
 ## Metadata
 


### PR DESCRIPTION
This commit attempts to clarify the differences between ExternalIdentifier and ExternalRef classes.

Closes #705