### PR TITLE
Use 4-space indent for nested unordered list to make it render correctly with MkDocs

### DIFF
--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -41,24 +41,24 @@ A hasDeclaredLicense may be expressed differently in practice for different
 types of Software Artifacts. For example:
 
 - for Packages:
-  - would include license info for the Package as a
-    whole, found in the Package itself (e.g., LICENSE file,
-    README file, metadata in the Package, etc.)
-  - would not include any license information that is not in the Package
-    itself (e.g., license information from the project's website or from a
+    - would include license info for the Package as a
+      whole, found in the Package itself (e.g., LICENSE file,
+      README file, metadata in the Package, etc.)
+    - would not include any license information that is not in the Package
+      itself (e.g., license information from the project's website or from a
       third party repository or website)
 - for Files:
-  - would include license info found in the File itself (e.g., license
-    header or notice, comments indicating the license, SPDX-License-Identifier
-    expression)
-  - would not include license info found in a different file (e.g., LICENSE
-    file in the top directory of a repository)
+    - would include license info found in the File itself (e.g., license
+      header or notice, comments indicating the license, SPDX-License-Identifier
+      expression)
+    - would not include license info found in a different file (e.g., LICENSE
+      file in the top directory of a repository)
 - for Snippets:
-  - would include license info found in the Snippet itself (e.g., license
-    notice, comments, SPDX-License-Identifier expression)
-  - would not include license info found elsewhere in the File or in a
-    different File (e.g., comment at top of File if it is not within the
-    Snippet, LICENSE file in the top directory of a repository)
+    - would include license info found in the Snippet itself (e.g., license
+      notice, comments, SPDX-License-Identifier expression)
+    - would not include license info found elsewhere in the File or in a
+      different File (e.g., comment at top of File if it is not within the
+      Snippet, LICENSE file in the top directory of a repository)
 
 A hasDeclaredLicense relationship to NoneLicense indicates that the
 corresponding Package, File or Snippet contains no license information


### PR DESCRIPTION
Option 1/3 to fix #916

![](https://github.com/user-attachments/assets/0a1a66d9-daeb-4cb9-bd69-26a654f63f2a)

Options:

- #920
- #921
- #922

**Only one of the three should be used**