### PR TITLE
Operations: fix spec-parser errors

### DIFF
--- a/model/Operations/Classes/ApplicationFacts.md
+++ b/model/Operations/Classes/ApplicationFacts.md
@@ -35,7 +35,7 @@ The Application Facts are collected all along the product lifecyle and contents 
 - distributedDeliverables
   - type: /Core/Artifact
   - minCount: 1
-- technicalDeploymnent
+- technicalDeployment
   - type: deploymentType
   - minCount: 1
   - maxCount: 1

--- a/model/Operations/Classes/DeliverableFacts.md
+++ b/model/Operations/Classes/DeliverableFacts.md
@@ -73,6 +73,3 @@ The deliverable facts are collected and update in all deliverable lifecycle phas
 - deliverableComment
   - type: xsd:string
   - maxCount: 1
-- supplierDeliverableFacts
-  - type: Delivery
-  - minCount: 0

--- a/model/Operations/Classes/Delivery.md
+++ b/model/Operations/Classes/Delivery.md
@@ -13,5 +13,5 @@ tbd
 ## Metadata
 
 - name: Delivery
-- SubclassOf: Core/Relationship
+- SubclassOf: /Core/Relationship
 - Instantiability: Concrete

--- a/model/Operations/Properties/reviews.md
+++ b/model/Operations/Properties/reviews.md
@@ -12,6 +12,6 @@ This field provides the links to the review reports
 
 ## Metadata
 
-- name: relationType
+- name: reviews
 - Nature: DataProperty
 - Range: xsd:anyURI


### PR DESCRIPTION
I ran the current state of the profile operations branch with spec-parser (df16de0) and fixed any errors.

The branch is probably still not free from content errors, but getting rid of these syntax errors should help with any further changes.