### PR TITLE
[Core] Add text labels to bare URLs

### DIFF
--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -10,7 +10,7 @@ A String constrained to the RFC 2046 specificiation.
 ## Description
 
 A MediaType is a string constrained to the
-[RFC 2046 specification (MIME Part Two: Media Types)](https://www.rfc-editor.org/rfc/rfc2046).
+[RFC 2046 MIME Part Two: Media Types](https://www.rfc-editor.org/info/rfc2046).
 It provides a standardized way of indicating the type of content of an Element
 or a Property.
 
@@ -25,7 +25,7 @@ or a Property.
 - `text/spdx`
 
 A list of all possible media types is available at
-<https://www.iana.org/assignments/media-types/media-types.xhtml>.
+[IANA Protocol Registries](https://www.iana.org/assignments/media-types/media-types.xhtml).
 
 ## Metadata
 

--- a/model/Core/Properties/packageVerificationCodeExcludedFile.md
+++ b/model/Core/Properties/packageVerificationCodeExcludedFile.md
@@ -13,7 +13,7 @@ A relative filename with the root of the package archive or directory
 referencing a file to be excluded from the `PackageVerificationCode`.
 
 In general, every filename is preceded with a `./`, see
-[http://www.ietf.org/rfc/rfc3986.txt](http://www.ietf.org/rfc/rfc3986.txt)
+[RFC 3986 Uniform Resource Identifier (URI): Generic Syntax](https://www.rfc-editor.org/info/rfc3986)
 for syntax.
 
 ## Metadata

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -33,7 +33,7 @@ ExternalRefType specifies the type of an external reference.
 - funding: A reference to funding information related to a package.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
-- mavenCentral: A reference to a Maven repository artifact. The package reference format, looks like `groupId:artifactId[:version]`, is defined in [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
+- mavenCentral: A reference to a Maven repository artifact. The artifact reference format, looks like `groupId:artifactId[:version]`, is defined in [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
 - metrics: A reference to metrics related to package such as OpenSSF scorecards.
 - npm: A reference to an npm package. The package reference format, looks like `package@version`, is defined in [npm Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
 - nuget: A reference to a NuGet package. The package reference format, looks like `package/version`, is defined in [NuGet documentation](https://docs.nuget.org).

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -19,7 +19,7 @@ ExternalRefType specifies the type of an external reference.
 - altDownloadLocation: A reference to an alternative download location.
 - altWebPage: A reference to an alternative web page.
 - binaryArtifact: A reference to binary artifacts related to a package.
-- bower: A reference to a Bower package. The package reference format, looks like `package#version`, is defined in the "install" section of [Bower API documentation](https://bower.io/docs/api/#install).
+- bower: A reference to a Bower package. The package locator format, looks like `package#version`, is defined in the "install" section of [Bower API documentation](https://bower.io/docs/api/#install).
 - buildMeta: A reference build metadata related to a published package.
 - buildSystem: A reference build system used to create or publish the package.
 - chat: A reference to the instant messaging system used by the maintainer for a package.
@@ -33,10 +33,10 @@ ExternalRefType specifies the type of an external reference.
 - funding: A reference to funding information related to a package.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
-- mavenCentral: A reference to a Maven repository artifact. The artifact reference format, looks like `groupId:artifactId[:version]`, is defined in [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
+- mavenCentral: A reference to a Maven repository artifact. The artifact locator format, looks like `groupId:artifactId[:version]`, is defined in [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
 - metrics: A reference to metrics related to package such as OpenSSF scorecards.
-- npm: A reference to an npm package. The package reference format, looks like `package@version`, is defined in [npm Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
-- nuget: A reference to a NuGet package. The package reference format, looks like `package/version`, is defined in [NuGet documentation](https://docs.nuget.org).
+- npm: A reference to an npm package. The package locator format, looks like `package@version`, is defined in [npm Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
+- nuget: A reference to a NuGet package. The package locator format, looks like `package/version`, is defined in [NuGet documentation](https://docs.nuget.org).
 - license: A reference to additional license information related to an artifact.
 - other: Used when the type does not match any of the other options.
 - privacyAssessment: A reference to a privacy assessment for a package.

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -19,7 +19,7 @@ ExternalRefType specifies the type of an external reference.
 - altDownloadLocation: A reference to an alternative download location.
 - altWebPage: A reference to an alternative web page.
 - binaryArtifact: A reference to binary artifacts related to a package.
-- bower: A reference to a bower package.
+- bower: A reference to a Bower package. The package reference format, looks like `package#version`, is defined in the "install" section of [Bower API documentation](https://bower.io/docs/api/#install).
 - buildMeta: A reference build metadata related to a published package.
 - buildSystem: A reference build system used to create or publish the package.
 - chat: A reference to the instant messaging system used by the maintainer for a package.
@@ -35,10 +35,10 @@ ExternalRefType specifies the type of an external reference.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
 - mavenCentral: A reference to a maven repository artifact.
 - metrics: A reference to metrics related to package such as OpenSSF scorecards.
-- npm: A reference to an npm package.
-- nuget: A reference to a nuget package.
+- npm: A reference to an npm package. The package reference format, looks like `package@version`, is defined in [npm Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
+- nuget: A reference to a NuGet package. The package reference format, looks like `package/version`, is defined in [NuGet documentation](https://docs.nuget.org).
 - license: A reference to additional license information related to an artifact.
-- other: Used when the type doesn't match any of the other options.
+- other: Used when the type does not match any of the other options.
 - privacyAssessment: A reference to a privacy assessment for a package.
 - productMetadata: A reference to additional product metadata such as reference within organization's product catalog.
 - purchaseOrder: A reference to a purchase order for a package.

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -25,7 +25,7 @@ ExternalRefType specifies the type of an external reference.
 - chat: A reference to the instant messaging system used by the maintainer for a package.
 - certificationReport: A reference to a certification report for a package from an accredited/independent body.
 - componentAnalysisReport: A reference to a Software Composition Analysis (SCA) report.
-- cwe: A reference to a source of software flaw defined within the official CWE Dictionary that conforms to the CWE specification as defined by https://csrc.nist.gov/glossary/term/common_weakness_enumeration.
+- cwe: [Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaw defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/).
 - documentation: A reference to the documentation for a package.
 - dynamicAnalysisReport: A reference to a dynamic analysis report for a package.
 - eolNotice: A reference to the End Of Sale (EOS) and/or End Of Life (EOL) information related to a package.
@@ -60,5 +60,5 @@ ExternalRefType specifies the type of an external reference.
 - staticAnalysisReport: A reference to a static analysis report for a package.
 - support: A reference to the software support channel or other support information for a package.
 - vcs: A reference to a version control system related to a software artifact.
-- vulnerabilityDisclosureReport: A reference to a Vulnerability Disclosure Report (VDR) which provides the software supplier's analysis and findings describing the impact (or lack of impact) that reported vulnerabilities have on packages or products in the supplier's SBOM as defined in [NIST SP 800-161](https://csrc.nist.gov/pubs/sp/800/161/r1/final).
+- vulnerabilityDisclosureReport: A reference to a Vulnerability Disclosure Report (VDR) which provides the software supplier's analysis and findings describing the impact (or lack of impact) that reported vulnerabilities have on packages or products in the supplier's SBOM as defined in [NIST SP 800-161 Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations](https://csrc.nist.gov/pubs/sp/800/161/r1/final).
 - vulnerabilityExploitabilityAssessment: A reference to a Vulnerability Exploitability eXchange (VEX) statement which provides information on whether a product is impacted by a specific vulnerability in an included package and, if affected, whether there are actions recommended to remediate. See also [NTIA VEX one-page summary](https://ntia.gov/files/ntia/publications/vex_one-page_summary.pdf).

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -33,7 +33,7 @@ ExternalRefType specifies the type of an external reference.
 - funding: A reference to funding information related to a package.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
-- mavenCentral: A reference to a maven repository artifact.
+- mavenCentral: A reference to a Maven repository artifact. The package reference format, looks like `groupId:artifactId[:version]`, is defined in [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html).
 - metrics: A reference to metrics related to package such as OpenSSF scorecards.
 - npm: A reference to an npm package. The package reference format, looks like `package@version`, is defined in [npm Docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
 - nuget: A reference to a NuGet package. The package reference format, looks like `package/version`, is defined in [NuGet documentation](https://docs.nuget.org).

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -48,7 +48,7 @@ ExternalRefType specifies the type of an external reference.
 - riskAssessment: A reference to a risk assessment for a package.
 - runtimeAnalysisReport: A reference to a runtime analysis report for a package.
 - secureSoftwareAttestation: A reference to information assuring that the software is developed using security practices as defined by [NIST SP 800-218 Secure Software Development Framework (SSDF) Version 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) or [CISA Secure Software Development Attestation Form](https://www.cisa.gov/resources-tools/resources/secure-software-development-attestation-form).
-- securityAdvisory: A reference to a published security advisory (where advisory as defined per ISO 29147:2018) that may affect one or more elements, e.g., vendor advisories or specific NVD entries.
+- securityAdvisory: A reference to a published security advisory (where advisory as defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries.
 - securityAdversaryModel: A reference to the security adversary model for a package.
 - securityFix: A reference to the patch or source code that fixes a vulnerability.
 - securityOther: A reference to related security information of unspecified type.

--- a/model/Core/Vocabularies/HashAlgorithm.md
+++ b/model/Core/Vocabularies/HashAlgorithm.md
@@ -8,8 +8,9 @@ A mathematical algorithm that maps data of arbitrary size to a bit string.
 
 ## Description
 
-A HashAlgorithm is a mathematical algorithm that maps data of arbitrary size to a bit string (the hash)
-and is a one-way function, that is, a function which is practically infeasible to invert.
+A HashAlgorithm is a mathematical algorithm that maps data of arbitrary size to
+a bit string (the hash) and is a one-way function, that is, a function which is
+practically infeasible to invert.
 
 ## Metadata
 
@@ -17,24 +18,24 @@ and is a one-way function, that is, a function which is practically infeasible t
 
 ## Entries
 
-- blake2b256: blake2b algorithm with a digest size of 256 https://datatracker.ietf.org/doc/html/rfc7693#section-4
-- blake2b384: blake2b algorithm with a digest size of 384 https://datatracker.ietf.org/doc/html/rfc7693#section-4
-- blake2b512: blake2b algorithm with a digest size of 512 https://datatracker.ietf.org/doc/html/rfc7693#section-4
-- blake3: https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf
-- crystalsKyber: https://pq-crystals.org/kyber/index.shtml
-- crystalsDilithium: https://pq-crystals.org/dilithium/index.shtml
-- falcon: https://falcon-sign.info/falcon.pdf
-- md2: https://datatracker.ietf.org/doc/rfc1319/
-- md4: https://datatracker.ietf.org/doc/html/rfc1186
-- md5: https://datatracker.ietf.org/doc/html/rfc1321
-- md6: https://people.csail.mit.edu/rivest/pubs/RABCx08.pdf
+- blake2b256: BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
+- blake2b384: BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
+- blake2b512: BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
+- blake3: [BLAKE3](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf)
+- crystalsDilithium: [Dilithium](https://pq-crystals.org/dilithium/)
+- crystalsKyber: [Kyber](https://pq-crystals.org/kyber/)
+- falcon: [FALCON](https://falcon-sign.info/falcon.pdf)
+- md2: MD2 message-digest algorithm, as defined in [RFC 1319](https://www.rfc-editor.org/info/rfc1319/).
+- md4: MD4 message-digest algorithm, as defined in [RFC 1186](https://www.rfc-editor.org/info/rfc1186).
+- md5: MD5 message-digest algorithm, as defined in [RFC 1321](https://www.rfc-editor.org/info/rfc1321).
+- md6: [MD6 hash function](https://people.csail.mit.edu/rivest/pubs/RABCx08.pdf)
 - other: any hashing algorithm that does not exist in this list of entries
-- sha1: https://datatracker.ietf.org/doc/html/rfc3174
-- sha224: secure hashing algorithm with a digest length of 224 https://datatracker.ietf.org/doc/html/draft-ietf-pkix-sha224-01
-- sha256: secure hashing algorithm with a digest length of 256 https://www.rfc-editor.org/rfc/rfc4634
-- sha3_224: sha3 with a digest length of 224 https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
-- sha3_256: sha3 with a digest length of 256 https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
-- sha3_384: sha3 with a digest length of 384 https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
-- sha3_512: sha3 with a digest length of 512 https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
-- sha384: secure hashing algorithm with a digest length of 384 https://www.rfc-editor.org/rfc/rfc4634
-- sha512: secure hashing algorithm with a digest length of 512 https://www.rfc-editor.org/rfc/rfc4634
+- sha1: SHA-1, a secure hashing algorithm, as defined in [RFC 3174](https://www.rfc-editor.org/info/rfc3174).
+- sha224: SHA-2 with a digest length of 224, as defined in [RFC 3874](https://www.rfc-editor.org/info/rfc3874).
+- sha256: SHA-2 with a digest length of 256, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
+- sha384: SHA-2 with a digest length of 384, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
+- sha512: SHA-2 with a digest length of 512, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
+- sha3_224: SHA-3 with a digest length of 224, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).
+- sha3_256: SHA-3 with a digest length of 256, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).
+- sha3_384: SHA-3 with a digest length of 384, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).
+- sha3_512: SHA-3 with a digest length of 512, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).

--- a/model/Core/Vocabularies/HashAlgorithm.md
+++ b/model/Core/Vocabularies/HashAlgorithm.md
@@ -32,9 +32,9 @@ practically infeasible to invert.
 - other: any hashing algorithm that does not exist in this list of entries
 - sha1: SHA-1, a secure hashing algorithm, as defined in [RFC 3174](https://www.rfc-editor.org/info/rfc3174).
 - sha224: SHA-2 with a digest length of 224, as defined in [RFC 3874](https://www.rfc-editor.org/info/rfc3874).
-- sha256: SHA-2 with a digest length of 256, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
-- sha384: SHA-2 with a digest length of 384, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
-- sha512: SHA-2 with a digest length of 512, as defined in [RFC 6234](https://www.rfc-editor.org/rfc/rfc6234).
+- sha256: SHA-2 with a digest length of 256, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234).
+- sha384: SHA-2 with a digest length of 384, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234).
+- sha512: SHA-2 with a digest length of 512, as defined in [RFC 6234](https://www.rfc-editor.org/info/rfc6234).
 - sha3_224: SHA-3 with a digest length of 224, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).
 - sha3_256: SHA-3 with a digest length of 256, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).
 - sha3_384: SHA-3 with a digest length of 384, as defined in [FIPS 202](https://csrc.nist.gov/pubs/fips/202/final).


### PR DESCRIPTION
Update refs in MediaType, packageVerificationCodeExcludedFile, ExternalRefType, HashAlgorithm

- Add text labels to bare URLs, as they are required by OMG/ISO standard documents.
- Add ref links to Bower, Maven, npm, NuGet packages. Using [information from v2.3](https://spdx.github.io/spdx-spec/v2.3/external-repository-identifiers/#f3-package-manager).
  - These links are already in Normative References chapter of the spec, but missing from v3.0 model file.
- Standardized IETF RFC links -- see: https://github.com/spdx/spdx-spec/issues/1012
- Update obsoleted spec documents:
  - sha224: replace pre-RFC (Internet Draft) ref with RFC 3874
  - sha256, sha384, sha51: replace obsoleted refs RFC 4634 with RFC 6234

This PR will also supersede small part of #751
