### PR TITLE
Fix typo: Asbtract -> Abstract

### DIFF
--- a/model/Security/Classes/VexVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexVulnAssessmentRelationship.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Asbtract ancestor class for all VEX relationships
+Abstract ancestor class for all VEX relationships
 
 ## Description
 
@@ -17,10 +17,10 @@ When linking elements using a VexVulnAssessmentRelationship, the following
 requirements must be observed:
 
 - The from: end must be a /Security/Vulnerability classed element
-- The to: end must point to elements representing the VEX _products_.
+- The to: end must point to elements representing the VEX *products*.
 
 To specify a different element where the vulnerability was detected, the VEX
-relationship can optionally specify _subcomponents_ using the assessedElement
+relationship can optionally specify *subcomponents* using the assessedElement
 property.
 
 VEX inherits information from the document level down to its statements. When a


### PR DESCRIPTION
In VexVulnAssessmentRelationship class:

- "Asbtract" -> "Abstract"
- Also fix inconsistent use of emphasis markup (`_,,,_` -> `*...*`) (the rest of the model files use `*...*`)