### PR TITLE
Update Build.md to remove separate definition of properties

### DIFF
--- a/model/Build/Classes/Build.md
+++ b/model/Build/Classes/Build.md
@@ -14,10 +14,6 @@ provides an element from which relationships can be created to describe the
 build's inputs, outputs, and related entities (e.g. builders, identities,
 etc.).
 
-Definitions of "buildType", "configSourceEntrypoint", "configSourceUri",
-"parameters" and "environment" follow those defined in
-[SLSA Provenance v0.2](https://slsa.dev/provenance/v0.2).
-
 ExternalIdentifier of type "urlScheme" may be used to identify build logs.
 In this case, the comment of the ExternalIdentifier should be "LogReference".
 


### PR DESCRIPTION
Update Build.md to remove separate definition of properties where it was referencing SLSA v0.2, and to avoid confusion against already defined properties.

@nishakm @JPEWdev 