### PR TITLE
Fix typos, casing, and make SoftwarePurpose entry description consistent

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -11,7 +11,7 @@ A process that takes data in any valid form (e.g., various serializations of SPD
 
 ## Class
 
-A represention of a scope/set of individual instances of a particular “concept” (e.g., File, Person, ExternalReference, etc.).
+A representation of a scope/set of individual instances of a particular “concept” (e.g., File, Person, ExternalReference, etc.).
 
 Each individual instance of a class has an Internationalized Resource Identifier (IRI) and is asserted as a member of a particular class via a type statement.
 
@@ -25,7 +25,7 @@ One example could be the requirement of a specific hash algorithm to be present.
 
 ## Core
 
-The namespace which contains definitions and constraints for all concpet classes and properties which are common to all other domains within the targeted scope of SPDX.
+The namespace which contains definitions and constraints for all concept classes and properties which are common to all other domains within the targeted scope of SPDX.
 
 ## Datatype property
 

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -31,9 +31,9 @@ In addition, the following Relationship Types may be used to describe a Build.
   or host.
 - configures: Describes the relationship from a configuration to the Build
   element.
-- ancestorOf: Describes a relationship from a Build element to Build eelements
+- ancestorOf: Describes a relationship from a Build element to Build elements
   that describe its child builds.
-- decendentOf: Describes a relationship from a child Build element to its
+- descendantOf: Describes a relationship from a child Build element to its
   parent.
 - usesTool: Describes a relationship from a Build element to a build tool.
 

--- a/model/Build/Properties/buildType.md
+++ b/model/Build/Properties/buildType.md
@@ -18,7 +18,7 @@ elements, it means they are the same kind of build, but difference instances
 and possible with different configurations.
 
 If you are not using a well-known buildType, it should be namespaced to a
-domain you own to prevent conflicts with other builtType IRIs.
+domain you own to prevent conflicts with other buildType IRIs.
 
 Examples of a buildType might be:
 

--- a/model/Core/Properties/dataLicense.md
+++ b/model/Core/Properties/dataLicense.md
@@ -23,7 +23,6 @@ and the identification of the supplier of SPDX files.
 Compliance with this document includes populating the SPDX fields therein
 with data related to such fields ("SPDX-Metadata").
 
-
 This document contains numerous fields where an SPDX file creator may provide
 relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness
 of "database rights" (in jurisdictions where applicable),

--- a/model/Core/Properties/externalSpdxId.md
+++ b/model/Core/Properties/externalSpdxId.md
@@ -9,7 +9,7 @@ external to that SpdxDocument.
 
 ## Description
 
-ExternalSpdxId identifies an external Element used within an SpdxDocument but
+An externalSpdxId identifies an external Element used within an SpdxDocument but
 defined external to that SpdxDocument.
 
 ## Metadata

--- a/model/Core/Properties/hashValue.md
+++ b/model/Core/Properties/hashValue.md
@@ -8,7 +8,7 @@ The result of applying a hash algorithm to an Element.
 
 ## Description
 
-HashValue is the result of applying a hash algorithm to an Element.
+A hashValue is the result of applying a hash algorithm to an Element.
 
 ## Metadata
 

--- a/model/Core/Properties/import.md
+++ b/model/Core/Properties/import.md
@@ -8,7 +8,7 @@ Provides an ExternalMap of Element identifiers.
 
 ## Description
 
-Import provides an ExternalMap of an Element identifier that is used within a
+An import provides an ExternalMap of an Element identifier that is used within a
 document but defined external to that document.
 
 ## Metadata

--- a/model/Core/Properties/originatedBy.md
+++ b/model/Core/Properties/originatedBy.md
@@ -8,7 +8,7 @@ Identifies from where or whom the Element originally came.
 
 ## Description
 
-OriginatedBy identifies from where or whom the Element originally came.
+An originatedBy identifies from where or whom the Element originally came.
 
 ## Metadata
 

--- a/model/Core/Properties/spdxId.md
+++ b/model/Core/Properties/spdxId.md
@@ -8,7 +8,7 @@ Identifies an Element to be referenced by other Elements.
 
 ## Description
 
-SpdxId uniquely identifies an Element which may thereby be referenced by other Elements.
+An spdxId uniquely identifies an Element which may thereby be referenced by other Elements.
 These references may be internal or external.
 While there may be several versions of the same Element, each one needs to be able to be referred to uniquely
 so that relationships between Elements can be clearly articulated.

--- a/model/Core/Properties/verifiedUsing.md
+++ b/model/Core/Properties/verifiedUsing.md
@@ -9,7 +9,7 @@ asserted.
 
 ## Description
 
-VerifiedUsing provides an IntegrityMethod with which the integrity of an
+A verifiedUsing provides an IntegrityMethod with which the integrity of an
 Element can be asserted.
 
 Please note that different profiles may also provide additional methods for

--- a/model/Core/Vocabularies/AnnotationType.md
+++ b/model/Core/Vocabularies/AnnotationType.md
@@ -16,5 +16,5 @@ AnnotationType specifies the type of an annotation.
 
 ## Entries
 
-- other: Used to store extra information about an Element which is not part of a Review (e.g. extra information provided during the creation of the Element).
+- other: Used to store extra information about an Element which is not part of a review (e.g. extra information provided during the creation of the Element).
 - review: Used when someone reviews the Element.

--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -8,7 +8,7 @@ Specifies the type of an external identifier.
 
 ## Description
 
-ExteralIdentifierType specifies the type of an external identifier.
+ExternalIdentifierType specifies the type of an external identifier.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -73,7 +73,7 @@ name completes the sentence:
 - hasVariant: Every `to` Element is a variant the `from` Element (`from` hasVariant `to`).
 - invokedBy: The `from` Element was invoked by the `to` Agent, during a LifecycleScopeType period (for example, a Build element that describes a build step).
 - modifiedBy: The `from` Element is modified by each `to` Element.
-- other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationhip types (this relationship is directionless).
+- other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationship types (this relationship is directionless).
 - packagedBy: Every `to` Element is a packaged instance of the `from` Element (`from` packagedBy `to`).
 - patchedBy: Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`).
 - publishedBy: Designates a `from` Vulnerability was made available for public use or reference by each `to` Agent.

--- a/model/Security/Properties/impactStatement.md
+++ b/model/Security/Properties/impactStatement.md
@@ -12,7 +12,7 @@ justification label.
 
 When a VEX product element is related with a VexNotAffectedVulnAssessmentRelationship
 and a machine readable justification label is not provided, then an impactStatement
-that further explains how or why the prouct(s) are not affected by the vulnerability
+that further explains how or why the product(s) are not affected by the vulnerability
 must be provided.
 
 ## Metadata

--- a/model/Software/Properties/additionalPurpose.md
+++ b/model/Software/Properties/additionalPurpose.md
@@ -8,7 +8,7 @@ Provides additional purpose information of the software artifact.
 
 ## Description
 
-Additional purpose provides information about the additional purposes of the
+An additionalPurpose provides information about the additional purpose of the
 software artifact in addition to the primaryPurpose.
 
 ## Metadata

--- a/model/Software/Properties/sourceInfo.md
+++ b/model/Software/Properties/sourceInfo.md
@@ -9,7 +9,7 @@ about the origin of the package.
 
 ## Description
 
-SourceInfo records any relevant background information or additional comments
+A sourceInfo records any relevant background information or additional comments
 about the origin of the package.
 
 For example, this field might include comments indicating whether the package

--- a/model/Software/Vocabularies/SoftwarePurpose.md
+++ b/model/Software/Vocabularies/SoftwarePurpose.md
@@ -23,32 +23,32 @@ conclusions about the context in which the Element exists.
 
 ## Entries
 
-- application: the Element is a software application
-- archive: the Element is an archived collection of one or more files (.tar, .zip, etc)
-- bom: Element is a bill of materials
-- configuration: Element is configuration data
-- container: the Element is a container image which can be used by a container runtime application
-- data: Element is data
-- device: the Element refers to a chipset, processor, or electronic board
-- diskImage: the Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc.
-- deviceDriver: Element represents software that controls hardware devices
-- documentation: Element is documentation
-- evidence: the Element is the evidence that a specification or requirement has been fulfilled
-- executable: Element is an Artifact that can be run on a computer
-- file: the Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc)
-- filesystemImage: the Element is a file system image that can be written to a disk (or virtual) partition
-- firmware: the Element provides low level control over a device's hardware
-- framework: the Element is a software framework
-- install: the Element is used to install software on disk
-- library: the Element is a software library
-- manifest: the Element is a software manifest
-- model: the Element is a machine learning or artificial intelligence model
-- module: the Element is a module of a piece of software
-- operatingSystem: the Element is an operating system
-- other: the Element doesn't fit into any of the other categories
-- patch: Element contains a set of changes to update, fix, or improve another Element
-- platform: Element represents a runtime environment
-- requirement: the Element provides a requirement needed as input for another Element
-- source: the Element is a single or a collection of source files
-- specification: the Element is a plan, guideline or strategy how to create, perform or analyse an application
-- test: The Element is a test used to verify functionality on an software element
+- application: The Element is a software application.
+- archive: The Element is an archived collection of one or more files (.tar, .zip, etc.).
+- bom: The Element is a bill of materials.
+- configuration: The Element is configuration data.
+- container: The Element is a container image which can be used by a container runtime application.
+- data: The Element is data.
+- device: The Element refers to a chipset, processor, or electronic board.
+- diskImage: The Element refers to a disk image that can be written to a disk, booted in a VM, etc. A disk image typically contains most or all of the components necessary to boot, such as bootloaders, kernels, firmware, userspace, etc.
+- deviceDriver: The Element represents software that controls hardware devices.
+- documentation: The Element is documentation.
+- evidence: The Element is the evidence that a specification or requirement has been fulfilled.
+- executable: The Element is an Artifact that can be run on a computer.
+- file: The Element is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc.).
+- filesystemImage: The Element is a file system image that can be written to a disk (or virtual) partition.
+- firmware: The Element provides low level control over a device's hardware.
+- framework: The Element is a software framework.
+- install: The Element is used to install software on disk.
+- library: The Element is a software library.
+- manifest: The Element is a software manifest.
+- model: The Element is a machine learning or artificial intelligence model.
+- module: The Element is a module of a piece of software.
+- operatingSystem: The Element is an operating system.
+- other: The Element doesn't fit into any of the other categories.
+- patch: The Element contains a set of changes to update, fix, or improve another Element.
+- platform: The Element represents a runtime environment.
+- requirement: The Element provides a requirement needed as input for another Element.
+- source: The Element is a single or a collection of source files.
+- specification: The Element is a plan, guideline or strategy how to create, perform or analyze an application.
+- test: The Element is a test used to verify functionality on an software element.


### PR DESCRIPTION
- Fix typos in model descriptions
- Make sure that the property names have correct casing (starts with a lowercase letter) in model descriptions
  - "ExternalSpdxId identifies ..." --> "An externalSpdxId identifies ..."
- Add "The" to entry description of SoftwarePurpose vocab (some already have, some don't; also make "The" casing consistent with entry description in other vocabs)
  - "Element ..." --> "The Element ..."
