### PR TITLE
Update SPDX License List link to v3.25.0

### DIFF
--- a/model/ExpandedLicensing/Properties/licenseXml.md
+++ b/model/ExpandedLicensing/Properties/licenseXml.md
@@ -12,10 +12,10 @@ XML format.
 The license XML format is defined and used by the SPDX legal team.
 
 The formal schema definition is available at
-[SPDX License List XML Schema](https://github.com/spdx/license-list-XML/blob/v3.24.0/schema/ListedLicense.xsd).
+[SPDX License List XML Schema](https://github.com/spdx/license-list-XML/blob/v3.25.0/schema/ListedLicense.xsd).
 
 For a text description of the XML fields, see
-[XML template fields](https://github.com/spdx/license-list-XML/blob/v3.24.0/DOCS/xml-fields.md).
+[XML template fields](https://github.com/spdx/license-list-XML/blob/v3.25.0/DOCS/xml-fields.md).
 
 ## Metadata
 


### PR DESCRIPTION
Update SPDX License List link to [v3.25.0](https://github.com/spdx/license-list-XML/releases/tag/v3.25.0)

- Similar PR in spdx-spec: https://github.com/spdx/spdx-spec/pull/1075