### PR TITLE
Update IRI in diagram for NoAssertionLicense and NoneLicense

### DIFF
--- a/model.drawio
+++ b/model.drawio
@@ -1199,13 +1199,13 @@
         <mxCell id="KA1xjPNPVZ9xSUQX3SqY-5" value="&lt;&lt;Individual&gt;&gt;&#xa;NoAssertionLicense : IndividualLicensingInfo" style="swimlane;fontStyle=1;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#f5f5f5;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#666666;fontColor=#333333;" parent="1" vertex="1">
           <mxGeometry x="2160" y="126" width="350" height="56" as="geometry" />
         </mxCell>
-        <mxCell id="_3iI9CYwvOLBjie_8vdV-1" value="https://rdf.spdx.org/v3/ExpandedLicensing/NoAssertionLicense" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="KA1xjPNPVZ9xSUQX3SqY-5" vertex="1">
+        <mxCell id="_3iI9CYwvOLBjie_8vdV-1" value="https://spdx.org/rdf/3.0.0/terms/Licensing/NoAssertion" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="KA1xjPNPVZ9xSUQX3SqY-5" vertex="1">
           <mxGeometry y="26" width="350" height="30" as="geometry" />
         </mxCell>
         <mxCell id="KA1xjPNPVZ9xSUQX3SqY-6" value="&lt;&lt;Individual&gt;&gt;&#xa;NoneLicense : IndividualLicensingInfo" style="swimlane;fontStyle=1;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#f5f5f5;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#666666;fontColor=#333333;" parent="1" vertex="1">
           <mxGeometry x="2160" y="198" width="350" height="56" as="geometry" />
         </mxCell>
-        <mxCell id="_3iI9CYwvOLBjie_8vdV-2" value="https://rdf.spdx.org/v3/ExpandedLicensing/NoneLicense" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="KA1xjPNPVZ9xSUQX3SqY-6" vertex="1">
+        <mxCell id="_3iI9CYwvOLBjie_8vdV-2" value="https://spdx.org/rdf/3.0.0/terms/Licensing/None" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;spacingLeft=4;spacingRight=4;overflow=hidden;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;rotatable=0;whiteSpace=wrap;html=1;" parent="KA1xjPNPVZ9xSUQX3SqY-6" vertex="1">
           <mxGeometry y="26" width="350" height="30" as="geometry" />
         </mxCell>
       </root>


### PR DESCRIPTION
In Licensing model diagram, update IRIs of two Individuals in ExpandedLicensing to new IRIs, as decided on the [2024-04-02 tech call](https://github.com/spdx/meetings/blob/main/tech/2024-04-02.md):
- `https://rdf.spdx.org/v3/ExpandedLicensing/NoAssertionLicense` -> `https://spdx.org/rdf/3.0.0/terms/Licensing/NoAssertion`
- `https://rdf.spdx.org/v3/ExpandedLicensing/NoneLicense` -> `https://spdx.org/rdf/3.0.0/terms/Licensing/None`

--

Also, does there a reason of using the term `IRI` instead of `id` in the Metadata section of these two specific Individuals `NoAssertionLicense` and `NoneLicense`?

If there's no specific reason, I can change that two "IRI:" text labels to "id:", to keep them consistent with others.

Please look at these snippets:

From [model/ExpandedLicensing/Individuals/NoneLicense.md](https://github.com/spdx/spdx-3-model/blob/main/model/ExpandedLicensing/Individuals/NoneLicense.md):

```markdown
## Metadata

- name: NoneLicense
- type: IndividualLicensingInfo
- IRI: https://spdx.org/rdf/3.0.0/terms/Licensing/None
```

From [model/ExpandedLicensing/Individuals/NoAssertionLicense.md](https://github.com/spdx/spdx-3-model/blob/main/model/ExpandedLicensing/Individuals/NoAssertionLicense.md):

```markdown
## Metadata

- name: NoAssertionLicense
- type: IndividualLicensingInfo
- IRI: https://spdx.org/rdf/3.0.0/terms/Licensing/NoAssertion
```

As for every other places, they use `id`:

From [model/Core/Core.md](https://github.com/spdx/spdx-3-model/blob/main/model/Core/Core.md):

```markdown
## Metadata

- id: https://spdx.org/rdf/3.0.0/terms/Core
- name: Core
```

See [more of other instances](https://github.com/search?q=repo%3Aspdx%2Fspdx-3-model+%22%3A+https%3A%2F%2Fspdx.org%2Frdf%2F3.0.0%2F%22&type=code).


