### PR TITLE
Fix link to serialization

### DIFF
--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -14,7 +14,7 @@ of Element IDs. This map is used in SPDX content serialization to provide
 a more human-readable and smaller serialized representation of the Elements.
 
 For details of how NamespaceMap content is to be serialized please refer to
-the [Model and serializations](../../../docs/serializations.md) clause
+the [Model and serializations](../../../serializations.md) clause
 and the various serialization format-specific files within the
 [spdx-3-model repository](https://github.com/spdx/spdx-3-model/tree/main/serialization).
 


### PR DESCRIPTION
The CI for the SPDX spec is currently failing with the warning "WARNING -  Doc file 'model/Core/Classes/NamespaceMap.md' contains a link '../../../docs/serializations.md', but the target 'docs/serializations.md' is not found among documentation files."  It looks like the published spec has the serializations published at the root level, not in the docs folder.