### PR TITLE
Fix inconsistent vocab entry format

### DIFF
--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -26,16 +26,16 @@ to all restrictions defined for that profile.
 
 ## Entries
 
-- core: the element follows the Core profile specification
-- software: the element follows the Software profile specification
-- simpleLicensing: the element follows the SimpleLicensing profile specification
-- expandedLicensing: the element follows the ExpandedLicensing profile specification
-- security: the element follows the Security profile specification
-- build: the element follows the Build profile specification
-- ai: the element follows the AI profile specification
-- dataset: the element follows the Dataset profile specification
-- extension: the element follows the Extension profile specification
-- lite: the element follows the Lite profile specification
+- core: The element follows the Core profile specification.
+- software: The element follows the Software profile specification.
+- simpleLicensing: The element follows the SimpleLicensing profile specification.
+- expandedLicensing: The element follows the ExpandedLicensing profile specification.
+- security: The element follows the Security profile specification.
+- build: The element follows the Build profile specification.
+- ai: The element follows the AI profile specification.
+- dataset: The element follows the Dataset profile specification.
+- extension: The element follows the Extension profile specification.
+- lite: The element follows the Lite profile specification.
 
 ## Summary @zh-Hans
 

--- a/model/Core/Vocabularies/SupportType.md
+++ b/model/Core/Vocabularies/SupportType.md
@@ -16,13 +16,13 @@ SupportType is an enumeration of the various types of support commonly found for
 
 ## Entries
 
-- development: the artifact is in active development and is not considered ready for formal support from the supplier.
-- support: the artifact has been released, and is supported from the supplier.   There is a validUntilDate that can provide additional information about the duration of support.
-- deployed: in addition to being supported by the supplier, the software is known to have been deployed and is in use.  For a software as a service provider, this implies the software is now available as a service.
-- limitedSupport: the artifact has been released, and there is limited support available from the supplier. There is a validUntilDate that can provide additional information about the duration of support.
-- endOfSupport: there is a defined end of support for the artifact from the supplier.  This may also be referred to as end of life. There is a validUntilDate that can be used to signal when support ends for the artifact.
-- noSupport: there is no support for the artifact from the supplier, consumer assumes any support obligations.
-- noAssertion: no assertion about the type of support is made.   This is considered the default if no other support type is used.
+- development: The artifact is in active development and is not considered ready for formal support from the supplier.
+- support: The artifact has been released, and is supported from the supplier. There is a validUntilDate that can provide additional information about the duration of support.
+- deployed: In addition to being supported by the supplier, the software is known to have been deployed and is in use. For a software as a service provider, this implies the software is now available as a service.
+- limitedSupport: The artifact has been released, and there is limited support available from the supplier. There is a validUntilDate that can provide additional information about the duration of support.
+- endOfSupport: There is a defined end of support for the artifact from the supplier. This may also be referred to as end of life. There is a validUntilDate that can be used to signal when support ends for the artifact.
+- noSupport: There is no support for the artifact from the supplier, consumer assumes any support obligations.
+- noAssertion: No assertion about the type of support is made. This is considered the default if no other support type is used.
 
 ## Summary @zh-Hans
 

--- a/model/Dataset/Vocabularies/DatasetAvailabilityType.md
+++ b/model/Dataset/Vocabularies/DatasetAvailabilityType.md
@@ -19,11 +19,11 @@ form.
 
 ## Entries
 
-- clickthrough: the dataset is not publicly available and can only be accessed after affirmatively accepting terms on a clickthrough webpage.
-- directDownload: the dataset is publicly available and can be downloaded directly.
-- query: the dataset is publicly available, but not all at once, and can only be accessed through queries which return parts of the dataset.
-- registration: the dataset is not publicly available and an email registration is required before accessing the dataset, although without an affirmative acceptance of terms.
-- scrapingScript: the dataset provider is not making available the underlying data and the dataset must be reassembled, typically using the provided script for scraping the data.
+- clickthrough: Dataset is not publicly available and can only be accessed after affirmatively accepting terms on a clickthrough webpage.
+- directDownload: Dataset is publicly available and can be downloaded directly.
+- query: Dataset is publicly available, but not all at once, and can only be accessed through queries which return parts of the dataset.
+- registration: Dataset is not publicly available and an email registration is required before accessing the dataset, although without an affirmative acceptance of terms.
+- scrapingScript: Dataset provider is not making available the underlying data and the dataset must be reassembled, typically using the provided script for scraping the data.
 
 ## Summary @zh-Hans
 

