### PR TITLE
Use consistent case.

### DIFF
--- a/model/Core/Classes/Bom.md
+++ b/model/Core/Classes/Bom.md
@@ -9,7 +9,7 @@ A container for a grouping of SPDX-3.0 content characterizing details
 
 ## Description
 
-A Bill Of Materials (BOM) is a container for a grouping of SPDX-3.0 content
+A Bill of Materials (BOM) is a container for a grouping of SPDX-3.0 content
 characterizing details about a product.
 This could include details of the content and composition of the product,
 provenence details of the product and/or


### PR DESCRIPTION
"Bill of Materials" is always written with "of" in the spec.