### PR TITLE
Change URIs to 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ These files are automatically processed by
 and the following are generated:
 
 - [MkDocs](https://www.mkdocs.org/) input, which then generates the
-  [specification](https://spdx.github.io/spdx-spec/v3.0/)
+  [specification](https://spdx.github.io/spdx-spec/v3.0.1/)
 - [JSON-LD context](http://niem.github.io/json/reference/json-ld/context/)
-  file: [spdx-context.jsonld](https://spdx.org/rdf/3.0.0/spdx-context.jsonld)
+  file: [spdx-context.jsonld](https://spdx.org/rdf/3.0.1/spdx-context.jsonld)
 - Model [SHACL](https://en.wikipedia.org/wiki/SHACL) and
   [OWL](https://www.w3.org/OWL/) files:
   - [Turtle format](https://en.wikipedia.org/wiki/Turtle_(syntax)):
-    [spdx-model.ttl](https://spdx.org/rdf/3.0.0/spdx-model.ttl)
+    [spdx-model.ttl](https://spdx.org/rdf/3.0.1/spdx-model.ttl)
   - [JSON-LD format](https://json-ld.org/):
     [model.jsonld](https://spdx.github.io/spdx-3-model/model.jsonld)
 

--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -15,7 +15,7 @@ development process, such as software packages, models, and datasets.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/AI
+- id: https://spdx.org/rdf/3.0.1/terms/AI
 - name: AI
 
 ## Profile conformance

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -45,7 +45,7 @@ the nature of these inputs are not known at the creation of an SPDX document.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Build
+- id: https://spdx.org/rdf/3.0.1/terms/Build
 - name: Build
 
 ## Profile Conformance

--- a/model/Core/Core.md
+++ b/model/Core/Core.md
@@ -13,5 +13,5 @@ SPDX-3.0 profiles.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Core
+- id: https://spdx.org/rdf/3.0.1/terms/Core
 - name: Core

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -14,7 +14,7 @@ preparation process, its characteristics, and its access methods.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Dataset
+- id: https://spdx.org/rdf/3.0.1/terms/Dataset
 - name: Dataset
 
 ## Profile conformance

--- a/model/ExpandedLicensing/ExpandedLicensing.md
+++ b/model/ExpandedLicensing/ExpandedLicensing.md
@@ -13,5 +13,5 @@ object form.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/ExpandedLicensing
+- id: https://spdx.org/rdf/3.0.1/terms/ExpandedLicensing
 - name: ExpandedLicensing

--- a/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
@@ -21,7 +21,7 @@ NoAssertionLicense should be used if
 
 - name: NoAssertionLicense
 - type: IndividualLicensingInfo
-- IRI: https://spdx.org/rdf/3.0.0/terms/Licensing/NoAssertion
+- IRI: https://spdx.org/rdf/3.0.1/terms/Licensing/NoAssertion
 
 ## Property Values
 

--- a/model/ExpandedLicensing/Individuals/NoneLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoneLicense.md
@@ -16,7 +16,7 @@ available for this Artifact.
 
 - name: NoneLicense
 - type: IndividualLicensingInfo
-- IRI: https://spdx.org/rdf/3.0.0/terms/Licensing/None
+- IRI: https://spdx.org/rdf/3.0.1/terms/Licensing/None
 
 ## Property Values
 

--- a/model/Extension/Extension.md
+++ b/model/Extension/Extension.md
@@ -13,5 +13,5 @@ base for all defined extension subclasses.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Extension
+- id: https://spdx.org/rdf/3.0.1/terms/Extension
 - name: Extension

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -113,7 +113,7 @@ the hasConcludedLicense relationship comment field.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Licensing
+- id: https://spdx.org/rdf/3.0.1/terms/Licensing
 - name: Licensing
 
 ## Profile conformance

--- a/model/Lite/Lite.md
+++ b/model/Lite/Lite.md
@@ -27,7 +27,7 @@ supply chains.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Lite
+- id: https://spdx.org/rdf/3.0.1/terms/Lite
 - name: Lite
 
 ## Profile conformance

--- a/model/Security/Security.md
+++ b/model/Security/Security.md
@@ -12,5 +12,5 @@ The Security Profile captures security related information.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Security
+- id: https://spdx.org/rdf/3.0.1/terms/Security
 - name: Security

--- a/model/SimpleLicensing/SimpleLicensing.md
+++ b/model/SimpleLicensing/SimpleLicensing.md
@@ -22,5 +22,5 @@ license expressions.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/SimpleLicensing
+- id: https://spdx.org/rdf/3.0.1/terms/SimpleLicensing
 - name: SimpleLicensing

--- a/model/Software/Software.md
+++ b/model/Software/Software.md
@@ -12,5 +12,5 @@ The Software namespace defines concepts related to software artifacts.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.0.0/terms/Software
+- id: https://spdx.org/rdf/3.0.1/terms/Software
 - name: Software


### PR DESCRIPTION
This updates the URIs of the model terms to refer to 3.0.1.

As decided in the tech call of 16 July 2024.

