### PR TITLE
Add .editorconfig and .gitattributes to enforce newline and whitespace consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# See also http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.md text eol=lf
+*.yml text eol=lf
+*.txt text eol=lf
+*.py text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.pdf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,12 +3,13 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
+*.json text eol=lf
 *.md text eol=lf
-*.yml text eol=lf
-*.txt text eol=lf
 *.py text eol=lf
+*.txt text eol=lf
+*.yml text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
-*.png binary
 *.jpg binary
 *.pdf binary
+*.png binary


### PR DESCRIPTION
Copying configurations from `spdx/spdx-spec` repo (sorted):

- https://github.com/spdx/spdx-spec/blob/development/v3.0.1/.editorconfig
- https://github.com/spdx/spdx-spec/blob/development/v3.0.1/.gitattributes