### PR TITLE
simplelicensing: Change custom license additions to link to an Element

### DIFF
--- a/model/Core/Classes/ElementMap.md
+++ b/model/Core/Classes/ElementMap.md
@@ -1,0 +1,32 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# ElementMap
+
+## Summary
+
+A key with an Element.
+
+## Description
+
+The class used for implementing mapping a string key to an Element.
+
+Each ElementMap contains a key-value pair which maps the key to its
+associated Element.
+
+To implement a dictionary, this class is to be used in a collection with
+unique keys.
+
+## Metadata
+
+- name: ElementMap
+- Instantiability: Concrete
+
+## Properties
+
+- key
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- elementValue
+  - type: Element
+  - maxCount: 1

--- a/model/Core/Classes/ElementMap.md
+++ b/model/Core/Classes/ElementMap.md
@@ -29,4 +29,5 @@ unique keys.
   - maxCount: 1
 - elementValue
   - type: Element
+  - minCount: 1
   - maxCount: 1

--- a/model/Core/Properties/elementValue.md
+++ b/model/Core/Properties/elementValue.md
@@ -1,0 +1,20 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# elementValue
+
+## Summary
+
+A value used in a key-value pair with a generic key that refers to an Element
+
+## Description
+
+A value used in a key-value pair with a generic key that refers to an Element.
+
+A key-value pair can be used to implement a dictionary which associates a key
+with an Element.
+
+## Metadata
+
+- name: elementValue
+- Nature: ObjectProperty
+- Range: Element

--- a/model/SimpleLicensing/Classes/LicenseExpression.md
+++ b/model/SimpleLicensing/Classes/LicenseExpression.md
@@ -21,6 +21,9 @@ set forth in that Annex.
 The ExpandedLicensing profile can be used to represent the complete parsed
 license expression as a combination of license objects.
 
+`customIdToUri` is deprecated. Migrate to `customIdToLicense`. `customIdToUri`
+will be removed in a future release.
+
 ## Metadata
 
 - name: LicenseExpression
@@ -38,4 +41,7 @@ license expression as a combination of license objects.
   - maxCount: 1
 - customIdToUri
   - type: /Core/DictionaryEntry
+  - minCount: 0
+- customIdToLicense
+  - type: /Core/ElementMap
   - minCount: 0

--- a/model/SimpleLicensing/Properties/customIdToLicense.md
+++ b/model/SimpleLicensing/Properties/customIdToLicense.md
@@ -1,0 +1,29 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# customIdToLicense
+
+## Summary
+
+Maps a "LicenseRef-" string for a custom license or a "AdditionRef-" string for
+a custom license addition to a `CustomLicense`, a `CustomLicenseAddition`, or a
+`SimpleLicensingText`.
+
+## Description
+
+Within a license expression, references can be made to a custom license or a
+custom license addition.
+
+The [License Expression syntax](../../../annexes/spdx-license-expressions.md)
+dictates any reference starting with a
+"LicenseRef-" or "AdditionRef-" refers to license or addition text not found in
+the official [SPDX License List](https://spdx.org/licenses/).
+
+The key for the DictionaryEntry is the string used in the license expression
+and the value is target Element, which must be a CustomLicense,
+CustomLicenseAddition, or SimpleLicensingText.
+
+## Metadata
+
+- name: customIdToLicense
+- Nature: ObjectProperty
+- Range: /Core/ElementMap

--- a/model/SimpleLicensing/Properties/customIdToUri.md
+++ b/model/SimpleLicensing/Properties/customIdToUri.md
@@ -4,10 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
+**DEPRECATED**
+
 Maps a LicenseRef or AdditionRef string for a Custom License or a Custom
 License Addition to its URI ID.
 
 ## Description
+
+**NOTE** This field is deprecated and only included for backward compatibility.
+New documents should use customIdToLicense instead.
 
 Within a License Expression, references can be made to a Custom License or a
 Custom License Addition.


### PR DESCRIPTION
Using a DictionaryEntry to map license additions in the `customIdToUri` field has the unfortunate side effect that the dictionary entry value will not be resolve to an actual object by either SHACL or code bindings, since they are unaware that the value is supposed to be an object IRI.

As such, create a new `ElementMap` object which can be used to map string keys to Elements, and use this in a new `customIdToLicense` property. The original `customIdToUri` property is retained for backward compatibility, but marked as deprecated.