### PR TITLE
use relative path syntax

### DIFF
--- a/model/Core/Properties/packageVerificationCodeExcludedFile.md
+++ b/model/Core/Properties/packageVerificationCodeExcludedFile.md
@@ -12,9 +12,7 @@ The relative file name of a file to be excluded from the
 A relative filename with the root of the package archive or directory
 referencing a file to be excluded from the `PackageVerificationCode`.
 
-In general, every filename is preceded with a `./`, see
-[RFC 3986 Uniform Resource Identifier (URI): Generic Syntax](https://datatracker.ietf.org/doc/rfc3986/)
-for syntax.
+Every filename is preceded with a `./`.
 
 ## Metadata
 


### PR DESCRIPTION
Require filenames to use the relative path syntax.

To fix https://github.com/spdx/spdx-3-model/issues/910