### PR TITLE
Remove mentions of .md; fix indent in YAML example; fix heading consistency

### DIFF
--- a/model/Build/Properties/configSourceEntrypoint.md
+++ b/model/Build/Properties/configSourceEntrypoint.md
@@ -24,14 +24,14 @@ is `publish`.
 name: Publish packages to PyPI
 
 on:
-create:
-tags: "*"
+  create:
+    tags: "*"
 
 jobs:
-publish:
-runs-on: ubuntu-latest
-if: startsWith(github.ref, 'refs/tags/')
-steps:
+  publish:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
 
 ...
 ```

--- a/model/Core/Classes/ElementCollection.md
+++ b/model/Core/Classes/ElementCollection.md
@@ -17,7 +17,7 @@ core profile is no specified in the profileConformance property.
 If the profileConformance property is not provided, core is to be assumed as
 the default.
 
-**Constraints**
+*Constraints*
 
 - If the ElementCollection has at least 1 element, it must also have at least
   1 rootElement.

--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -14,7 +14,7 @@ A MediaType is a string constrained to the
 It provides a standardized way of indicating the type of content of an Element
 or a Property.
 
-**Examples**
+*Example*
 
 - `application/java-archive`
 - `application/vcard+json`

--- a/model/Security/Properties/catalogType.md
+++ b/model/Security/Properties/catalogType.md
@@ -8,7 +8,8 @@ Specifies the exploit catalog type.
 
 ## Description
 
-A catalogType is a mandatory value and must select one of the existing entries in the `ExploitCatalogType.md` vocabulary.
+A catalogType is a mandatory value and must select one of the existing entries
+in the [`ExploitCatalogType`](../Vocabularies/ExploitCatalogType.md) vocabulary.
 
 ## Metadata
 

--- a/model/Security/Properties/decisionType.md
+++ b/model/Security/Properties/decisionType.md
@@ -10,7 +10,7 @@ Provide the enumeration of possible decisions in the
 ## Description
 
 A decisionType is a mandatory value and must select one of the four entries in
-the `SsvcDecisionType.md` vocabulary.
+the [`SsvcDecisionType`](../Vocabularies/SsvcDecisionType.md) vocabulary.
 
 ## Metadata
 

--- a/model/Security/Properties/vectorString.md
+++ b/model/Security/Properties/vectorString.md
@@ -13,7 +13,7 @@ and/or Supplemental vector string values for a vulnerability.
 
 Supports vectorStrings specified in all CVSS versions.
 
-**Constraints**
+*Constraints*
 
 String values for the vectorString range must only include the abbreviated form
 of metric names specified in CVSS specifications, e.g.

--- a/serialization/README.md
+++ b/serialization/README.md
@@ -72,7 +72,7 @@ elements and relationships step-by-step:
   CVSS, etc. to communicate, e.g.,
   - Changes to a vulnerability element’s status affecting a specific package
     element using VEX (Vulnerability Exploitability eXchange) (see the
-    serialized examples listed in *Syntax* under each vulnerability assessment
+    serialized examples listed in *Example* under each vulnerability assessment
     relationship class definition)
   - How a vulnerability element may be fixed for a particular software package
     element


### PR DESCRIPTION
## Build/configSourceEntrypoint: Fix indent in example
- With the keywords inside, the configuration in YAML looks like one that similar to GitHub workflow.
- This PR gives the configuration an indentation according to those keywords, checked with GitHub web editor.

## Security: Remove the mentions of Markdown files inside model description
- Replace mentions of `ExploitCatalogType.md` and `SsvcDecisionType.md` Markdown files (which are not visible to readers, as `.md` part will be removed when site/PDF got generated) with actual links to the vocabularies.

## Make heading consistent
- Replace 2 instances of `**Constraints**` with `*Constraints*`, to make them similar to other Constraints instances
- in MediaType: change `**Examples**` to `*Example*` to make it similar to other Example instances
- Update serialization/README, was referenced to an outdated name `*Syntax*`. It is now `*Example*`.
