### PR TITLE
VEX affected cardinalities

### DIFF
--- a/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
@@ -47,8 +47,9 @@ following requirements must be observed:
 
 - actionStatement
   - type: xsd:string
-  - minCount: 0
+  - minCount: 1
   - maxCount: 1
 - actionStatementTime
   - type: /Core/DateTime
   - minCount: 0
+  - maxCount: 1


### PR DESCRIPTION
- /Security/actionStatement:
The description in actionStatement states that:
"When an element is referenced with a VexAffectedVulnAssessmentRelationship, the relationship MUST include one actionStatement that SHOULD describe actions to remediate or mitigate the vulnerability".

This conforms to VEX_Use_Cases_Aprill2022:
"If a status is AFFECTED, the VEX document must have an action statement that tells the product user what to do".

The cardinality of actionStatement in VexAffectedVulnAssessmentRelationship is 0..1 but should to be 1..1.


- /Security/actionStatementTime:
It is optional and records the time when the actionStatement was first communicated (this conforms to the VEX docs).

The cardinality of actionStatementTime in VexAffectedVulnAssessmentRelationship is 0..* but should to be 0..1.
