### PR TITLE
Remove unnecessary restrictions

### DIFF
--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -75,16 +75,11 @@ Metadata information that can be added to a package to describe an AI applicatio
 
 - /Core/Artifact/releaseTime
   - minCount: 1
-  - maxCount: 1
 - /Core/Artifact/suppliedBy
   - minCount: 1
-  - maxCount: 1
 - /Software/Package/downloadLocation
   - minCount: 1
-  - maxCount: 1
 - /Software/Package/packageVersion
   - minCount: 1
-  - maxCount: 1
 - /Software/SoftwareArtifact/primaryPurpose
   - minCount: 1
-  - maxCount: 1

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -70,16 +70,12 @@ Metadata information that can be added to a dataset that may be used in a softwa
 
 - /Core/Artifact/builtTime
   - minCount: 1
-  - maxCount: 1
 - /Core/Artifact/originatedBy
   - minCount: 1
   - maxCount: 1
 - /Core/Artifact/releaseTime
   - minCount: 1
-  - maxCount: 1
 - /Software/Package/downloadLocation
   - minCount: 1
-  - maxCount: 1
 - /Software/SoftwareArtifact/primaryPurpose
   - minCount: 1
-  - maxCount: 1

--- a/model/Security/Classes/VulnAssessmentRelationship.md
+++ b/model/Security/Classes/VulnAssessmentRelationship.md
@@ -40,7 +40,3 @@ assessment relationships. It factors out the common properties shared by them.
   - minCount: 0
   - maxCount: 1
 
-## External properties restrictions
-
-- /Core/Relationship/to
-  - minCount: 1


### PR DESCRIPTION
Now that spec-parser processes and check external property restrictions, the following warnings were generated:

> WARNING: In class `/AI/AIPackage` property `/Core/Artifact/releaseTime` has same `maxCount` as the parent class
> WARNING: In class `/AI/AIPackage` property `/Core/Artifact/suppliedBy` has same `maxCount` as the parent class
> WARNING: In class `/AI/AIPackage` property `/Software/Package/downloadLocation` has same `maxCount` as the parent class
> WARNING: In class `/AI/AIPackage` property `/Software/Package/packageVersion` has same `maxCount` as the parent class
> WARNING: In class `/AI/AIPackage` property `/Software/SoftwareArtifact/primaryPurpose` has same `maxCount` as the parent class
> WARNING: In class `/Dataset/DatasetPackage` property `/Core/Artifact/builtTime` has same `maxCount` as the parent class
> WARNING: In class `/Dataset/DatasetPackage` property `/Core/Artifact/releaseTime` has same `maxCount` as the parent class
> WARNING: In class `/Dataset/DatasetPackage` property `/Software/Package/downloadLocation` has same `maxCount` as the parent class
> WARNING: In class `/Dataset/DatasetPackage` property `/Software/SoftwareArtifact/primaryPurpose` has same `maxCount` as the parent class
> WARNING: In class `/Security/VulnAssessmentRelationship` property `/Core/Relationship/to` has same `minCount` as the parent class

This PR removes these unnecessary external property restrictions.

