### PR TITLE
VulnAssessmentRelationship example fixes

### DIFF
--- a/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
@@ -47,7 +47,7 @@ It is intended to communicate the results of using a CVSS calculator.
       "locator": "https://github.com/indutny/elliptic/commit/441b742"
     }
   ],
-  "suppliedBy": ["urn:spdx.dev:agent-my-security-vendor"],
+  "suppliedBy": "urn:spdx.dev:agent-my-security-vendor",
   "publishedTime": "2023-05-06T10:06:13Z"
 },
 {

--- a/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
@@ -22,7 +22,7 @@ It is intended to communicate the results of using a CVSS calculator.
 
 ```json
 {
-  "type": "CvssV2VulnAssessmentRelationship",
+  "type": "security_CvssV2VulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:cvssv2-cve-2020-28498",
   "relationshipType": "hasAssessmentFor",
   "security_score": "4.3",

--- a/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV2VulnAssessmentRelationship.md
@@ -26,7 +26,7 @@ It is intended to communicate the results of using a CVSS calculator.
   "spdxId": "urn:spdx.dev:cvssv2-cve-2020-28498",
   "relationshipType": "hasAssessmentFor",
   "security_score": "4.3",
-  "security_vectorString": "(AV:N/AC:M/Au:N/C:P/I:N/A:N)",
+  "security_vectorString": "AV:N/AC:M/Au:N/C:P/I:N/A:N",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:npm-elliptic-6.5.2",

--- a/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
@@ -50,7 +50,7 @@ It is intended to communicate the results of using a CVSS calculator.
       "locator": "https://github.com/indutny/elliptic/commit/441b742"
     }
   ],
-  "suppliedBy": ["urn:spdx.dev:agent-my-security-vendor"],
+  "suppliedBy": "urn:spdx.dev:agent-my-security-vendor",
   "publishedTime": "2023-05-06T10:06:13Z"
 },
 {

--- a/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV3VulnAssessmentRelationship.md
@@ -24,7 +24,7 @@ It is intended to communicate the results of using a CVSS calculator.
 
 ```json
 {
-  "type": "CvssV3VulnAssessmentRelationship",
+  "type": "security_CvssV3VulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:cvssv3-cve-2020-28498",
   "relationshipType": "hasAssessmentFor",
   "security_score": "6.8",

--- a/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
@@ -27,7 +27,7 @@ It is intended to communicate the results of using a CVSS calculator.
   "relationshipType": "hasAssessmentFor",
   "security_severity": "critical",
   "security_score": "10.0",
-  "security_vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/AR:N/UI:N/VCH/VI:H/VA:H/SC:H/SI:H/SA:H/E:A",
+  "security_vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N",
   "from": "urn:spdx.dev:vuln-cve-2021-44228",
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:apache-log4j-2.14.1",

--- a/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
@@ -48,7 +48,7 @@ It is intended to communicate the results of using a CVSS calculator.
       "locator": "https://www.first.org/cvss/v4.0/examples#Apache-log4j-Vulnerability-CVE-2021-44228"
     },
   ],
