### PR TITLE
Add notes that English is the normative language (target: `support/3.0`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,32 @@ All use cases supported by the prior version are supported here as well.
 This repository holds the model for the information captured in SPDX version 3
 standard.
 
+Translations of the information model may be available.
+English remains the normative language in all cases.
+
 ## Branch Structure
 
-The SPDX 3 model repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0) workflow with the addition of support branches.
+The SPDX 3 model repo follows the
+[Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0)
+workflow with the addition of support branches.
 
 The branches in use are:
 
 - `main` - This will always be the latest released specification.
-- `develop` - This branch will be where the active development for the next major or minor version takes place.  Once released, the `develop` branch will be merged into the `main` branch.
-- `support/x.y` - These branches will be long lived and contain any updates to a minor version of the specification.  Additions such as translations can be added to the support branch.  `x.y` represents the major.minor version.  Once any changes are accepted and released, the support branch will be tagged and merged into both the develop and main branches.
-- General feature or fix branches - there may be feature branches made for specific enhancements or fixes to the spec.  These will be short lived and merged into either a support branch or the develop branch.
+- `develop` - This branch will be where the active development for the next
+  major or minor version takes place.
+  Once released, the `develop` branch will be merged into the `main` branch.
+- `support/x.y` - These branches will be long-lived and contain any updates to
+  a minor version of the specification.
+  Additions such as translations can be added to the support branch.
+  `x.y` represents the MAJOR.MINOR version, following Semantic Versioning
+  (SemVer) conventions.
+  Once any changes are accepted and released, the support branch will be tagged
+  and merged into both `develop` and `main` branches.
+- General feature or fix branches - there may be feature branches made for
+  specific enhancements or fixes to the spec.
+  These will be short-lived and merged into either a `support` branch or the
+  `develop` branch.
 
 ## Formats
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ All use cases supported by the prior version are supported here as well.
 This repository holds the model for the information captured in SPDX version 3
 standard.
 
-## Branches and Formats
+## Branch Structure
+
+The SPDX spec repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0) workflow with the addition of support branches.
+
+The branches in use are:
+
+- `main` - This will always be the latest released specification.
+- `develop` - This branch will be where the active development for the next major or minor version takes place.  Once released, the `develop` branch will be merged into the `main` branch.
+- `support/x.y` - These branches will be long lived and contain any updates to a minor version of the specification.  Additions such as translations can be added to the support branch.  `x.y` represents the major.minor version.  Once any changes are accepted and released, the support branch will be tagged and merged into both the develop and main branches.
+- General feature or fix branches - there may be feature branches made for specific enhancements or fixes to the spec.  These will be short lived and merged into either a support branch or the develop branch.
+
+## Formats
 
 The editable files inside `model/` directory are written in a
 [constrained subset of Markdown][format],

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ standard.
 
 ## Branch Structure
 
-The SPDX spec repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0) workflow with the addition of support branches.
+The SPDX 3 model repo follows the [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0) workflow with the addition of support branches.
 
 The branches in use are:
 

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -28,6 +28,8 @@ Therefore, the language tag used to identify the language must follow the
 well-formedness rules defined in [IETF BCP 47 (RFC 5646)][rfc5646].
 Appendix A of that document provides examples of valid language tags.
 
+English remains the normative language in all cases.
+
 [headings]: ./format.md#syntax
 [language-tagged-string]: https://www.w3.org/TR/rdf11-concepts/#dfn-language-tagged-string
 [rfc5646]: https://datatracker.ietf.org/doc/rfc5646


### PR DESCRIPTION
### Background

- Chinese (zh-Hans) translations are started to get merged into `support/3.0` branch
  - For example, https://github.com/spdx/spdx-3-model/blob/support/3.0/model/Build/Build.md
- We don't have the normative language notification yet in `support/3.0` branch
  - It is one of to-dos in https://github.com/spdx/spdx-spec/issues/1169

### What this PR do?

- Add a notes "English remains the normative language in all cases." to README and translation.md in `support/3.0` branch
- (This change has already been merged to `develop` branch by #946)
