### PR TITLE
Fix typos: an -> a; descendents -> descendants

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -25,8 +25,7 @@ the following has to hold:
 
 1. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
    of type `hasConcludedLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
+   and a `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
 2. for every `/AI/AIPackage` there MUST exist exactly one `/Core/Relationship`
    of type `hasDeclaredLicense` having that element as its `from` property
-   and an `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
-
+   and a `/SimpleLicensing/AnyLicenseInfo` as its `to` property.

--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 ## Summary
 
 Standardized way of indicating the type of content of an Element or a Property.
-A String constrained to the RFC 2046 specificiation.
+A String constrained to the RFC 2046 specification.
 
 ## Description
 

--- a/model/Core/Individuals/NoAssertionElement.md
+++ b/model/Core/Individuals/NoAssertionElement.md
@@ -23,7 +23,7 @@ For example, a Relationship with
 and
 `to`=NoAssertionElement
 is explicitly expressing that
-no assertion is being made about any potential descendents of Element1.
+no assertion is being made about any potential descendants of Element1.
 
 ## Metadata
 

--- a/model/Core/Individuals/NoneElement.md
+++ b/model/Core/Individuals/NoneElement.md
@@ -17,7 +17,7 @@ For example, a Relationship with
 `from`=Element1,
 and `to`=NoneElement
 is explicitly expressing an assertion that
-Element1 has no descendents.
+Element1 has no descendants.
 
 ## Metadata
 

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -24,9 +24,9 @@ the following has to hold:
 
 1. for every `/Dataset/DatasetPackage` there MUST exist exactly one
    `/Core/Relationship` of type `hasConcludedLicense` having that element as its
-   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
     property.
 2. for every `/Dataset/DatasetPackage` there MUST exist exactly one
    `/Core/Relationship` of type `hasDeclaredLicense` having that element as its
-   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
     property.

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -119,5 +119,5 @@ the following has to hold:
 
 1. for every `/Software/SoftwareArtifact` there MUST exist exactly one
    `/Core/Relationship` of type `hasConcludedLicense` having that element as
-   its `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   its `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.

--- a/model/Lite/Lite.md
+++ b/model/Lite/Lite.md
@@ -40,11 +40,11 @@ Additionally:
 
 1. for every `/Software/Package` there MUST exist exactly one
    `/Core/Relationship` of type `hasConcludedLicense` having that element as
-   its `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   its `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.
 2. for every `/Software/Package` there MUST exist exactly one
    `/Core/Relationship` of type `hasDeclaredLicense` having that element as its
-   `from` property and an `/SimpleLicensing/AnyLicenseInfo` as its `to`
+   `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
    property.
 
 For a `/Core/SpdxDocument` to be conformant with this profile, the following has to hold:


### PR DESCRIPTION
- an /SimpleLicensing/AnyLicenseInfo -> a /SimpleLicensing/AnyLicenseInfo
- specificiation -> specification
- descendents -> descendants