-  "suppliedBy": ["urn:spdx.dev:agent-my-security-vendor"],
+  "suppliedBy": "urn:spdx.dev:agent-my-security-vendor",
   "publishedTime": "2023-10-05T23:09:13Z"
 },
 {

--- a/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
@@ -25,7 +25,7 @@ It is intended to communicate the results of using a CVSS calculator.
   "type": "CvssV4VulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:cvssv4-cve-2021-44228",
   "relationshipType": "hasAssessmentFor",
-  "security_severity": "medium",
+  "security_severity": "critical",
   "security_score": "10.0",
   "security_vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/AR:N/UI:N/VCH/VI:H/VA:H/SC:H/SI:H/SA:H/E:A",
   "from": "urn:spdx.dev:vuln-cve-2021-44228",

--- a/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
@@ -22,7 +22,7 @@ It is intended to communicate the results of using a CVSS calculator.
 
 ```json
 {
-  "type": "CvssV4VulnAssessmentRelationship",
+  "type": "security_CvssV4VulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:cvssv4-cve-2021-44228",
   "relationshipType": "hasAssessmentFor",
   "security_severity": "critical",

--- a/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
+++ b/model/Security/Classes/CvssV4VulnAssessmentRelationship.md
@@ -33,17 +33,17 @@ It is intended to communicate the results of using a CVSS calculator.
   "security_assessedElement": "urn:apache-log4j-2.14.1",
   "externalRef": [
     {
-      "@type": "ExternalRef",
+      "type": "ExternalRef",
       "externalRefType": "securityAdvisory",
       "locator": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228"
     },
     {
-      "@type": "ExternalRef",
+      "type": "ExternalRef",
       "externalRefType": "securityAdvisory",
       "locator": "https://logging.apache.org/log4j/2.x/security.html"
     },
     {
-      "@type": "ExternalRef",
+      "type": "ExternalRef",
       "externalRefType": "securityOther",
       "locator": "https://www.first.org/cvss/v4.0/examples#Apache-log4j-Vulnerability-CVE-2021-44228"
     },

--- a/model/Security/Classes/EpssVulnAssessmentRelationship.md
+++ b/model/Security/Classes/EpssVulnAssessmentRelationship.md
@@ -31,7 +31,7 @@ scores, using the Exploit Prediction Scoring System (EPSS) as defined at
   "security_percentile": "0.42356",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2023-10-05T00:00:30Z"
 }
 ```

--- a/model/Security/Classes/EpssVulnAssessmentRelationship.md
+++ b/model/Security/Classes/EpssVulnAssessmentRelationship.md
@@ -24,7 +24,7 @@ scores, using the Exploit Prediction Scoring System (EPSS) as defined at
 
 ```json
 {
-  "type": "EpssVulnAssessmentRelationship",
+  "type": "security_EpssVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:epss-CVE-2020-28498",
   "relationshipType": "hasAssessmentFor",
   "security_probability": "0.00105",

--- a/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
+++ b/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
@@ -20,7 +20,7 @@ listed in any exploit catalog such as the
 
 ```json
 {
-  "type": "ExploitCatalogVulnAssessmentRelationship",
+  "type": "security_ExploitCatalogVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:exploit-catalog-1",
   "relationshipType": "hasAssessmentFor",
   "security_catalogType": "kev",

--- a/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
+++ b/model/Security/Classes/ExploitCatalogVulnAssessmentRelationship.md
@@ -28,7 +28,7 @@ listed in any exploit catalog such as the
   "security_exploited": "true",
   "from": "urn:spdx.dev:vuln-cve-2023-2136",
   "to": ["urn:product-google-chrome-112.0.5615.136"],
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/SsvcVulnAssessmentRelationship.md
+++ b/model/Security/Classes/SsvcVulnAssessmentRelationship.md
@@ -23,8 +23,8 @@ It is intended to communicate the results of using the CISA SSVC Calculator.
 
 ```json
 {
-  "@type": "SsvcVulnAssessmentRelationship",
-  "@id": "urn:spdx.dev:ssvc-1",
+  "type": "SsvcVulnAssessmentRelationship",
+  "spdxId": "urn:spdx.dev:ssvc-1",
   "relationshipType": "hasAssessmentFor",
   "security_decisionType": "act",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",

--- a/model/Security/Classes/SsvcVulnAssessmentRelationship.md
+++ b/model/Security/Classes/SsvcVulnAssessmentRelationship.md
@@ -23,7 +23,7 @@ It is intended to communicate the results of using the CISA SSVC Calculator.
 
 ```json
 {
-  "type": "SsvcVulnAssessmentRelationship",
+  "type": "security_SsvcVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:ssvc-1",
   "relationshipType": "hasAssessmentFor",
   "security_decisionType": "act",

--- a/model/Security/Classes/SsvcVulnAssessmentRelationship.md
+++ b/model/Security/Classes/SsvcVulnAssessmentRelationship.md
@@ -30,7 +30,7 @@ It is intended to communicate the results of using the CISA SSVC Calculator.
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:npm-elliptic-6.5.2",
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
@@ -32,7 +32,7 @@ following requirements must be observed:
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:npm-elliptic-6.5.2",
   "security_actionStatement": "Upgrade to version 1.4 of ACME application.",
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexAffectedVulnAssessmentRelationship.md
@@ -25,7 +25,7 @@ following requirements must be observed:
 
 ```json
 {
-  "type": "VexAffectedVulnAssessmentRelationship",
+  "type": "security_VexAffectedVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:vex-affected-1",
   "relationshipType": "affects",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",

--- a/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
@@ -31,7 +31,7 @@ requirements must be observed:
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:npm-elliptic-6.5.4",
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
@@ -25,7 +25,7 @@ requirements must be observed:
 
 ```json
 {
-  "type": "VexFixedVulnAssessmentRelationship",
+  "type": "security_VexFixedVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:vex-fixed-in-1",
   "relationshipType": "fixedIn",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",

--- a/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexFixedVulnAssessmentRelationship.md
@@ -20,8 +20,6 @@ requirements must be observed:
 
 - Elements linked with a VulnVexFixedAssessmentRelationship are constrained to
   using the fixedIn relationship type.
-- The from: end of the relationship must be a /Security/Vulnerability classed
-  element.
 
 *Example*
 

--- a/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
@@ -37,7 +37,7 @@ following requirements must be observed:
   "security_assessedElement": "urn:npm-elliptic-6.5.2",
   "security_justificationType": "componentNotPresent",
   "security_impactStatement": "Not using this vulnerable part of this library.",
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
@@ -29,7 +29,7 @@ following requirements must be observed:
 
 ```json
 {
-  "type": "VexNotAffectedVulnAssessmentRelationship",
+  "type": "security_VexNotAffectedVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:vex-not-affected-1",
   "relationshipType": "doesNotAffect",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",

--- a/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexNotAffectedVulnAssessmentRelationship.md
@@ -20,8 +20,6 @@ following requirements must be observed:
 
 - Relating elements with a VexNotAffectedVulnAssessmentRelationship is
   restricted to the doesNotAffect relationship type.
-- The from: end of the relationship must be a /Security/Vulnerability classed
-  element.
 - Both impactStatement and justificationType properties have a cardinality of
   0..1 making them optional. Nevertheless, to produce a valid VEX not_affected
   statement, one of them MUST be defined. This is specified in the Minimum

--- a/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
@@ -25,7 +25,7 @@ the following requirements must be observed:
 
 ```json
 {
-  "type": "VexUnderInvestigationVulnAssessmentRelationship",
+  "type": "security_VexUnderInvestigationVulnAssessmentRelationship",
   "spdxId": "urn:spdx.dev:vex-underInvestigation-1",
   "relationshipType": "underInvestigationFor",
   "from": "urn:spdx.dev:vuln-cve-2020-28498",

--- a/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
@@ -20,8 +20,6 @@ the following requirements must be observed:
 
 - Elements linked with a VexUnderInvestigationVulnAssessmentRelationship are
   constrained to using the underInvestigationFor relationship type.
-- The from: end of the relationship must be a /Security/Vulnerability classed
-  element.
 
 *Example*
 

--- a/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexUnderInvestigationVulnAssessmentRelationship.md
@@ -31,7 +31,7 @@ the following requirements must be observed:
   "from": "urn:spdx.dev:vuln-cve-2020-28498",
   "to": ["urn:product-acme-application-1.3"],
   "security_assessedElement": "urn:npm-elliptic-6.5.2",
-  "suppliedBy": ["urn:spdx.dev:agent-jane-doe"],
+  "suppliedBy": "urn:spdx.dev:agent-jane-doe",
   "publishedTime": "2021-03-09T11:04:53Z"
 }
 ```

--- a/model/Security/Classes/VexVulnAssessmentRelationship.md
+++ b/model/Security/Classes/VexVulnAssessmentRelationship.md
@@ -16,7 +16,6 @@ properties shared by all the SPDX-VEX status relationships.
 When linking elements using a VexVulnAssessmentRelationship, the following
 requirements must be observed:
 
-- The from: end must be a /Security/Vulnerability classed element
 - The to: end must point to elements representing the VEX *products*.
 
 To specify a different element where the vulnerability was detected, the VEX

--- a/model/Security/Classes/Vulnerability.md
+++ b/model/Security/Classes/Vulnerability.md
@@ -14,10 +14,10 @@ Specifies a vulnerability and its associated information.
 
 ```json
 {
-  "type": "Vulnerability",
+  "type": "security_Vulnerability",
   "spdxId": "urn:spdx.dev:vuln-1",
   "summary": "Use of a Broken or Risky Cryptographic Algorithm",
-  "description": "The package `elliptic` before version 6.5.4 are vulnerable to ..."
+  "description": "The package `elliptic` before version 6.5.4 are vulnerable to ...",
   "modifiedTime": "2021-03-08T16:06:43Z",
   "publishedTime": "2021-03-08T16:02:50Z",
   "externalIdentifier": [


### PR DESCRIPTION
- cvss2 vector had parentheses
- cvss4 had severity=medium for score=10.0
- cvss4 vector was invalid
- replaced @type and @id
- suppliedBy has max cardinality of 1 so I removed the brackets
- RelationshipType requires "from" to be Vulnerability for VulnAssessmentRelationship. Requiring it again and in each subclass is redundant.
- Classes not in Core need to be prefixed with their profile. Added "security_".