### PR TITLE
Bom and SpdxDocument must have element and rootElement

### DIFF
--- a/model/Core/Classes/Bom.md
+++ b/model/Core/Classes/Bom.md
@@ -21,3 +21,11 @@ its composition, licensing information, known quality or security issues, etc.
 - name: Bom
 - SubclassOf: Bundle
 - Instantiability: Concrete
+
+## External properties restrictions
+
+- /Core/ElementCollection/element
+  - minCount: 1
+- /Core/ElementCollection/rootElement
+  - minCount: 1
+

--- a/model/Core/Classes/SpdxDocument.md
+++ b/model/Core/Classes/SpdxDocument.md
@@ -37,3 +37,11 @@ SpdxDocument element definition.
 - dataLicense
   - type: /SimpleLicensing/AnyLicenseInfo
   - maxCount: 1
+
+## External properties restrictions
+
+- /Core/ElementCollection/element
+  - minCount: 1
+- /Core/ElementCollection/rootElement
+  - minCount: 1
+


### PR DESCRIPTION
This makes sure Core/Bom and Core/SpdxDocument have at least one `element` and at least one `rootElement`.

Simply adds minCount:1 for element and rootElement in these classes.

Closes #841 

**Incompatible with** #844 (choose one)