### PR TITLE
Bom and SpdxDocument cannot be empty

### DIFF
--- a/model/Core/Classes/Bom.md
+++ b/model/Core/Classes/Bom.md
@@ -21,3 +21,9 @@ its composition, licensing information, known quality or security issues, etc.
 - name: Bom
 - SubclassOf: Bundle
 - Instantiability: Concrete
+
+## External properties restrictions
+
+- /Core/ElementCollection/element
+  - minCount: 1
+

--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -37,3 +37,9 @@ SpdxDocument element definition.
 - dataLicense
   - type: /SimpleLicensing/AnyLicenseInfo
   - maxCount: 1
+
+## External properties restrictions
+
+- /Core/ElementCollection/element
+  - minCount: 1
+


### PR DESCRIPTION
This makes sure Core/Bom and Core/SpdxDocument are not empty.

Essentially adds minCount:1 for elements in these classes.

Closes #841 

**Incompatible with** #845 (choose one)
