### PR TITLE
Core: Update ProfileIdentifierType entries

### DIFF
--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -17,7 +17,7 @@ The profile may also contain additional restrictions on existing properties and
 classes defined in other profiles.
 
 If the creator of an SPDX collection of elements includes a profile in the list
-of conformanceProfiles, they are claiming that all contained elements conform
+of profileConformance, they are claiming that all contained elements conform
 to all restrictions defined for that profile.
 
 ## Metadata
@@ -33,7 +33,6 @@ to all restrictions defined for that profile.
 - expandedLicensing: the element follows the expanded Licensing profile
   specification
 - extension: the element follows the Extension profile specification
-- licensing: the element follows the Licensing profile specification
 - lite: the element follows the Lite profile specification
 - security: the element follows the Security profile specification
 - simpleLicensing: the element follows the simple Licensing profile

--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -26,15 +26,15 @@ to all restrictions defined for that profile.
 
 ## Entries
 
-- ai: the element follows the AI profile specification
-- build: the element follows the Build profile specification
 - core: the element follows the Core profile specification
-- dataset: the element follows the Dataset profile specification
-- expandedLicensing: the element follows the expanded Licensing profile
-  specification
-- extension: the element follows the Extension profile specification
-- lite: the element follows the Lite profile specification
-- security: the element follows the Security profile specification
+- software: the element follows the Software profile specification
 - simpleLicensing: the element follows the simple Licensing profile
   specification
-- software: the element follows the Software profile specification
+- expandedLicensing: the element follows the expanded Licensing profile
+  specification
+- security: the element follows the Security profile specification
+- build: the element follows the Build profile specification
+- ai: the element follows the AI profile specification
+- dataset: the element follows the Dataset profile specification
+- extension: the element follows the Extension profile specification
+- lite: the element follows the Lite profile specification

--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -4,14 +4,21 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Enumeration of the valid profiles. 
+Enumeration of the valid profiles.
 
 ## Description
 
 There are a set of profiles that have been defined by a profile team.
-A profile consists of a namespace that may add properties and classes to the core profile unique to the domain covered by the profile.
-The profile may also contain additional restrictions on existing properties and classes defined in other profiles.
-If the creator of an SPDX collection of elements includes a profile in the list of conformanceProfiles, they are claiming that all contained elements conform to all restrictions defined for that profile.
+
+A profile consists of a namespace that may add properties and classes to the
+core profile unique to the domain covered by the profile.
+
+The profile may also contain additional restrictions on existing properties and
+classes defined in other profiles.
+
+If the creator of an SPDX collection of elements includes a profile in the list
+of conformanceProfiles, they are claiming that all contained elements conform
+to all restrictions defined for that profile.
 
 ## Metadata
 
@@ -19,13 +26,16 @@ If the creator of an SPDX collection of elements includes a profile in the list 
 
 ## Entries
 
-- core: the element follows the Core profile specification
-- software: the element follows the Software profile specification
-- simpleLicensing: the element follows the simple Licensing profile specification
-- expandedLicensing: the element follows the expanded Licensing profile specification
-- security: the element follows the Security profile specification
-- build: the element follows the Build profile specification
 - ai: the element follows the AI profile specification
+- build: the element follows the Build profile specification
+- core: the element follows the Core profile specification
 - dataset: the element follows the Dataset profile specification
-- usage: the element follows the Usage profile specification
+- expandedLicensing: the element follows the expanded Licensing profile
+  specification
 - extension: the element follows the Extension profile specification
+- licensing: the element follows the Licensing profile specification
+- lite: the element follows the Lite profile specification
+- security: the element follows the Security profile specification
+- simpleLicensing: the element follows the simple Licensing profile
+  specification
+- software: the element follows the Software profile specification


### PR DESCRIPTION
- Remove non-existing `usage` profile (for 3.0, it got pushed to 3.1 see: #191)
- Add missing `lite` profile
- <s>Sort entries (will make it easier to spot anything missing in the future)</s>

This will fix #735 as reported by @vargenau