### PR TITLE
Fix "low" entry of CvssSeverityType

### DIFF
--- a/model/Security/Vocabularies/CvssSeverityType.md
+++ b/model/Security/Vocabularies/CvssSeverityType.md
@@ -8,7 +8,21 @@ Specifies the CVSS base, temporal, threat, or environmental severity type.
 
 ## Description
 
-CvssSeverityType specifies the CVSS severity type, defined in the CVSS specifications as the textual representation of the numeric CVSS score. The severity type entries are inclusive of and applicable to enumerations found in CVSS versions [3](https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale) and [4](https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale). CvssSeverityType is a mandatory field because baseSeverity is required in the CVSS version [3.0](https://www.first.org/cvss/cvss-v3.0.json), [3.1](https://www.first.org/cvss/cvss-v3.1.json), and [4.0](https://www.first.org/cvss/cvss-v4.0.json) schemas. The field can be used to document the base, temporal, threat, or environmental severity.
+CvssSeverityType specifies the CVSS severity type, defined in the CVSS
+specifications as the textual representation of the numeric CVSS score.
+
+The severity type entries are inclusive of and applicable to enumerations found
+in CVSS versions
+[3](https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale)
+and
+[4](https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale).
+
+CvssSeverityType is a mandatory field because baseSeverity is required in the
+CVSS version [3.0](https://www.first.org/cvss/cvss-v3.0.json),
+[3.1](https://www.first.org/cvss/cvss-v3.1.json), and
+[4.0](https://www.first.org/cvss/cvss-v4.0.json) schemas.
+
+The field can be used to document the base, temporal, threat, or environmental severity.
 
 ## Metadata
 
@@ -18,6 +32,6 @@ CvssSeverityType specifies the CVSS severity type, defined in the CVSS specifica
 
 - critical: When a CVSS score is between 9.0 - 10.0
 - high: When a CVSS score is between 7.0 - 8.9
-- medium: When a CVSS score is between 4 - 6.9
-- low: When a CVSS score is between 0 - 3.9
-- none: When a CVSS score is 0
+- medium: When a CVSS score is between 4.0 - 6.9
+- low: When a CVSS score is between 0.1 - 3.9
+- none: When a CVSS score is 0.0

--- a/model/Security/Vocabularies/CvssSeverityType.md
+++ b/model/Security/Vocabularies/CvssSeverityType.md
@@ -8,21 +8,7 @@ Specifies the CVSS base, temporal, threat, or environmental severity type.
 
 ## Description
 
-CvssSeverityType specifies the CVSS severity type, defined in the CVSS
-specifications as the textual representation of the numeric CVSS score.
-
-The severity type entries are inclusive of and applicable to enumerations found
-in CVSS versions
-[3](https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale)
-and
-[4](https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale).
-
-CvssSeverityType is a mandatory field because baseSeverity is required in the
-CVSS version [3.0](https://www.first.org/cvss/cvss-v3.0.json),
-[3.1](https://www.first.org/cvss/cvss-v3.1.json), and
-[4.0](https://www.first.org/cvss/cvss-v4.0.json) schemas.
-
-The field can be used to document the base, temporal, threat, or environmental severity.
+CvssSeverityType specifies the CVSS severity type, defined in the CVSS specifications as the textual representation of the numeric CVSS score. The severity type entries are inclusive of and applicable to enumerations found in CVSS versions [3](https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale) and [4](https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale). CvssSeverityType is a mandatory field because baseSeverity is required in the CVSS version [3.0](https://www.first.org/cvss/cvss-v3.0.json), [3.1](https://www.first.org/cvss/cvss-v3.1.json), and [4.0](https://www.first.org/cvss/cvss-v4.0.json) schemas. The field can be used to document the base, temporal, threat, or environmental severity.
 
 ## Metadata
 


### PR DESCRIPTION
"low" entry should be for 0.1-3.9 range of CVSS score, not 0-3.9.

Current:
```markdown
- critical: When a CVSS score is between 9.0 - 10.0
- high: When a CVSS score is between 7.0 - 8.9
- medium: When a CVSS score is between 4 - 6.9
- low: When a CVSS score is between 0 - 3.9
- none: When a CVSS score is 0
```

Proposed fix:
```markdown
- critical: When a CVSS score is between 9.0 - 10.0
- high: When a CVSS score is between 7.0 - 8.9
- medium: When a CVSS score is between 4.0 - 6.9
- low: When a CVSS score is between 0.1 - 3.9
- none: When a CVSS score is 0.0
```

Refs:
<img width="500" alt="Qualitative Severity Rating Scale" src="https://github.com/user-attachments/assets/98835abe-f3cb-41f6-9631-1f7d110d6c8c">

- https://www.first.org/cvss/v3.0/specification-document#Qualitative-Severity-Rating-Scale
- https://www.first.org/cvss/v4.0/specification-document#Qualitative-Severity-Rating-Scale