### PR TITLE
Fix model desc inconsistencies; CdxPropertiesExtension mention non-existing class/property

### DIFF
--- a/model/Build/Properties/parameter.md
+++ b/model/Build/Properties/parameter.md
@@ -9,9 +9,11 @@ Property describing a parameter used in an instance of a build.
 ## Description
 
 parameter is a key-value of a build parameter and its value that
-was provided to the builder for a build instance. This is different from the
-[environment](environment.md) property in that the key and value are provided
-as command line arguments or a configuration file to the builder.
+was provided to the builder for a build instance.
+
+This is different from the [environment](environment.md) property in that
+the key and value are provided as command line arguments or
+a configuration file to the builder.
 
 ## Metadata
 

--- a/model/Extension/Classes/CdxPropertiesExtension.md
+++ b/model/Extension/Classes/CdxPropertiesExtension.md
@@ -11,7 +11,7 @@ A type of extension consisting of a list of name value pairs.
 This extension provides a more structured extension using a name-value
 approach.
 
-Unlike key-value stores, cdxProperty support duplicate names, each
+Unlike key-value stores, properties in CdxPropertiesExtension support duplicate names, each
 potentially having different values.
 
 This is intended to be compatible with the CycloneDX property `properties`.

--- a/model/Extension/Classes/CdxPropertiesExtension.md
+++ b/model/Extension/Classes/CdxPropertiesExtension.md
@@ -11,7 +11,7 @@ A type of extension consisting of a list of name value pairs.
 This extension provides a more structured extension using a name-value
 approach.
 
-Unlike key-value stores, cdxProperties support duplicate names, each
+Unlike key-value stores, cdxProperty support duplicate names, each
 potentially having different values.
 
 This is intended to be compatible with the CycloneDX property `properties`.

--- a/model/Extension/Classes/CdxPropertyEntry.md
+++ b/model/Extension/Classes/CdxPropertyEntry.md
@@ -11,8 +11,8 @@ A property name with an associated value.
 Each CdxPropertyEntry contains a name-value pair which maps the name to its
 associated value.
 
-Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
-potentially having different values.
+Unlike key-value stores, properties in CdxPropertiesExtension support duplicate
+names, each potentially having different values.
 
 This class can be used to implement CycloneDX compatible properties.
 

--- a/model/Extension/Classes/CdxPropertyEntry.md
+++ b/model/Extension/Classes/CdxPropertyEntry.md
@@ -8,10 +8,10 @@ A property name with an associated value.
 
 ## Description
 
-Each CdxPropertyEntry  contains a name-value pair which maps the name to its
+Each CdxPropertyEntry contains a name-value pair which maps the name to its
 associated value.
 
-Unlike key-value stores, cdxProperties support duplicate names, each
+Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
 potentially having different values.
 
 This class can be used to implement CycloneDX compatible properties.

--- a/model/Extension/Properties/cdxPropName.md
+++ b/model/Extension/Properties/cdxPropName.md
@@ -10,8 +10,8 @@ A name used in a CdxPropertyEntry name-value pair.
 
 A cdxPropName is used in a CdxPropertyEntry name-value pair.
 
-Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
-potentially having different values.
+Unlike key-value stores, properties in CdxPropertiesExtension support duplicate
+names, each potentially having different values.
 
 ## Metadata
 

--- a/model/Extension/Properties/cdxPropName.md
+++ b/model/Extension/Properties/cdxPropName.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A name used in a CdxExtension name-value pair.
+A name used in a CdxPropertyEntry name-value pair.
 
 ## Description
 
-A cdxPropName is used in a CdxExtension name-value pair.
+A cdxPropName is used in a CdxPropertyEntry name-value pair.
 
 Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
 potentially having different values.

--- a/model/Extension/Properties/cdxPropName.md
+++ b/model/Extension/Properties/cdxPropName.md
@@ -10,7 +10,7 @@ A name used in a CdxExtension name-value pair.
 
 A cdxPropName is used in a CdxExtension name-value pair.
 
-Unlike key-value stores, cdxProperties support duplicate names, each
+Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
 potentially having different values.
 
 ## Metadata

--- a/model/Extension/Properties/cdxPropValue.md
+++ b/model/Extension/Properties/cdxPropValue.md
@@ -10,7 +10,7 @@ A value used in a CdxExtension name-value pair.
 
 A cdxPropValue is used in a CdxExtension name-value pair.
 
-Unlike key-value stores, cdxProperties support duplicate names, each
+Unlike key-value stores, cdxPropertiesExtension support duplicate names, each
 potentially having different values.
 
 ## Metadata

--- a/model/Extension/Properties/cdxPropValue.md
+++ b/model/Extension/Properties/cdxPropValue.md
@@ -10,8 +10,8 @@ A value used in a CdxPropertyEntry name-value pair.
 
 A cdxPropValue is used in a CdxPropertyEntry name-value pair.
 
-Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
-potentially having different values.
+Unlike key-value stores, properties in CdxPropertiesExtension support duplicate
+names, each potentially having different values.
 
 ## Metadata
 

--- a/model/Extension/Properties/cdxPropValue.md
+++ b/model/Extension/Properties/cdxPropValue.md
@@ -4,13 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A value used in a CdxExtension name-value pair.
+A value used in a CdxPropertyEntry name-value pair.
 
 ## Description
 
-A cdxPropValue is used in a CdxExtension name-value pair.
+A cdxPropValue is used in a CdxPropertyEntry name-value pair.
 
