### PR TITLE
Standardize phrase "each to Element" in RelationshipType

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -41,24 +41,24 @@ name completes the sentence:
 - expandsTo: The `from` archive expands out as an artifact described by each `to` Element.
 - exploitCreatedBy: The `from` Vulnerability has had an exploit created against it by each `to` Agent.
 - fixedBy: Designates a `from` Vulnerability has been fixed by the `to` Agent(s).
-- fixedIn: A `from` Vulnerability has been fixed in each of the `to` Element(s). The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships.
+- fixedIn: A `from` Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships.
 - foundBy: Designates a `from` Vulnerability was originally discovered by the `to` Agent(s).
 - generates: The `from` Element generates each `to` Element.
 - hasAddedFile: Every `to` Element is a file added to the `from` Element (`from` hasAddedFile `to`).
-- hasAssessmentFor: Relates a `from` Vulnerability and each `to` Element(s) with a security assessment. To be used with `VulnAssessmentRelationship` types.
+- hasAssessmentFor: Relates a `from` Vulnerability and each `to` Element with a security assessment. To be used with `VulnAssessmentRelationship` types.
 - hasAssociatedVulnerability: Used to associate a `from` Artifact with each `to` Vulnerability.
-- hasConcludedLicense: The `from` Software Artifact is concluded by the SPDX data creator to be governed by each `to` license.
+- hasConcludedLicense: The `from` SoftwareArtifact is concluded by the SPDX data creator to be governed by each `to` license.
 - hasDataFile: The `from` Element treats each `to` Element as a data file. A data file is an artifact that stores data required or optional for the `from` Element's functionality. A data file can be a database file, an index file, a log file, an AI model file, a calibration data file, a temporary file, a backup file, and more. For AI training dataset, test dataset, test artifact, configuration data, build input data, and build output data, please consider using the more specific relationship types: `trainedOn`, `testedOn`, `hasTest`, `configures`, `hasInput`, and `hasOutput`, respectively. This relationship does not imply dependency.
-- hasDeclaredLicense: The `from` Software Artifact was discovered to actually contain each `to` license, for example as detected by use of automated tooling.
+- hasDeclaredLicense: The `from` SoftwareArtifact was discovered to actually contain each `to` license, for example as detected by use of automated tooling.
 - hasDeletedFile: Every `to` Element is a file deleted from the `from` Element (`from` hasDeletedFile `to`).
 - hasDependencyManifest: The `from` Element has manifest files that contain dependency information in each `to` Element.
-- hasDistributionArtifact: The `from` Element is distributed as an artifact in each Element `to` (e.g. an RPM or archive file).
+- hasDistributionArtifact: The `from` Element is distributed as an artifact in each `to` Element (e.g. an RPM or archive file).
 - hasDocumentation: The `from` Element is documented by each `to` Element.
 - hasDynamicLink: The `from` Element dynamically links in each `to` Element, during a LifecycleScopeType period.
 - hasEvidence: Every `to` Element is considered as evidence for the `from` Element (`from` hasEvidence `to`).
 - hasExample: Every `to` Element is an example for the `from` Element (`from` hasExample `to`).
 - hasHost: The `from` Build was run on the `to` Element during a LifecycleScopeType period (e.g. the host that the build runs on).
-- hasInput: The `from` Build has each `to` Elements as an input, during a LifecycleScopeType period.
+- hasInput: The `from` Build has each `to` Element as an input, during a LifecycleScopeType period.
 - hasMetadata: Every `to` Element is metadata about the `from` Element (`from` hasMetadata `to`).
 - hasOptionalComponent: Every `to` Element is an optional component of the `from` Element (`from` hasOptionalComponent `to`).
 - hasOptionalDependency: The `from` Element optionally depends on each `to` Element, during a LifecycleScopeType period.


### PR DESCRIPTION
- One instance of "each `to` Elements" -> "each `to` Element"
- One instance of "each Element `to`" -> "each `to` Element"
- One instance of "each of the `to` Element(s)" -> "each `to` Element"

Make them the same as other 25+ instances of "each `to` Element"

- "Software Artifact" ->  "SoftwareArtifact", to match class name spelling