### PR TITLE
[Licensing] Add text labels to bare URLs

### DIFF
--- a/model/ExpandedLicensing/Classes/CustomLicense.md
+++ b/model/ExpandedLicensing/Classes/CustomLicense.md
@@ -8,9 +8,9 @@ A license that is not listed on the SPDX License List.
 
 ## Description
 
-A CustomLicense represents a License that is not listed on the SPDX License
-List at <https://spdx.org/licenses>, and is therefore defined by an SPDX data
-creator.
+A CustomLicense represents a License that is not listed on the
+[SPDX License List](https://spdx.org/licenses),
+and is therefore defined by an SPDX data creator.
 
 ## Metadata
 

--- a/model/ExpandedLicensing/Classes/CustomLicenseAddition.md
+++ b/model/ExpandedLicensing/Classes/CustomLicenseAddition.md
@@ -9,8 +9,8 @@ A license addition that is not listed on the SPDX Exceptions List.
 ## Description
 
 A CustomLicenseAddition represents an addition to a License that is not listed
-on the SPDX Exceptions List at
-<https://spdx.org/licenses/exceptions-index.html>,
+on the
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html),
 and is therefore defined by an SPDX data creator.
 
 It is intended to represent additional language which is meant to be added to

--- a/model/ExpandedLicensing/Classes/LicenseAddition.md
+++ b/model/ExpandedLicensing/Classes/LicenseAddition.md
@@ -14,7 +14,7 @@ as additional text, but which is not itself intended to be a standalone
 License.
 
 It may be an exception which is listed on the
-[SPDX Exceptions List](https://spdx.org/licenses/exceptions-index.html)
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html)
 (ListedLicenseException), or may be any other additional text (as an exception
 or otherwise) which is defined by an SPDX data creator (CustomLicenseAddition).
 

--- a/model/ExpandedLicensing/Classes/ListedLicense.md
+++ b/model/ExpandedLicensing/Classes/ListedLicense.md
@@ -8,8 +8,8 @@ A license that is listed on the SPDX License List.
 
 ## Description
 
-A ListedLicense represents a License that is listed on the SPDX License List
-at <https://spdx.org/licenses>.
+A ListedLicense represents a License that is listed on the
+[SPDX License List](https://spdx.org/licenses).
 
 ## Metadata
 

--- a/model/ExpandedLicensing/Classes/ListedLicenseException.md
+++ b/model/ExpandedLicensing/Classes/ListedLicenseException.md
@@ -10,8 +10,8 @@ A license exception that is listed on the SPDX Exceptions list.
 
 A ListedLicenseException represents an exception to a License (in other words,
 an exception to a license condition or an additional permission beyond those
-granted in a License) which is listed on the SPDX Exceptions List at
-<https://spdx.org/licenses/exceptions-index.html>.
+granted in a License) which is listed on the
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html).
 
 ## Metadata
 

--- a/model/ExpandedLicensing/Classes/WithAdditionOperator.md
+++ b/model/ExpandedLicensing/Classes/WithAdditionOperator.md
@@ -11,8 +11,7 @@ text applied to it.
 
 A WithAdditionOperator indicates that the designated License is subject to the
 designated LicenseAddition, which might be a license exception on the
-[SPDX
-Exceptions List](https://spdx.org/licenses/exceptions-index.html)
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html)
 (ListedLicenseException) or may be other additional text
 (CustomLicenseAddition). It is represented in the SPDX License Expression
 Syntax by the `WITH` operator.