-Unlike key-value stores, cdxPropertiesExtension support duplicate names, each
+Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
 potentially having different values.
 
 ## Metadata

--- a/model/Extension/Properties/cdxProperty.md
+++ b/model/Extension/Properties/cdxProperty.md
@@ -10,10 +10,10 @@ Provides a map of a property names to a values.
 
 This field provides a mapping of a name to a value.
 
-This is intended to be compatible with the CycloneDX property "properties".
+This is intended to be compatible with the CycloneDX property `properties`.
 
-Unlike key-value stores, properties support duplicate names, each potentially
-having different values.
+Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
+potentially having different values.
 
 ## Metadata
 

--- a/model/Extension/Properties/cdxProperty.md
+++ b/model/Extension/Properties/cdxProperty.md
@@ -12,8 +12,8 @@ This field provides a mapping of a name to a value.
 
 This is intended to be compatible with the CycloneDX property `properties`.
 
-Unlike key-value stores, CdxPropertiesExtension support duplicate names, each
-potentially having different values.
+Unlike key-value stores, properties in CdxPropertiesExtension support duplicate
+names, each potentially having different values.
 
 ## Metadata
 

--- a/model/SimpleLicensing/Classes/AnyLicenseInfo.md
+++ b/model/SimpleLicensing/Classes/AnyLicenseInfo.md
@@ -8,7 +8,7 @@ Abstract class representing a license combination consisting of one or more lice
 
 ## Description
 
-AnyLicenseInfo is 
+AnyLicenseInfo is
 an abstract class representing a license combination consisting of one or more
 licenses (optionally including additional text), which may be combined
 according to the
@@ -18,8 +18,8 @@ An AnyLicenseInfo is used by licensing properties of software artifacts.
 
 It can be:
 
-- a NoneLicense;
-- a NoAssertionLicense;
+- a [NoneLicense](../../ExpandedLicensing/Individuals/NoneLicense.md);
+- a [NoAssertionLicense](../../ExpandedLicensing/Individuals/NoAssertionLicense.md);
 - a single license (either on the
   [SPDX License List](https://spdx.org/licenses/) or
   [a custom-defined license](../../ExpandedLicensing/Classes/CustomLicense.md));

--- a/model/SimpleLicensing/Classes/AnyLicenseInfo.md
+++ b/model/SimpleLicensing/Classes/AnyLicenseInfo.md
@@ -18,8 +18,8 @@ An AnyLicenseInfo is used by licensing properties of software artifacts.
 
 It can be:
 
-- a [NoneLicense](../../ExpandedLicensing/Individuals/NoneLicense.md);
-- a [NoAssertionLicense](../../ExpandedLicensing/Individuals/NoAssertionLicense.md);
+- a NoneLicense;
+- a NoAssertionLicense;
 - a single license (either on the
   [SPDX License List](https://spdx.org/licenses/) or
   [a custom-defined license](../../ExpandedLicensing/Classes/CustomLicense.md));

--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -12,11 +12,11 @@ A LicenseExpression enables the representation, in a single string, of a
 combination of one or more licenses, together with additions such as license
 exceptions.
 
-The syntax for a LicenseExpression string is set forth in the corresponding
+The syntax for a licenseExpression string is set forth in the corresponding
 Annex of this specification
 (["SPDX license expressions"](../../../annexes/spdx-license-expressions.md)).
-A LicenseExpression string is not valid if it does not conform to the grammar
-set forth in that annex.
+A licenseExpression string is not valid if it does not conform to the grammar
+set forth in that Annex.
 
 The ExpandedLicensing profile can be used to represent the complete parsed
 license expression as a combination of license objects.

--- a/model/SimpleLicensing/Properties/licenseExpression.md
+++ b/model/SimpleLicensing/Properties/licenseExpression.md
@@ -12,11 +12,11 @@ A licenseExpression enables the representation, in a single string, of a
 combination of one or more licenses, together with additions such as license
 exceptions.
 
-The syntax for a LicenseExpression string is set forth in the Annex D
-of the SPDX Specification
+The syntax for a licenseExpression string is set forth in the corresponding
+Annex of this specification
 (["SPDX license expressions"](../../../annexes/spdx-license-expressions.md)).
-A LicenseExpression string is not valid if it does not conform to the grammar
-set forth in that annex.
+A licenseExpression string is not valid if it does not conform to the grammar
+set forth in that Annex.
 
 The ExpandedLicensing profile can be used to represent the complete parsed
 license expression as a combination of license objects.


### PR DESCRIPTION
Found during diagrams check.

## Build
- Format "parameter" description to make it parallel with "environment" description, as both of them are related and their desc referring to each other.

### License
- Fix typo in LicenseExpression and licenseExpression
  - The "licenseExpression string" is referring to a property "licenseExpression" of a class "LicenseExpression". Lowercase "l" should be used for "licenseExpression string".
  - Removing the Annex number. Make that section of text similar in both class and property.
- AnyLicenseInfo: Add link to NonLicense and NoAssertionLicense (other classes already have link)

## Extension
- Update descriptions of classes and properties related to CdxPropertiesExtension
  - Were refer to non-existing `CdxExtension` and `cdxProperties`
  - CdxPropertiesExtension
  - CdxPropertyEntry
  - cdxProperty
  - cdxPropName
  - cdxPropValue

** Please recheck those Cdx-related, all fix referring to each other. I'm not 100% sure here. **