### PR TITLE
AI and Dataset: Sort entries A-Z

### DIFF
--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -18,29 +18,36 @@ Metadata information that can be added to a package to describe an AI applicatio
 
 ## Properties
 
+- autonomyType
+  - type: /Core/PresenceType
+  - minCount: 0
+  - maxCount: 1
+- domain
+  - type: xsd:string
+  - minCount: 0
 - energyConsumption
   - type: EnergyConsumption
   - minCount: 0
   - maxCount: 1
-- standardCompliance
-  - type: xsd:string
+- hyperparameter
+  - type: /Core/DictionaryEntry
   - minCount: 0
-- limitation
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- typeOfModel
-  - type: xsd:string
-  - minCount: 0
-- informationAboutTraining
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
 - informationAboutApplication
   - type: xsd:string
   - minCount: 0
   - maxCount: 1
-- hyperparameter
+- informationAboutTraining
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- limitation
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- metric
+  - type: /Core/DictionaryEntry
+  - minCount: 0
+- metricDecisionThreshold
   - type: /Core/DictionaryEntry
   - minCount: 0
 - modelDataPreprocessing
@@ -49,30 +56,26 @@ Metadata information that can be added to a package to describe an AI applicatio
 - modelExplainability
   - type: xsd:string
   - minCount: 0
-- useSensitivePersonalInformation
-  - type: /Core/PresenceType
-  - minCount: 0
-  - maxCount: 1
-- metricDecisionThreshold
-  - type: /Core/DictionaryEntry
-  - minCount: 0
-- metric
-  - type: /Core/DictionaryEntry
-  - minCount: 0
-- domain
-  - type: xsd:string
-  - minCount: 0
-- autonomyType
-  - type: /Core/PresenceType
-  - minCount: 0
-  - maxCount: 1
 - safetyRiskAssessment
   - type: SafetyRiskAssessmentType
+  - minCount: 0
+  - maxCount: 1
+- standardCompliance
+  - type: xsd:string
+  - minCount: 0
+- typeOfModel
+  - type: xsd:string
+  - minCount: 0
+- useSensitivePersonalInformation
+  - type: /Core/PresenceType
   - minCount: 0
   - maxCount: 1
 
 ## External properties restrictions
 
+- /Core/Artifact/releaseTime
+  - minCount: 1
+  - maxCount: 1
 - /Core/Artifact/suppliedBy
   - minCount: 1
   - maxCount: 1
@@ -83,8 +86,5 @@ Metadata information that can be added to a package to describe an AI applicatio
   - minCount: 1
   - maxCount: 1
 - /Software/SoftwareArtifact/primaryPurpose
-  - minCount: 1
-  - maxCount: 1
-- /Core/Artifact/releaseTime
   - minCount: 1
   - maxCount: 1

--- a/model/AI/Classes/EnergyConsumption.md
+++ b/model/AI/Classes/EnergyConsumption.md
@@ -17,9 +17,9 @@ The class used for denoting the training energy consumption, inference energy co
 
 ## Properties
 
-- trainingEnergyConsumption
-  - type: EnergyConsumptionDescription
 - finetuningEnergyConsumption
   - type: EnergyConsumptionDescription
 - inferenceEnergyConsumption
+  - type: EnergyConsumptionDescription
+- trainingEnergyConsumption
   - type: EnergyConsumptionDescription

--- a/model/AI/Properties/hyperparameter.md
+++ b/model/AI/Properties/hyperparameter.md
@@ -18,7 +18,7 @@ hyperparameters manually or through a process of hyperparameter tuning
 
 Examples of hyperparameters include learning rate, batch size, and the number
 of layers in a neural network.
- 
+
 ## Metadata
 
 - name: hyperparameter

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -18,38 +18,6 @@ Metadata information that can be added to a dataset that may be used in a softwa
 
 ## Properties
 
