### PR TITLE
Fix license relationship type

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -24,8 +24,8 @@ For an element collection to be conformant with this profile,
 the following has to hold:
 
 1. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
-   of type `concludedLicense` having that element as its `from` property
+   of type `hasConcludedLicense` having that element as its `from` property
    and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
 2. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
-   of type `declaredLicense` having that element as its `from` property
+   of type `hasDeclaredLicense` having that element as its `from` property
    and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -23,10 +23,10 @@ For an element collection to be conformant with this profile,
 the following has to hold:
 
 1. for every `/Dataset/DatasetPackage` there MUST exist exactly one
-  `/Core/Relationship` of type `concludedLicense` having that element as its
+  `/Core/Relationship` of type `hasConcludedLicense` having that element as its
   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
   property.
 2. for every `/Dataset/DatasetPackage` there MUST exist exactly one
-  `/Core/Relationship` of type `declaredLicense` having that element as its
+  `/Core/Relationship` of type `hasDeclaredLicense` having that element as its
   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
   property.

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -10,26 +10,26 @@ facilitate compliance with typical license use cases.
 ## Description
 
 The Licensing profile only contains the additional requirement that any
-Software Artifact must have a concludedLicense Relationship.
+Software Artifact must have a Relationship of type hasConcludedLicense.
 
 Classes and Property restrictions are defined in the SimpleLicensingProfile
 (Classes and Properties associated with string license expressions) and in the
 ExpandedLicensingProfile (Classes and Properties used for a fully parsed syntax
 tree of license expressions).
 
-There are 2 relationship types related to licensing - declaredLicense and
-concludedLicense.
+There are 2 relationship types related to licensing - `hasDeclaredLicense` and
+`hasConcludedLicense`.
 
-***declaredLicense***
+***hasDeclaredLicense***
 
-A declaredLicense identifies the license information actually found in the
+A hasDeclaredLicense identifies the license information actually found in the
 Software Artifact, for example as detected by use of automated tooling.
 
 This field is not intended to capture license information obtained from an
 external source, such as a package's website. Such information can be
 included, as needed, in the concludedLicense field.
 
-A declaredLicense may be expressed differently in practice for different
+A hasDeclaredLicense may be expressed differently in practice for different
 types of Software Artifacts. For example:
 
 for Packages:
@@ -44,7 +44,8 @@ for Packages:
 for Files:
 
 - would include license info found in the File itself (e.g., license
-  header or notice, comments indicating the license, SPDX-License-Identifier expression)
+  header or notice, comments indicating the license, SPDX-License-Identifier
+  expression)
 - would not include license info found in a different file (e.g., LICENSE
   file in the top directory of a repository)
   
@@ -56,11 +57,11 @@ for Snippets:
   different File (e.g., comment at top of File if it is not within the
   Snippet, LICENSE file in the top directory of a repository)
 
-A declaredLicense relationship to NoneLicense indicates that the
+A hasDeclaredLicense relationship to NoneLicense indicates that the
 corresponding Package, File or Snippet contains no license information
 whatsoever.
 
-A declaredLicense relationship to NoAssertionLicense 
+A hasDeclaredLicense relationship to NoAssertionLicense
 indicates that one of the following applies:
 
 - the SPDX data creator has attempted to but cannot reach a reasonable
@@ -69,25 +70,25 @@ indicates that one of the following applies:
 - the SPDX data creator has intentionally provided no information (no meaning
   should be implied by doing so).
   
-If a declaredLicense relationship is not present, no assumptions can be made
-about whether or not a declaredLicense exists.
+If a hasDeclaredLicense relationship is not present, no assumptions can be made
+about whether or not a hasDeclaredLicense exists.
 
-Note that a missing declaredLicense is not the same as a relationship to
+Note that a missing hasDeclaredLicense is not the same as a relationship to
 NoAssertionLicense since the latter is a "known unknown" whereas no assumptions
-can be made from a missing declaredLicense relationship.
+can be made from a missing hasDeclaredLicense relationship.
 
 ***concludedLicense***
 
-A concludedLicense is the license identified by the SPDX data creator,
+A hasConcludedLicense is the license identified by the SPDX data creator,
 based on analyzing the license information in the Software Artifact
 and other information to arrive at a reasonably objective
 conclusion as to what license governs the Software Artifact.
 
-A concludedLicense relationship to NoneLicense indicates that the
+A hasConcludedLicense relationship to NoneLicense indicates that the
 SPDX data creator has looked and did not find any license information for this
 Software Artifact.
 
-A concludedLicense relationship to NoAssertionLicense
+A hasConcludedLicense relationship to NoAssertionLicense
 indicates that one of the following applies:
 
 - the SPDX data creator has attempted to but cannot reach a reasonable
@@ -96,19 +97,19 @@ indicates that one of the following applies:
 - the SPDX data creator has intentionally provided no information (no
   meaning should be implied by doing so).
 
-If a concludedLicense is not present, no assumptions can be made
-about whether or not a concludedLicense exists.
+If a hasConcludedLicense is not present, no assumptions can be made
+about whether or not a hasConcludedLicense exists.
 
-Note that a missing concludedLicense is not the same as a relationship to a
+Note that a missing hasConcludedLicense is not the same as a relationship to a
 NoAssertionLicense since the latter is a "known unknown" whereas no assumptions
