### PR TITLE
Remove ref to Legacy Text Template

### DIFF
--- a/model/ExpandedLicensing/Properties/standardAdditionTemplate.md
+++ b/model/ExpandedLicensing/Properties/standardAdditionTemplate.md
@@ -4,13 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Identifies the full text of a LicenseAddition, in SPDX templating format.
+Identifies the full text of a LicenseAddition.
 
 ## Description
 
 A standardAdditionTemplate contains a license addition template which describes
-sections of the LicenseAddition text which can be varied. See the Legacy Text
-Template format section of the SPDX specification for format information.
+sections of the LicenseAddition text which can be varied.
 
 ## Metadata
 

--- a/model/ExpandedLicensing/Properties/standardLicenseTemplate.md
+++ b/model/ExpandedLicensing/Properties/standardLicenseTemplate.md
@@ -4,15 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Identifies the full text of a License, in SPDX templating format.
+Identifies the full text of a License.
 
 ## Description
 
 A standardLicenseTemplate contains a license template which describes sections
 of the License text which can be varied.
-
-See the Legacy Text Template format section of the SPDX specification for
-format information.
 
 ## Metadata
 


### PR DESCRIPTION
Remove references to Legacy Text Template in these ExpandedLicensing properties:

- [standardLicenseTemplate](https://github.com/spdx/spdx-3-model/blob/main/model/ExpandedLicensing/Properties/standardLicenseTemplate.md)
- [standardAdditionTemplate](https://github.com/spdx/spdx-3-model/blob/main/model/ExpandedLicensing/Properties/standardAdditionTemplate.md)

See full discussion starting at https://github.com/spdx/spdx-3-model/issues/747#issuecomment-2263417097 by @swinslow

This will resolve #747

Target 3.0.1