### PR TITLE
AI: Energy consumption: Add examples and update desc

### DIFF
--- a/model/AI/Classes/EnergyConsumption.md
+++ b/model/AI/Classes/EnergyConsumption.md
@@ -17,16 +17,20 @@ during its training, fine-tuning, and inference stages.
 ```json
 {
   "type": "ai_EnergyConsumption",
-  "ai_trainingEnergyConsumption": {
-    "type": "ai_EnergyConsumptionDescription",
-    "ai_energyQuantity": 36.5,
-    "ai_energyUnit": "kilowattHour"
-  },
-  "ai_inferenceEnergyConsumption": {
-    "type": "ai_EnergyConsumptionDescription",
-    "ai_energyQuantity": 0.042,
-    "ai_energyUnit": "kilowattHour"
-  }
+  "ai_trainingEnergyConsumption": [
+    {
+      "type": "ai_EnergyConsumptionDescription",
+      "ai_energyQuantity": 36.5,
+      "ai_energyUnit": "kilowattHour"
+    }
+  ],
+  "ai_inferenceEnergyConsumption": [
+    {
+      "type": "ai_EnergyConsumptionDescription",
+      "ai_energyQuantity": 0.042,
+      "ai_energyUnit": "kilowattHour"
+    }
+  ]
 }
 ```
 

--- a/model/AI/Classes/EnergyConsumption.md
+++ b/model/AI/Classes/EnergyConsumption.md
@@ -4,8 +4,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A class for describing the energy consumption incurred by an AI model.
-throughout its lifecycle.
+A class for describing the energy consumption incurred by an AI model in
+different stages of its lifecycle.
 
 ## Description
 

--- a/model/AI/Classes/EnergyConsumption.md
+++ b/model/AI/Classes/EnergyConsumption.md
@@ -4,14 +4,31 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The class that contains properties to describe energy consumption incurred
-by an AI model in different stages of its lifecycle.
+A class for describing the energy consumption incurred by an AI model.
+throughout its lifecycle.
 
 ## Description
 
-The class used for denoting the training energy consumption, inference energy
-consumption and fine tuning energy consumption of the AI model(s) used in an AI
-system.
+A class to denote the known or estimated energy consumption of an AI model
+during its training, fine-tuning, and inference stages.
+
+**Syntax**
+
+```json
+{
+  "type": "ai_EnergyConsumption",
+  "ai_trainingEnergyConsumption": {
+    "type": "ai_EnergyConsumptionDescription",
+    "ai_energyQuantity": 36.5,
+    "ai_energyUnit": "kilowattHour"
+  },
+  "ai_inferenceEnergyConsumption": {
+    "type": "ai_EnergyConsumptionDescription",
+    "ai_energyQuantity": 0.042,
+    "ai_energyUnit": "kilowattHour"
+  }
+}
+```
 
 ## Metadata
 

--- a/model/AI/Classes/EnergyConsumption.md
+++ b/model/AI/Classes/EnergyConsumption.md
@@ -20,14 +20,14 @@ during its training, fine-tuning, and inference stages.
   "ai_trainingEnergyConsumption": [
     {
       "type": "ai_EnergyConsumptionDescription",
-      "ai_energyQuantity": 36.5,
+      "ai_energyQuantity": "36.5",
       "ai_energyUnit": "kilowattHour"
     }
   ],
   "ai_inferenceEnergyConsumption": [
     {
       "type": "ai_EnergyConsumptionDescription",
-      "ai_energyQuantity": 0.042,
+      "ai_energyQuantity": "0.042",
       "ai_energyUnit": "kilowattHour"
     }
   ]

--- a/model/AI/Classes/EnergyConsumptionDescription.md
+++ b/model/AI/Classes/EnergyConsumptionDescription.md
@@ -24,7 +24,7 @@ property `energyQuantity`, and `"kilowattHour"` as a value for property
 ```json
 {
   "type": "ai_EnergyConsumptionDescription",
-  "ai_energyQuantity": 0.042,
+  "ai_energyQuantity": "0.042",
   "ai_energyUnit": "kilowattHour"
 }
 ```

--- a/model/AI/Classes/EnergyConsumptionDescription.md
+++ b/model/AI/Classes/EnergyConsumptionDescription.md
@@ -12,8 +12,22 @@ used for measurement.
 This class is designed to store energy consumption data, including the quantity
 and the unit of measurement.
 
-The energyQuantity property stores the amount of energy consumed,
-and the energyUnit property stores the unit used for measurement.
+The `energyQuantity` property stores the amount of energy consumed,
+and the `energyUnit` property stores the unit used for measurement.
+
+For example, 0.0042 kilowatt-hour of energy will have `0.042` as a value for
+property `energyQuantity`, and `"kilowattHour"` as a value for property
+`energyUnit`.
+
+**Syntax**
+
+```json
+{
+  "type": "ai_EnergyConsumptionDescription",
+  "ai_energyQuantity": 0.042,
+  "ai_energyUnit": "kilowattHour"
+}
+```
 
 ## Metadata
 

--- a/model/AI/Properties/energyConsumption.md
+++ b/model/AI/Properties/energyConsumption.md
@@ -4,17 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Indicates the amount of energy consumed to train the AI model.
+Indicates the amount of energy consumption incurred by an AI model.
 
 ## Description
 
-A free-form text captures known or estimated energy consumption for the
-training of the AI model.
+Captures the energy consumption of an AI model, either known or estimated.
 
-In case not known, the estimation could be based on information about
-computational resources used (e.g. number of floating point operations --
-FLOPs), training time, type and quantity of processing units, and other
-relevant details related to the training.
+In the absence of direct measurements, one can estimate the energy consumption
+based on information about computational resources (e.g. number of floating
+point operations), training time, and other relevant training details.
 
 ## Metadata
 

--- a/model/AI/Properties/energyConsumption.md
+++ b/model/AI/Properties/energyConsumption.md
@@ -10,9 +10,10 @@ Indicates the amount of energy consumption incurred by an AI model.
 
 Captures the energy consumption of an AI model, either known or estimated.
 
-In the absence of direct measurements, one can estimate the energy consumption
-based on information about computational resources (e.g. number of floating
-point operations), training time, and other relevant training details.
+In the absence of direct measurements, an SPDX data creator may choose to
+estimate the energy consumption based on information about computational
+resources (e.g., number of floating-point operations), training time, and other
+relevant training details.
 
 ## Metadata
 


### PR DESCRIPTION
Update descriptions for
- energyConsumption property of AIPackage
  - Was mistakenly described as a "free-form text", which it is not.
  - Remove a specific reference to "training", as this property can be used for more than just training
- EnergyConsumption class
  - Add an example snippet
- EnergyConsumptionDescription class
  - Add an example snippet

This will close #767 and close #771

Thanks @VenkatTechnologist for comments.