### PR TITLE
licenseXml: Link license-list-XML to a specific version (v3.24.0)

### DIFF
--- a/model/ExpandedLicensing/Properties/licenseXml.md
+++ b/model/ExpandedLicensing/Properties/licenseXml.md
@@ -11,12 +11,11 @@ XML format.
 
 The license XML format is defined and used by the SPDX legal team.
 
-See the XML fields defined at
-[XML template fields](https://github.com/spdx/license-list-XML/blob/main/DOCS/xml-fields.md)
-for a text description.
+The formal schema definition is available at
+[SPDX License List XML Schema](https://github.com/spdx/license-list-XML/blob/v3.24.0/schema/ListedLicense.xsd).
 
-There is also an XML schema available at
-[SPDX license-list-XML GitHub repository](https://github.com/spdx/license-list-XML/blob/main/schema/ListedLicense.xsd).
+For a text description of the XML fields, see
+[XML template fields](https://github.com/spdx/license-list-XML/blob/v3.24.0/DOCS/xml-fields.md).
 
 ## Metadata
 


### PR DESCRIPTION
- Link to v3.24.0 of license-list-XML
- Use "SPDX License List XML Schema" name, for ref text label, taken from a heading in [schema/ListedLicense.xsd](https://github.com/spdx/license-list-XML/blob/v3.24.0/schema/ListedLicense.xsd)
  - `<xhtml:h1>SPDX License List XML Schema</xhtml:h1>`
