### PR TITLE
Recommend to use licenseXml, instead of Legacy Text Template properties

### DIFF
--- a/model/ExpandedLicensing/Properties/additionText.md
+++ b/model/ExpandedLicensing/Properties/additionText.md
@@ -11,7 +11,8 @@ Identifies the full text of a LicenseAddition.
 An additionText contains the plain text of the LicenseAddition, without
 templating or other similar markup.
 
-Users of the additionText for a License can apply the SPDX Matching Guidelines
+Users of the additionText for a License can apply the
+[SPDX License List Matching Guidelines](../../../annexes/license-matching-guidelines-and-templates.md)
 when comparing it to another text for matching purposes.
 
 ## Metadata

--- a/model/ExpandedLicensing/Properties/standardAdditionTemplate.md
+++ b/model/ExpandedLicensing/Properties/standardAdditionTemplate.md
@@ -9,8 +9,14 @@ Identifies the full text of a LicenseAddition, in SPDX templating format.
 ## Description
 
 A standardAdditionTemplate contains a license addition template which describes
-sections of the LicenseAddition text which can be varied. See the Legacy Text
-Template format section of the SPDX specification for format information.
+sections of the LicenseAddition text which can be varied.
+
+See the Legacy Text Template format section of the
+[SPDX License List Matching Guidelines](../../../annexes/license-matching-guidelines-and-templates.md)
+for format information.
+
+It is recommended to use [licenseXml](./licenseXml.md) instead, as it can
+capture all the text and metadata associated with a license.
 
 ## Metadata
 

--- a/model/ExpandedLicensing/Properties/standardLicenseTemplate.md
+++ b/model/ExpandedLicensing/Properties/standardLicenseTemplate.md
@@ -11,8 +11,12 @@ Identifies the full text of a License, in SPDX templating format.
 A standardLicenseTemplate contains a license template which describes sections
 of the License text which can be varied.
 
-See the Legacy Text Template format section of the SPDX specification for
-format information.
+See the Legacy Text Template format section of the
+[SPDX License List Matching Guidelines](../../../annexes/license-matching-guidelines-and-templates.md)
+for format information.
+
+It is recommended to use [licenseXml](./licenseXml.md) instead, as it can
+capture all the text and metadata associated with a license.
 
 ## Metadata
 

--- a/model/SimpleLicensing/Properties/licenseText.md
+++ b/model/SimpleLicensing/Properties/licenseText.md
@@ -11,7 +11,8 @@ Identifies the full text of a License or Addition.
 A licenseText contains the plain text of the License or Addition,
 without templating or other similar markup.
 
-Users of the licenseText for a License can apply the SPDX Matching Guidelines
+Users of the licenseText for a License can apply the
+[SPDX License List Matching Guidelines](../../../annexes/license-matching-guidelines-and-templates.md)
 when comparing it to another text for matching purposes.
 
 ## Metadata


### PR DESCRIPTION
This PR addresses two ExpandedLicensing properties at using Legacy Text Template:

- standardAdditionTemplate
- standardLicenseTemplate

See discussion at https://github.com/spdx/spdx-3-model/issues/747#issuecomment-2263645277