### PR TITLE
Change security externalIdentifierType in example

### DIFF
--- a/model/Security/Classes/Vulnerability.md
+++ b/model/Security/Classes/Vulnerability.md
@@ -33,7 +33,7 @@ Specifies a vulnerability and its associated information.
     },
     {
       "type": "ExternalIdentifier",
-      "externalIdentifierType": "securityOther",
+      "externalIdentifierType": "securityAdvisory",
       "identifier": "GHSA-r9p9-mrjm-926w",
       "identifierLocator": "https://github.com/advisories/GHSA-r9p9-mrjm-926w"
     },


### PR DESCRIPTION
Update the Vulnerability class syntax example to change the externalIdentifierType from securityOther to securityAdvisory for a GitHub advisory because it references a well known advisory source.

Thanks @puerco for catching this.