### PR TITLE
Revert PackageVerificationCode.md to original algorithm, and improve readability/formatting.

### DIFF
--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -23,7 +23,7 @@ Algorithm:
 
     for all files in the package {
         if file is a packageVerificationCodeExcludedFile
-            skip it /* exclude SPDX analysis file(s) */
+            skip it  /* exclude SPDX analysis file */
         else
             append "algorithm(file)/n" to templist
     }

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -18,19 +18,21 @@ This identifier enables a recipient to determine if any file in the original pac
 
 Algorithm:
 
+    hashValue = 0
     templist = empty list of strings
 
-    for all files in the package
-        if file is an "excludes" file
+    for all files in the package {
+        if file is a packageVerificationCodeExcludedFile
             skip it /* exclude SPDX analysis file(s) */
         else
-            append algorithm(contents of file) to templist
+            append "algorithm(file)/n" to templist
+        }
 
     sort templist in ascending order by value
-
-    valueslist = join templist values     /* ordered sequence with no separators */
+    
+    valueslist = remove "/n"s from templist  /* ordered sequence with no separators */
      
-    verificationcode = algorithm(valueslist)
+    hasValue = algorithm(valueslist)
 
 where `algorithm(string)` applies a hash algorithm on a string and returns the result in lowercase hexadecimal digits.
 

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -18,7 +18,6 @@ This identifier enables a recipient to determine if any file in the original pac
 
 Algorithm:
 
-    hashValue = 0
     templist = empty list of strings
 
     for all files in the package {

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -18,7 +18,7 @@ This identifier enables a recipient to determine if any file in the original pac
 
 Algorithm:
 
-    templist = empty list of strings
+    templist = ""
 
     for all files in the package {
         if file is a packageVerificationCodeExcludedFile

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -32,7 +32,10 @@ Algorithm:
     
     valueslist = remove "/n"s from templist  /* ordered sequence with no separators */
      
-    hashValue = algorithm(valueslist)
+    if valuelist is empty
+       hashValue = 0
+    else
+       hashValue = algorithm(valueslist)
 
 where `algorithm(string)` applies a hash algorithm on a string and returns the result in lowercase hexadecimal digits.
 

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -32,7 +32,7 @@ Algorithm:
     /* remove separators from ordered sequence */
     valueslist = remove "/n"s from templist
      
-    if valuelist is empty
+    if valueslist is empty
        hashValue = 0
     else
        hashValue = algorithm(valueslist)

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -32,7 +32,7 @@ Algorithm:
     
     valueslist = remove "/n"s from templist  /* ordered sequence with no separators */
      
-    hasValue = algorithm(valueslist)
+    hashValue = algorithm(valueslist)
 
 where `algorithm(string)` applies a hash algorithm on a string and returns the result in lowercase hexadecimal digits.
 

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -29,7 +29,8 @@ Algorithm:
 
     sort templist in ascending order by value
     
-    valueslist = remove "/n"s from templist  /* ordered sequence with no separators */
+    /* remove separators from ordered sequence */
+    valueslist = remove "/n"s from templist
      
     if valuelist is empty
        hashValue = 0

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -26,7 +26,7 @@ Algorithm:
             skip it /* exclude SPDX analysis file(s) */
         else
             append "algorithm(file)/n" to templist
-        }
+    }
 
     sort templist in ascending order by value
     


### PR DESCRIPTION
Add back in line separators, else the sort won't work. 
Use revised property names.   Set default value for hashValue.

Signed-off-by:  Kate Stewart <kstewart@linuxfoundation.org>