--- a/model/Dataset/Vocabularies/DatasetType.md
+++ b/model/Dataset/Vocabularies/DatasetType.md
@@ -19,20 +19,20 @@ image data could also be considered categorical.
 
 ## Entries
 
-- audio: data is audio based, such as a collection of music from the 80s.
-- categorical: data that is classified into a discrete number of categories, such as the eye color of a population of people.
-- graph: data is in the form of a graph where entries are somehow related to each other through edges, such a social network of friends.
-- image: data is a collection of images such as pictures of animals.
-- noAssertion: data type is not known.
-- numeric: data consists only of numeric entries.
-- other: data is of a type not included in this list.
-- sensor: data is recorded from a physical sensor, such as a thermometer reading or biometric device.
-- structured: data is stored in tabular format or retrieved from a relational database.
-- syntactic: data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing.
-- text: data consists of unstructured text, such as a book, Wikipedia article (without images), or transcript.
-- timeseries: data is recorded in an ordered sequence of timestamped entries, such as the price of a stock over the course of a day.
-- timestamp: data is recorded with a timestamp for each entry, but not necessarily ordered or at specific intervals, such as when a taxi ride starts and ends.
-- video: data is video based, such as a collection of movie clips featuring Tom Hanks.
+- audio: Data is audio based, such as a collection of music from the 80s.
+- categorical: Data that is classified into a discrete number of categories, such as the eye color of a population of people.
+- graph: Data is in the form of a graph where entries are somehow related to each other through edges, such a social network of friends.
+- image: Data is a collection of images such as pictures of animals.
+- noAssertion: Data type is not known.
+- numeric: Data consists only of numeric entries.
+- other: Data is of a type not included in this list.
+- sensor: Data is recorded from a physical sensor, such as a thermometer reading or biometric device.
+- structured: Data is stored in tabular format or retrieved from a relational database.
+- syntactic: Data describes the syntax or semantics of a language or text, such as a parse tree used for natural language processing.
+- text: Data consists of unstructured text, such as a book, a Wikipedia article (without images), or a transcript.
+- timeseries: Data is recorded in an ordered sequence of timestamped entries, such as the price of a stock over the course of a day.
+- timestamp: Data is recorded with a timestamp for each entry, but not necessarily ordered or at specific intervals, such as when a taxi ride starts and ends.
+- video: Data is video based, such as a collection of movie clips featuring Tom Hanks.
 
 ## Summary @zh-Hans
 

--- a/model/Security/Vocabularies/CvssSeverityType.md
+++ b/model/Security/Vocabularies/CvssSeverityType.md
@@ -32,11 +32,11 @@ severity.
 
 ## Entries
 
-- critical: When a CVSS score is between 9.0 - 10.0
-- high: When a CVSS score is between 7.0 - 8.9
-- medium: When a CVSS score is between 4.0 - 6.9
-- low: When a CVSS score is between 0.1 - 3.9
-- none: When a CVSS score is 0.0
+- critical: When a CVSS score is between 9.0 - 10.0.
+- high: When a CVSS score is between 7.0 - 8.9.
+- medium: When a CVSS score is between 4.0 - 6.9.
+- low: When a CVSS score is between 0.1 - 3.9.
+- none: When a CVSS score is 0.0.
 
 ## Summary @zh-Hans
 

--- a/model/Security/Vocabularies/ExploitCatalogType.md
+++ b/model/Security/Vocabularies/ExploitCatalogType.md
@@ -17,7 +17,7 @@ ExploitCatalogType specifies the type of exploit catalog that a vulnerability is
 ## Entries
 
 - kev: CISA's Known Exploited Vulnerability (KEV) catalog.
-- other: Other exploit catalogs,
+- other: Other exploit catalogs.
 
 ## Summary @zh-Hans
 

--- a/model/Security/Vocabularies/ExploitCatalogType.md
+++ b/model/Security/Vocabularies/ExploitCatalogType.md
@@ -16,8 +16,8 @@ ExploitCatalogType specifies the type of exploit catalog that a vulnerability is
 
 ## Entries
 
-- kev: CISA's Known Exploited Vulnerability (KEV) Catalog
-- other: Other exploit catalogs
+- kev: CISA's Known Exploited Vulnerability (KEV) catalog.
+- other: Other exploit catalogs,
 
 ## Summary @zh-Hans
 


### PR DESCRIPTION
> This PR targets `support/3.0` branch.
> It is the equivalent of #974 which was already approved and merged to `develop`.

Update the formatting of entry descriptions in DatatsetType, DatasetAvailabilityType, SupportType, etc, to make their format consistent with other vocabs.

- Uppercase the first letter of the description
- End the description with a fullstop
