### PR TITLE
NamespaceMap: Remove TODO and fix caps

### DIFF
--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -15,7 +15,7 @@ order to provide a more human-readable and smaller serialized representation of
 the Elements.
 
 For details of how NamespaceMap content is to be serialized please refer to
-[Model and Serializations](../../../docs/serializations.md)
+the [Model and Serializations](../../../docs/serializations.md) clause
 and the various serialization format-specific .md files in
 [spdx-3-model repository](https://github.com/spdx/spdx-3-model/tree/main/serialization).
 

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -15,7 +15,7 @@ order to provide a more human-readable and smaller serialized representation of
 the Elements.
 
 For details of how NamespaceMap content is to be serialized please refer to
-[general SPDX serialization guidance](https://github.com/spdx/spdx-3-model/tree/main/serialization#readme/)
+[Model and Serializations](../../../docs/serializations.md)
 and the various serialization format-specific .md files in
 [spdx-3-model repository](https://github.com/spdx/spdx-3-model/tree/main/serialization).
 

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -15,37 +15,39 @@ order to provide a more human-readable and smaller serialized representation of
 the Elements.
 
 For details of how NamespaceMap content is to be serialized please refer to
-general SPDX serialization guidance at
-<https://github.com/spdx/spdx-3-model/blob/main/serialization/README.md>
-and the various serialization format specific .md filed under
-<https://github.com/spdx/spdx-3-model/tree/main/serialization>.
+[general SPDX serialization guidance](https://github.com/spdx/spdx-3-model/tree/main/serialization#readme/)
+and the various serialization format-specific .md files in
+[spdx-3-model repository](https://github.com/spdx/spdx-3-model/tree/main/serialization).
 
 Namespace maps support a variety of relevant use cases such as:
 
 1. An SPDX content producer wishing to provide clarity of their serialization
-  of an SPDX 2.X simple style collection where all content is newly minted and
-  a single prefix-namespace is used. The consumer of SPDX content wishes to
-  preserve the name space mapping provided by such a producer. In this case,
-  the consumer would record the namespace map prefixes in the NamespaceMap such
-  that subsequent serializations could reproduce the prefixes / namespaces in
-  the native serialization format.
+    of an SPDX 2.X simple style collection where all content is newly minted
+    and a single prefix-namespace is used. The consumer of SPDX content wishes
+    to preserve the name space mapping provided by such a producer.
+
+    In this case, the consumer would record the namespace map prefixes in the
+    NamespaceMap such that subsequent serializations could reproduce the
+    prefixes / namespaces in the native serialization format.
 
 2. An SPDX content producer wishing to maintain consistent prefix use and
-  understanding across multiple different serialization formats of the produced
-  content.
-  For example, an SBOM producer wishes to share/publish the SBOM as JSON-LD and
-  XML. The producer can specify the preferred prefix mappings in the native
-  serialization format using information from a single NamespaceMap accessible
-  local to the producer.
+    understanding across multiple different serialization formats of the
+    produced content.
+  
+    For example, an SBOM producer wishes to share/publish the SBOM as JSON-LD
+    and XML. The producer can specify the preferred prefix mappings in the
+    native serialization format using information from a single NamespaceMap
+    accessible local to the producer.
 
 3. An SPDX content consumer/producer wishing to maintain consistent prefix use
-  while round tripping from SPDX content received, deserialized,
-  modified/extended in some way, and then reserialized in the same
-  serialization form.
-  In this case the prefix-namespace mappings utilized in the content are
-  transformed from the original native namespace/prefix into the in memory
-  NamespaceMap then transformed from the NamespaceMap back into the resultant
-  serialization native namespace / prefix format.
+    while round tripping from SPDX content received, deserialized,
+    modified/extended in some way, and then reserialized in the same
+    serialization form.
+
+    In this case the prefix-namespace mappings utilized in the content are
+    transformed from the original native namespace/prefix into the in memory
+    NamespaceMap then transformed from the NamespaceMap back into the resultant
+    serialization native namespace / prefix format.
 
 ## Metadata
 

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -18,8 +18,7 @@ For details of how NamespaceMap content is to be serialized please refer to
 general SPDX serialization guidance at
 <https://github.com/spdx/spdx-3-model/blob/main/serialization/README.md>
 and the various serialization format specific .md filed under
-<https://github.com/spdx/spdx-3-model/tree/main/serialization>
-(TODO: update the URLs as soon as the context is publicly available)
+<https://github.com/spdx/spdx-3-model/tree/main/serialization>.
 
 Namespace maps support a variety of relevant use cases such as:
 
@@ -36,7 +35,7 @@ Namespace maps support a variety of relevant use cases such as:
   content.
   For example, an SBOM producer wishes to share/publish the SBOM as JSON-LD and
   XML. The producer can specify the preferred prefix mappings in the native
-  serialization format using information from a single Namespacemap accessible
+  serialization format using information from a single NamespaceMap accessible
   local to the producer.
 
 3. An SPDX content consumer/producer wishing to maintain consistent prefix use

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -16,7 +16,7 @@ the Elements.
 
 For details of how NamespaceMap content is to be serialized please refer to
 the [Model and Serializations](../../../docs/serializations.md) clause
-and the various serialization format-specific .md files in
+and the various serialization format-specific files in
 [spdx-3-model repository](https://github.com/spdx/spdx-3-model/tree/main/serialization).
 
 Namespace maps support a variety of relevant use cases such as:


### PR DESCRIPTION
- Remove "TODO" as the URLs are already updated. (although they are all pointing directly to the repo: https://github.com/spdx/spdx-3-model/ - is this something we are preferred?)
- Also use 4-space indent for list, to keep the multiple paragraphs rendered correctly.