-can be made from a missing concludedLicense relationship.
+can be made from a missing hasConcludedLicense relationship.
 
 A written explanation of a relationship to a NoAssertionLicense MAY be
 provided in the comment field for the relationship.
 
-If the concludedLicense for a Software Artifact is not the
-same as its declaredLicense, a written explanation SHOULD be provided in
-the concludedLicense relationship comment field.
+If the hasConcludedLicense for a Software Artifact is not the
+same as its hasDeclaredLicense, a written explanation SHOULD be provided in
+the hasConcludedLicense relationship comment field.
 
 ## Metadata
 
@@ -121,6 +122,6 @@ For an element collection to be conformant with this profile,
 the following has to hold:
 
 1. for every `/Software/SoftwareArtifact` there MUST exist exactly one
-   `/Core/Relationship` of type `concludedLicense` having that element as its
-   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   `/Core/Relationship` of type `hasConcludedLicense` having that element as
+   its `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -27,7 +27,7 @@ Software Artifact, for example as detected by use of automated tooling.
 
 This field is not intended to capture license information obtained from an
 external source, such as a package's website. Such information can be
-included, as needed, in the concludedLicense field.
+included, as needed, in the hasConcludedLicense field.
 
 A hasDeclaredLicense may be expressed differently in practice for different
 types of Software Artifacts. For example:
@@ -77,7 +77,7 @@ Note that a missing hasDeclaredLicense is not the same as a relationship to
 NoAssertionLicense since the latter is a "known unknown" whereas no assumptions
 can be made from a missing hasDeclaredLicense relationship.
 
-***concludedLicense***
+***hasConcludedLicense***
 
 A hasConcludedLicense is the license identified by the SPDX data creator,
 based on analyzing the license information in the Software Artifact

--- a/model/Lite/Lite.md
+++ b/model/Lite/Lite.md
@@ -42,10 +42,10 @@ the following has to hold:
 1. The mincount for `/Software/Package/packageVersion` is 1
 1. The mincount for `/Software/SoftwareArtifact/copyrightText` is 1
 1. for every `/Software/Package` there MUST exist exactly one
-   `/Core/Relationship` of type `concludedLicense` having that element as its
-   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   `/Core/Relationship` of type `hasConcludedLicense` having that element as
+   its `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.
 1. for every `/Software/Package` there MUST exist exactly one
-   `/Core/Relationship` of type `declaredLicense` having that element as its
+   `/Core/Relationship` of type `hasDeclaredLicense` having that element as its
    `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.

--- a/model/Software/Properties/attributionText.md
+++ b/model/Software/Properties/attributionText.md
@@ -19,12 +19,12 @@ materials, or another form.
 
 This field may describe where, or in which contexts, the acknowledgements
 need to be reproduced, but it is not required to do so. The SPDX data creator
-may also explain elsewhere (such as in a licenseComment field) how they intend
-for data in this field to be used.
+may also explain elsewhere (such as in a comment field) how they intend for
+data in this field to be used.
 
-An attributionText is is not meant to include the software Package, File or
-Snippet's actual complete license text (see concludedLicense to identify the
-corresponding license).
+An attributionText is not meant to include the software Package, File or
+Snippet's actual complete license text. Use hasConcludedLicense to identify the
+corresponding license.
 
 ## Metadata
 

--- a/serialization/lite.md
+++ b/serialization/lite.md
@@ -2,11 +2,16 @@
 
 ## Summary
 
-The SPDX Lite serialization specification defines a subset of the SPDX specification, from the point of view of use cases in some industries. SPDX Lite aims at the balance between the SPDX standard and actual workflows in some industries.
+The SPDX Lite serialization specification defines a subset of the SPDX
+specification, from the point of view of use cases in some industries.
+
+SPDX Lite aims at the balance between the SPDX standard and actual workflows in
+some industries.
 
 ## Supported SPDX Fields
 
-The SPDX Lite serialization supports a subset of the entire SPDX specification.  Any unsupported properties may result in a parsing error.
+The SPDX Lite serialization supports a subset of the entire SPDX specification.
+Any unsupported properties may result in a parsing error.
 
 The following classes and fields are supported within the Lite profile:
 
@@ -14,8 +19,6 @@ The following classes and fields are supported within the Lite profile:
   - /Core/Element/name
   - /Software/Package/packageVersion
   - /Software/Package/packageUrl
-  - /Software/SoftwareArtifact/concludedLicense
-  - /Software/SoftwareArtifact/declaredLicense
   - /Software/SoftwareArtifact/copyrightText
   
 TODO: Add remaining classes


### PR DESCRIPTION
- As there were changes in relationship type names in #548, documentation needed to be updated as well:
  - `concludedLicense` -> `hasConcludedLicense` (an entry from Core/Vocabularies/RelationshipType)
  - `declaredLicense` -> `hasDeclaredLicense` (an entry from Core/Vocabularies/RelationshipType)
- Also update the old name from 2.3 to its 3.0 equivalence
  - `licenseComment` -> `comment` (Core/comment)
  - see https://spdx.github.io/spdx-spec/v3.0/annexes/diffs-from-previous-editions/#licensecomment
- A Lite Profile documentation might need to be updated further
  - `concludedLicense` and `declaredLicense` are removed from the property list
  - No explanation yet about the license relationship in this PR
- Kudos to the validator in https://github.com/maxhbr/spdx3ToGraph to help spotting the issue.