### PR TITLE
Fix paragraph collapsed in zh-Hans translation of NoAssertionElement

### DIFF
--- a/model/Core/Individuals/NoAssertionElement.md
+++ b/model/Core/Individuals/NoAssertionElement.md
@@ -45,4 +45,9 @@ no assertion is being made about any potential descendants of Element1.
 - SPDX创建者尝试但无法达成合理的客观判断；
 - SPDX创建者未尝试确定此字段；
 - SPDX创建者故意不提供信息（这样做不应被暗示为有任何含义）。
-例如，关系`relationshipType=ancestorOf`、`from=Element1`和`to=NoAssertionElement`明确表示不对`Element1`的任何潜在后代作出任何断言。
+
+例如，关系
+`relationshipType=ancestorOf`、`from=Element1`
+和
+`to=NoAssertionElement`
+明确表示不对`Element1`的任何潜在后代作出任何断言。


### PR DESCRIPTION
Fix wrong paragraph running by add a missing newline at the end of last bullet point, as approved/confirmed correct by the zh-Hans translator @gomico - see https://github.com/spdx/spdx-3-model/pull/1016#issuecomment-2834120472

This PR retain the original zh-Hans typographic emphasis of terms (which is different from the English version) - for the discussion about that, see Point 2 of #1016 