### PR TITLE
Make pseudocode indents even - PackageVerificationCode

### DIFF
--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -21,17 +21,17 @@ Algorithm:
     verificationcode = 0
     filelist = templist = ""
     for all files in the package {
-         if file is an "excludes" file, skip it /* exclude SPDX analysis file(s) */
-         else append templist with "algorithm(file)/n"
-        }
-        
-     sort templist in ascending order by algorithm value
-     
-     filelist = templist with "/n"s removed. /* ordered sequence of algorithm values with no separators */
-     
-     hashValue = algorithm(filelist) /* Where algorithm(file) applies a hash algorithm on the contents of file and returns the result in lowercase hexadecimal digits. */
+        if file is an "excludes" file, skip it /* exclude SPDX analysis file(s) */
+        else append templist with "algorithm(file)/n"
+    }
 
-Required sort order: '0','1','2','3','4','5','6','7','8','9','a','b','c','d','e','f' (ASCII order)
+    sort templist in ascending order by algorithm value
+
+    filelist = templist with "/n"s removed. /* ordered sequence of algorithm values with no separators */
+     
+    hashValue = algorithm(filelist) /* Where algorithm(file) applies a hash algorithm on the contents of file and returns the result in lowercase hexadecimal digits. */
+
+Required sort order: '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' (ASCII order)
 
 ## Metadata
 


### PR DESCRIPTION
PackageVerificationCode has various indent sizes in the pseudo code section,
make them even for better readability.

Also add a space between characters in sort order list for readability.