-- datasetType
-  - type: DatasetType
-  - minCount: 1
-- dataCollectionProcess
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- intendedUse
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- datasetSize
-  - type: xsd:nonNegativeInteger
-  - minCount: 0
-  - maxCount: 1
-- datasetNoise
-  - type: xsd:string
-  - minCount: 0
-  - maxCount: 1
-- dataPreprocessing
-  - type: xsd:string
-  - minCount: 0
-- sensor
-  - type: /Core/DictionaryEntry
-  - minCount: 0
-- knownBias
-  - type: xsd:string
-  - minCount: 0
-- hasSensitivePersonalInformation
-  - type: /Core/PresenceType
-  - minCount: 0
-  - maxCount: 1
 - anonymizationMethodUsed
   - type: xsd:string
   - minCount: 0
@@ -57,29 +25,61 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - type: ConfidentialityLevelType
   - minCount: 0
   - maxCount: 1
-- datasetUpdateMechanism
+- dataCollectionProcess
   - type: xsd:string
   - minCount: 0
   - maxCount: 1
+- dataPreprocessing
+  - type: xsd:string
+  - minCount: 0
 - datasetAvailability
   - type: DatasetAvailabilityType
   - minCount: 0
   - maxCount: 1
+- datasetNoise
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- datasetSize
+  - type: xsd:nonNegativeInteger
+  - minCount: 0
+  - maxCount: 1
+- datasetType
+  - type: DatasetType
+  - minCount: 1
+- datasetUpdateMechanism
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- hasSensitivePersonalInformation
+  - type: /Core/PresenceType
+  - minCount: 0
+  - maxCount: 1
+- intendedUse
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: 1
+- knownBias
+  - type: xsd:string
+  - minCount: 0
+- sensor
+  - type: /Core/DictionaryEntry
+  - minCount: 0
 
 ## External properties restrictions
 
+- /Core/Artifact/builtTime
+  - minCount: 1
+  - maxCount: 1
 - /Core/Artifact/originatedBy
+  - minCount: 1
+  - maxCount: 1
+- /Core/Artifact/releaseTime
   - minCount: 1
   - maxCount: 1
 - /Software/Package/downloadLocation
   - minCount: 1
   - maxCount: 1
 - /Software/SoftwareArtifact/primaryPurpose
-  - minCount: 1
-  - maxCount: 1
-- /Core/Artifact/releaseTime
-  - minCount: 1
-  - maxCount: 1
-- /Core/Artifact/builtTime
   - minCount: 1
   - maxCount: 1

--- a/model/Dataset/Vocabularies/DatasetType.md
+++ b/model/Dataset/Vocabularies/DatasetType.md
@@ -16,17 +16,17 @@ Describes the different structures of data within a given dataset. A dataset can
 
 ## Entries
 
-- structured: data is stored in tabular format or retrieved from a relational database.
-- numeric: data consists only of numeric entries.
-- text: data consists of unstructured text, such as a book, wikipedia article (without images), or transcript.
+- audio: data is audio based, such as a collection of music from the 80s.
 - categorical: data that is classified into a discrete number of categories, such as the eye color of a population of people.
 - graph: data is in the form of a graph where entries are somehow related to each other through edges, such a social network of friends.
+- image: data is a collection of images such as pictures of animals.
+- numeric: data consists only of numeric entries.
+- sensor: data is recorded from a physical sensor, such as a thermometer reading or biometric device.
+- structured: data is stored in tabular format or retrieved from a relational database.
+- syntactic: data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing.
+- text: data consists of unstructured text, such as a book, Wikipedia article (without images), or transcript.
 - timeseries: data is recorded in an ordered sequence of timestamped entries, such as the price of a stock over the course of a day.
 - timestamp: data is recorded with a timestamp for each entry, but not necessarily ordered or at specific intervals, such as when a taxi ride starts and ends.
-- sensor: data is recorded from a physical sensor, such as a thermometer reading or biometric device.
-- image: data is a collection of images such as pictures of animals.
-- syntactic: data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing.
-- audio: data is audio based, such as a collection of music from the 80s.
 - video: data is video based, such as a collection of movie clips featuring Tom Hanks.
 - other: data is of a type not included in this list.
 - noAssertion: data type is not known.


### PR DESCRIPTION
As some lists are getting long and it is inconvenient to find an entry in an unsorted list. 

Sorting rules:
- Do not alphabetically sort the list that is already semantically sorted, such as by level of intensity (as in SafetyRiskAssessmentType, ConfidentialityLevelType, DatasetAvailabilityType)
- Sort A-Z
- Keep `other` and `noAssertion` at the end of the list