### PR TITLE
Add SupportRelationship

### DIFF
--- a/model/Core/Classes/SupportRelationship.md
+++ b/model/Core/Classes/SupportRelationship.md
@@ -1,0 +1,37 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# SupportRelationship
+
+## Summary
+
+Describes how an Agent Provides Support for an Artifact
+
+## Description
+
+Specifies how an Agent supports a given Artifact. The Relationship Type must be
+`providesSupportFor`. The `from` of the relationship is the `Agent` providing
+support, and the `to` are the `Artifact` for which support is being provided.
+
+`startTime` and `endTime` are mandatory when using this class.
+
+## Metadata
+
+- name: SupportRelationship
+- SubclassOf: Relationship
+- Instantiability: Concrete
+
+## Properties
+
+- supportLevel
+  - type: SupportType
+  - minCount: 1
+  - maxCount: 1
+
+## External properties restrictions
+
+- /Core/Relationship/startTime
+  - minCount: 1
+  - maxCount: 1
+- /Core/Relationship/endTime
+  - minCount: 1
+  - maxCount: 1

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -77,6 +77,7 @@ name completes the sentence:
 - other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationship types (this relationship is directionless).
 - packagedBy: Every `to` Element is a packaged instance of the `from` Element (`from` packagedBy `to`).
 - patchedBy: Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`).
+- providesSupportFor: The `from` Agent provides support for each `to` Artifact. Must be a `SupportRelationship` type.
 - publishedBy: Designates a `from` Vulnerability was made available for public use or reference by each `to` Agent.
 - reportedBy: Designates a `from` Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent.
 - republishedBy: Designates a `from` Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by each `to` Agent.


### PR DESCRIPTION
Adds a new SupportRelationship that uses a derived Relationship to indicate support, since this allows associating the support with a specific entity.