### PR TITLE
trainedOn relationship type desc: "trained by" -> "trained on"

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -82,7 +82,7 @@ type is contrained to `VexFixedVulnAssessmentRelationship` classed relationships
 - reportedBy: (Security) Designates a `from` Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent
 - republishedBy: (Security) Designates a `from` Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by a `to` Agent(s)
 - serializedInArtifact: The `from` SPDXDocument can be found in a serialized form in each `to` Artifact
-- testedOn: (AI, Dataset) The `from` Element has been tested on the `to` Element
-- trainedOn: (AI, Dataset) The `from` Element has been trained by the `to` Element(s)
+- testedOn: (AI, Dataset) The `from` Element has been tested on the `to` Element(s)
+- trainedOn: (AI, Dataset) The `from` Element has been trained on the `to` Element(s)
 - underInvestigationFor: (Security/VEX) The `from` Vulnerability impact is being investigated for each `to` Element. The use of the `underInvestigationFor` type is contrained to `VexUnderInvestigationVulnAssessmentRelationship` classed relationships.
 - usesTool: The `from` Element uses each `to` Element as a tool during a LifecycleScopeType period.


### PR DESCRIPTION
Change from:

```text
The `from` Element has been trained by the `to` Element(s)
```

to:

```text
The `from` Element has been trained on the `to` Element(s)
```

- This will make the description consistent to the name of the type.
  - `testedOn` type description also use the phrase "tested on"
- Also to avoid confusion. "by" may signify that the `to` is an Agent, which is not the case here.
