### PR TITLE
Remove redundant maxCount of EpssVulnAssessmentRelationship

### DIFF
--- a/model/Security/Classes/EpssVulnAssessmentRelationship.md
+++ b/model/Security/Classes/EpssVulnAssessmentRelationship.md
@@ -57,4 +57,3 @@ scores, using the Exploit Prediction Scoring System (EPSS) as defined at
 
 - /Security/VulnAssessmentRelationship/publishedTime
   - minCount: 1
-  - maxCount: 1


### PR DESCRIPTION
Fix spec-parser's "has same maxCount as the parent class" warning.

In class /Security/EpssVulnAssessmentRelationship, property /Security/VulnAssessmentRelationship/publishedTime has same maxCount as the parent class.