### PR TITLE
buildType: Fix broken bullet lists rendering

### DIFF
--- a/model/Build/Properties/buildType.md
+++ b/model/Build/Properties/buildType.md
@@ -21,18 +21,19 @@ If you are not using a well-known buildType, it should be namespaced to a
 domain you own to prevent conflicts with other builtType IRIs.
 
 Examples of a buildType might be:
-* A GitHub action workflow
-* A step in a GitHub actions pipeline
-* An invocation of a compiler or other tool
-* A script that orchestrates builds at a higher level
 
-Keep in mind that builds can be "nested" using the `ancestorOf` relationship
+- A GitHub action workflow
+- A step in a GitHub actions pipeline
+- An invocation of a compiler or other tool
+- A script that orchestrates builds at a higher level
+
+Keep in mind that builds can be "nested" using the `ancestorOf` relationship.
 
 If the buildType IRI is not recognized, it is still possible to inspect other
 properties of the build, but it may not be possible to derive deeper meaning
-from them
+from them.
 
-For more information, see the SLSA definition of buildType
+For more information, see the SLSA definition of buildType.
 
 ## Metadata
 


### PR DESCRIPTION
A follow up of #875 that we just merged an hour ago - the rendering of the new bullet list in the description is broken.
See: https://spdx.github.io/spdx-spec/v3.0.1/model/Build/Properties/buildType/

<img width="726" src="https://github.com/user-attachments/assets/a871ef29-926c-4bdd-825e-97c614eedc63">

This PR just fix that.