--- a/model/ExpandedLicensing/Properties/deprecatedVersion.md
+++ b/model/ExpandedLicensing/Properties/deprecatedVersion.md
@@ -12,7 +12,7 @@ identifier was deprecated.
 A deprecatedVersion, for a ListedLicense on the
 [SPDX License List](https://spdx.org/licenses/)
 or a ListedLicenseException on the
-[SPDX Exceptions List](https://spdx.org/licenses/exceptions-index.html),
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html),
 specifies which version release of the License List was the first
 one in which it was marked as deprecated.
 

--- a/model/ExpandedLicensing/Properties/isDeprecatedAdditionId.md
+++ b/model/ExpandedLicensing/Properties/isDeprecatedAdditionId.md
@@ -13,8 +13,8 @@ LicenseAddition has been marked as deprecated. If the property is not defined,
 then it is presumed to be false (i.e., not deprecated).
 
 If the LicenseAddition is included on the
-[SPDX Exceptions List](https://spdx.org/licenses/exceptions-index.html), then
-the `deprecatedVersion` property indicates on which version release of the
+[SPDX License Exceptions](https://spdx.org/licenses/exceptions-index.html),
+then the `deprecatedVersion` property indicates on which version release of the
 Exceptions List it was first marked as deprecated.
 
 "Deprecated" in this context refers to deprecating the use of the

--- a/model/ExpandedLicensing/Properties/isFsfLibre.md
+++ b/model/ExpandedLicensing/Properties/isFsfLibre.md
@@ -10,10 +10,10 @@ Specifies whether the License is listed as free by the
 ## Description
 
 isFsfLibre specifies whether the
-[Free Software Foundation FSF](https://fsf.org)
+[Free Software Foundation (FSF)](https://fsf.org)
 has listed this License as "free" in their commentary on licenses, located at
 the time of this writing at
-<https://www.gnu.org/licenses/license-list.en.html>.
+[Various Licenses and Comments about Them](https://www.gnu.org/licenses/license-list.en.html).
 
 A value of "true" indicates that the license is in the list of licenses that
 FSF publishes as libre.

--- a/model/ExpandedLicensing/Properties/isOsiApproved.md
+++ b/model/ExpandedLicensing/Properties/isOsiApproved.md
@@ -12,7 +12,8 @@ Specifies whether the License is listed as approved by the
 isOsiApproved specifies whether the
 [Open Source Initiative (OSI)](https://opensource.org)
 has listed this License as "approved" in their list of OSI Approved Licenses,
-located at the time of this writing at <https://opensource.org/licenses/>.
+located at the time of this writing at
+[OSI Approved Licenses](https://opensource.org/licenses).
 
 A value of "true" indicates that the license is in the list of licenses that
 OSI publishes as approved.

--- a/model/ExpandedLicensing/Properties/licenseXml.md
+++ b/model/ExpandedLicensing/Properties/licenseXml.md
@@ -12,11 +12,11 @@ XML format.
 The license XML format is defined and used by the SPDX legal team.
 
 See the XML fields defined at
-<https://github.com/spdx/license-list-XML/blob/main/DOCS/xml-fields.md>
+[XML template fields](https://github.com/spdx/license-list-XML/blob/main/DOCS/xml-fields.md)
 for a text description.
 
 There is also an XML schema available at
-<https://github.com/spdx/license-list-XML/blob/main/schema/ListedLicense.xsd>.
+[SPDX license-list-XML GitHub repository](https://github.com/spdx/license-list-XML/blob/main/schema/ListedLicense.xsd).
 
 ## Metadata
 

--- a/model/SimpleLicensing/Classes/AnyLicenseInfo.md
+++ b/model/SimpleLicensing/Classes/AnyLicenseInfo.md
@@ -17,10 +17,12 @@ It can be:
 
 - a NoneLicense;
 - a NoAssertionLicense;
-- a single license (either on the [SPDX License List](https://spdx.org/licenses/) or [a custom-defined license](../../ExpandedLicensing/Classes/CustomLicense.md));
+- a single license (either on the
+  [SPDX License List](https://spdx.org/licenses/) or
+  [a custom-defined license](../../ExpandedLicensing/Classes/CustomLicense.md));
 - a single license with an "or later" operator applied;
-- the foregoing with additional text applied;
-- or a set of licenses combined by applying "AND" and "OR" operators recursively.
+- the foregoing with additional text applied; or
+- a set of licenses combined by applying "AND" and "OR" operators recursively.
 
 ## Metadata
 

--- a/model/SimpleLicensing/Classes/SimpleLicensingText.md
+++ b/model/SimpleLicensing/Classes/SimpleLicensingText.md
@@ -9,8 +9,7 @@ A license or addition that is not listed on the SPDX License List.
 ## Description
 
 A SimpleLicensingText represents a License or Addition that is not listed on
-the SPDX License List at
-[https://spdx.org/licenses](https://spdx.org/licenses),
+the [SPDX License List](https://spdx.org/licenses),
 and is therefore defined by an SPDX data creator.
 
 ## Metadata

--- a/model/SimpleLicensing/Properties/customIdToUri.md
+++ b/model/SimpleLicensing/Properties/customIdToUri.md
@@ -15,7 +15,7 @@ Custom License Addition.
 The [License Expression syntax](../../../annexes/SPDX-license-expressions.md)
 dictates any reference starting with a
 "LicenseRef-" or "AdditionRef-" refers to license or addition text not found in
-[the official SPDX License List](https://spdx.org/licenses/).
+the official [SPDX License List](https://spdx.org/licenses/).
 
 These custom licenses must be a CustomLicense, a CustomLicenseAddition, or a
 SimpleLicensingText which are identified with a unique URI identifier.


### PR DESCRIPTION
Add text labels to bare URLs in ExpandedLicensing and SimpleLicensing Profiles.

For the purpose of OMG/ISO standard doc preparation.

This PR will also supersede large parts of #751