### PR TITLE
Update info about SPDX 3 JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ standard.
 Translations of the information model may be available.
 English remains the normative language in all cases.
 
-[![Core Profile diagram](./images/model-Core.png "Core Profile diagram")](./images/model-Core.png)
-
 ## Table of contents
 
 - [Branch structure](#branch-structure)
@@ -90,10 +88,12 @@ For the specification content other than the model, they are in the
 ## Model
 
 The SPDX model is described using profiles related to the software application.
-The profiles are organized as sub-directories under the ‘model’ directory.
+The profiles are organized as sub-directories under the `model/` directory.
 
 The model diagram is available in [model.drawio][model-diagram] file
 and in [`images/`](./images/) directory.
+
+<a href="./images/" title="Click to see more Profile diagrams" ><img src="./images/model-Core.png" alt="Core Profile diagram" height="120" /></a>
 
 Note:
 
@@ -165,7 +165,8 @@ snippets, and artifacts of the software application.
 ## Serialization and validation
 
 Information about serialization of SPDX 3 documents can be found in the
-[Model and serializations][sr-spec] section of the SPDX specification.
+[Serialization information][sr-spec] section in the "Model and serializations"
+chapter of the SPDX specification.
 
 For additional technical information about serialization,
 please see [Notes on serialization][sr-notes].
@@ -198,7 +199,7 @@ All the details are in: <https://spdx.dev/participate/tech/>
 [format]: ./docs/format.md
 [translation]: ./docs/translation.md
 [model-diagram]: ./docs/model.drawio
-[sr-spec]: https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md
+[sr-spec]: https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md#serialization-information
 [sr-notes]: ./serialization/README.md
 [validate-spdx3]: ./serialization/jsonld/validation.md
 [glossary]: ./docs/glossary.md

--- a/README.md
+++ b/README.md
@@ -18,7 +18,20 @@ standard.
 Translations of the information model may be available.
 English remains the normative language in all cases.
 
-## Branch Structure
+[![Core Profile diagram](./images/model-Core.png "Core Profile diagram")](./images/model-Core.png)
+
+## Table of contents
+
+- [Branch structure](#branch-structure)
+- [Formats](#formats)
+- [Model](#model)
+  - [Profiles](#profiles-of-the-model)
+- [Serialization and validation](#serialization-and-validation)
+- [Change log](#change-log)
+- [Glossary](#glossary)
+- [Contribute](#contribute)
+
+## Branch structure
 
 The SPDX 3 model repo follows the
 [Gitflow](https://gist.github.com/HeratPatel/271b5d2304de2e2cd1823b9b62bf43e0)
@@ -79,7 +92,8 @@ For the specification content other than the model, they are in the
 The SPDX model is described using profiles related to the software application.
 The profiles are organized as sub-directories under the ‘model’ directory.
 
-The model diagram is available in [model.drawio][model-diagram] file.
+The model diagram is available in [model.drawio][model-diagram] file
+and in [`images/`](./images/) directory.
 
 Note:
 
@@ -148,6 +162,18 @@ and VEX (affected, not affected, under investigation, and fixed categories).
 The Software profile contains information about files, packages, SBOMs,
 snippets, and artifacts of the software application.
 
+## Serialization and validation
+
+Information about serialization of SPDX 3 documents can be found in the
+[Model and serializations][sr-spec] section of the SPDX specification.
+
+For additional technical information about serialization,
+please see [Notes on serialization][sr-notes].
+
+For information about the validation of SPDX 3 JSON documents,
+using JSON Schema and the SHACL model,
+please see [Validating SPDX 3 JSON Documents][validate-spdx3].
+
 ## Change log
 
 See [CHANGELOG.md](CHANGELOG.md) for changes between versions.
@@ -172,6 +198,9 @@ All the details are in: <https://spdx.dev/participate/tech/>
 [format]: ./docs/format.md
 [translation]: ./docs/translation.md
 [model-diagram]: ./docs/model.drawio
+[sr-spec]: https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md
+[sr-notes]: ./serialization/README.md
+[validate-spdx3]: ./serialization/jsonld/validation.md
 [glossary]: ./docs/glossary.md
 [meetings]: https://github.com/spdx/meetings/
 [spdx-tech-list]: https://lists.spdx.org/mailman/listinfo/spdx-tech

--- a/serialization/README.md
+++ b/serialization/README.md
@@ -4,8 +4,10 @@
 
 For information on what can be included in an SPDX serialization and how they
 are structured, please refer to the
-[Model and serializations](https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md)
-section of the SPDX specification.
+[Serialization information][sr-spec] section
+in the "Model and serializations" chapter of the SPDX specification.
+
+[sr-spec]: https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md#serialization-information
 
 ## Serialization formats
 

--- a/serialization/README.md
+++ b/serialization/README.md
@@ -4,7 +4,7 @@
 
 For information on what can be included in an SPDX serialization and how they
 are structured, please refer to the
-[Serialization information](https://github.com/spdx/spdx-spec/blob/development/v3.0.1/docs/serializations.md)
+[Model and serializations](https://github.com/spdx/spdx-spec/blob/develop/docs/serializations.md)
 section of the SPDX specification.
 
 ## Serialization formats

--- a/serialization/canonical.md
+++ b/serialization/canonical.md
@@ -16,7 +16,7 @@ Such a canonical form normalizes things like ordering and formatting.
 
 1. integers: represented in base 10 using decimal digits. Contains an integer component that may be prefixed with an optional minus sign. Leading zeros are not allowed.
 
-1. strings: UTF-8 representation without specific canonicalisation. A string begins and ends with quotation marks (%x22). Any Unicode characters may be placed within the quotation marks, except for the characters that MUST be escaped: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).
+1. strings: UTF-8 representation without specific normalization. A string begins and ends with quotation marks (%x22). Any Unicode characters may be placed within the quotation marks, except for the characters that MUST be escaped: quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).
 
 1. arrays: An array structure is represented as square brackets surrounding zero or more items. Items are separated by commas.
 

--- a/serialization/jsonld.md
+++ b/serialization/jsonld.md
@@ -65,7 +65,7 @@ An SPDX serialization in JSON-LD is considered valid if it validates against
 the OWL ontology which also includes SHACL shape restrictions.
 
 Read a detailed document on how to
-[validating SPDX 3 JSON-LD documents](jsonld/validation.md), structurally and
+[validating SPDX 3 JSON documents](jsonld/validation.md), structurally and
 semantically. The document also include a few tools that are known to work.
 
 The OWL ontology is located at <https://spdx.org/rdf/3.0.1/spdx-model.ttl>.

--- a/serialization/jsonld/examples.md
+++ b/serialization/jsonld/examples.md
@@ -1,4 +1,4 @@
-# JSON-LD Serialization Examples
+# SPDX 3 JSON Serialization Examples
 
 ## Agents
 
@@ -39,4 +39,4 @@
 ## Full examples
 
 - [Converted SPDX 3.0 document from SPDX 2.3 document](examples/converted_from_spdx_2.json)
-  - converted from [this file](https://github.com/spdx/spdx-spec/blob/development/v2.3.1/examples/SPDXJSONExample-v2.3.spdx.json)
+  - converted from [this file](https://github.com/spdx/spdx-spec/blob/support/2.3.1/examples/SPDXJSONExample-v2.3.spdx.json)

--- a/serialization/jsonld/validation.md
+++ b/serialization/jsonld/validation.md
@@ -1,6 +1,11 @@
-# Validating SPDX 3 JSON-LD documents
+# Validating SPDX 3 JSON documents
 
-There are two mechanisms for validating SPDX 3 JSON-LD documents:
+> The SPDX 3 JSON format is a strict subset of JSON-LD.
+> It requires data to be serialized according to the defined serialization
+> specification and validated against the SPDX 3 JSON Schema.
+> It may be parsed – not serialized – using standard JSON-LD libraries.
+
+There are two mechanisms for validating SPDX 3 JSON documents:
 validating the structure against the JSON Schema, and
 validating the semantics against the SHACL model.
 
@@ -27,17 +32,20 @@ documents are correct.
 
 ### Validating the structure against the JSON Schema
 
-SPDX 3 JSON-LD documents adhere to a [JSON Schema][json-schema] to ensure that
+SPDX 3 JSON documents adhere to the SPDX 3 JSON Schema to ensure that
 they can be parsed as either RDF documents using a full RDF parsing library,
 or as more simplistic JSON documents using a basic JSON parser.
 
-JSON Schema validation is designed to ensure that a document is structurally
+[JSON Schema][json-schema] validation
+is designed to ensure that a document is structurally
 conformant to the SPDX 3 spec (that is, all the proper fields are used and have
 the correct types), but it is unable to ensure that a document is semantically
 correct (that is that everything is used in the correct way).
 
-Known validators: [spdx3-validate](#spdx3-validate), [ajv](#ajv),
-[check-jsonschema](#check-jsonschema)
+- The SPDX 3 JSON Schema is available at:
+  <https://spdx.org/schema/3.0.1/spdx-json-schema.json>
+- Known validators: [spdx3-validate](#spdx3-validate), [ajv](#ajv),
+  [check-jsonschema](#check-jsonschema)
 
 [json-schema]: https://en.wikipedia.org/wiki/JSON#Metadata_and_schema
 
@@ -51,7 +59,10 @@ However, the SHACL model cannot validate the structure of a document,
 since there are many different ways of encoding an RDF document,
 many of which are not allowed by SPDX 3.
 
-Known validators: [spdx3-validate](#spdx3-validate), [pyshacl](#pyshacl)
+- The SPDX 3 OWL ontology, which contains the SPDX 3 SHACL model,
+  is available at:
+  <https://spdx.org/rdf/3.0.1/spdx-model.ttl>
+- Known validators: [spdx3-validate](#spdx3-validate), [pyshacl](#pyshacl)
 
 [shacl]: https://en.wikipedia.org/wiki/SHACL
 


### PR DESCRIPTION
- Use "SPDX 3 JSON" name, per 15 Apr 2025 Tech Team meeting
  - This PR update instances in spdx-3-model repo, while https://github.com/spdx/spdx-spec/pull/1197 (merged) does the same for spdx-spec repo
- Update links to use new branch structure
- Add validation doc link to README
- Add table of contents to README