### PR TITLE
[Build] Specify v0.2 version number for SLSA Provenance

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -16,7 +16,7 @@ etc.).
 
 Definitions of "buildType", "configSourceEntrypoint", "configSourceUri",
 "parameters" and "environment" follow those defined in
-[SLSA provenance](https://slsa.dev/provenance/v0.2).
+[SLSA Provenance v0.2](https://slsa.dev/provenance/v0.2).
 
 ExternalIdentifier of type "urlScheme" may be used to identify build logs.
 In this case, the comment of the ExternalIdentifier should be "LogReference".


### PR DESCRIPTION
In the [Build](https://github.com/spdx/spdx-3-model/blob/main/model/Build/Classes/Build.md) class description, a reference to "SLSA provenance" contains no version or date information.

> Definitions of "buildType", "configSourceEntrypoint", "configSourceUri",
"parameters" and "environment" follow those defined in
[SLSA provenance](https://slsa.dev/provenance/v0.2).

The "SLSA provenance" text links to https://slsa.dev/provenance/v0.2

This PR add "v0.2" to the text, to match the version in the URL.

This is also to make it explicit in the text about the desired version, which is necessary because:

- Normative References section states that:
  > For undated references, the latest edition of the referenced document (including any amendments) applies.
- The latest version of SLSA is 1.0 https://slsa.dev/provenance/v1
- `parameters` and `environment` are renamed to `externalParameters` and `internalParameters` in 1.0
- `configSource` (and its `.entryPoint` and `.uri`) is removed in 1.0
- See changes from 0.2 to 1.0 https://slsa.dev/spec/v1.0/provenance#v10