### PR TITLE
Add Adler32 to hash algorithms

### DIFF
--- a/model/Core/Vocabularies/HashAlgorithm.md
+++ b/model/Core/Vocabularies/HashAlgorithm.md
@@ -18,6 +18,7 @@ practically infeasible to invert.
 
 ## Entries
 
+- adler32: Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950])(https://www.ietf.org/rfc/rfc1950.txt) Section 2.3.
 - blake2b256: BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
 - blake2b384: BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
 - blake2b512: BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.

--- a/model/Core/Vocabularies/HashAlgorithm.md
+++ b/model/Core/Vocabularies/HashAlgorithm.md
@@ -18,7 +18,7 @@ practically infeasible to invert.
 
 ## Entries
 
-- adler32: Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950])(https://www.ietf.org/rfc/rfc1950.txt) Section 2.3.
+- adler32: Adler-32 checksum is part of the widely used zlib compression library as defined in [RFC 1950](https://www.rfc-editor.org/info/rfc1950) Section 2.3.
 - blake2b256: BLAKE2b algorithm with a digest size of 256, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
 - blake2b384: BLAKE2b algorithm with a digest size of 384, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.
 - blake2b512: BLAKE2b algorithm with a digest size of 512, as defined in [RFC 7693](https://www.rfc-editor.org/info/rfc7693) Section 4.


### PR DESCRIPTION
Adler32 was added to SPDX 2.3 based on issue 624 (https://github.com/spdx/spdx-spec/issues/624).  This algorithm is not present in the SPDX 3.0 spec.

I searched the SPDX tech minutes to see if this was discussed for 3.0 and I could not find any record - so I assume this was an oversight.