### PR TITLE
Fix kilowatt-hour value typo in EnergyConsumptionDescription

### DIFF
--- a/model/AI/Classes/EnergyConsumptionDescription.md
+++ b/model/AI/Classes/EnergyConsumptionDescription.md
@@ -15,7 +15,7 @@ and the unit of measurement.
 The `energyQuantity` property stores the amount of energy consumed,
 and the `energyUnit` property stores the unit used for measurement.
 
-For example, 0.0042 kilowatt-hour of energy will have `0.042` as a value for
+For example, 0.042 kilowatt-hour of energy will have `0.042` as a value for
 property `energyQuantity`, and `"kilowattHour"` as a value for property
 `energyUnit`.
 
@@ -55,4 +55,4 @@ property `energyQuantity`, and `"kilowattHour"` as a value for property
 
 `energyQuantity`属性存储能耗的数量，而`energyUnit`属性存储测量单位。
 
-例如，0.0042千瓦时的能量，其`energyQuantity`属性的值将为`0.0042`，`energyUnit`属性的值为`"kilowattHour"`。
+例如，0.042千瓦时的能量，其`energyQuantity`属性的值将为`0.042`，`energyUnit`属性的值为`"kilowattHour"`。


### PR DESCRIPTION
- 0.0042 -> 0.042
- Similar to the merged PR #1004 but target `support/3.0` branch (also fix the inherited typo in Traditional Chinese translation)
