### PR TITLE
ExternalMap: Replace "Document" with "SpdxDocument"

### DIFF
--- a/model/Core/Classes/ExternalMap.md
+++ b/model/Core/Classes/ExternalMap.md
@@ -4,13 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A map of Element identifiers that are used within a Document but defined
-external to that Document.
+A map of Element identifiers that are used within an SpdxDocument but defined
+external to that SpdxDocument.
 
 ## Description
 
-An external map is a map of Element identifiers that are used within a Document
-but defined external to that Document.
+An external map is a map of Element identifiers that are used within an
+SpdxDocument but defined external to that SpdxDocument.
 The external map provides details about the externally-defined Element
 such as its provenance, where to retrieve it, and how to verify its integrity.
 

--- a/model/Core/Properties/externalSpdxId.md
+++ b/model/Core/Properties/externalSpdxId.md
@@ -4,13 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Identifies an external Element used within a Document but defined external to
-that Document.
+Identifies an external Element used within an SpdxDocument but defined
+external to that SpdxDocument.
 
 ## Description
 
-ExternalSpdxId identifies an external Element used within a Document but
-defined external to that Document.
+ExternalSpdxId identifies an external Element used within an SpdxDocument but
+defined external to that SpdxDocument.
 
 ## Metadata
 


### PR DESCRIPTION
In [ExternalMap](https://spdx.github.io/spdx-spec/v3.0.1-draft/model/Core/Classes/ExternalMap/) and [externalSpdxId](https://spdx.github.io/spdx-spec/v3.0.1-draft/model/Core/Properties/externalSpdxId/) description,
replacing the "Document" (uppercase "D") with "SpdxDocument".

To resolve #871