### PR TITLE
Fix typos: provenence, etc.

### DIFF
--- a/model/Core/Classes/Bom.md
+++ b/model/Core/Classes/Bom.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 ## Summary
 
 A container for a grouping of SPDX-3.0 content characterizing details
-(provenence, composition, licensing, etc.) about a product.
+(provenance, composition, licensing, etc.) about a product.
 
 ## Description
 
@@ -13,7 +13,7 @@ A Bill of Materials (BOM) is a container for a grouping of SPDX-3.0 content
 characterizing details about a product.
 
 This could include details of the content and composition of the product,
-provenence details of the product and/or
+provenance details of the product and/or
 its composition, licensing information, known quality or security issues, etc.
 
 ## Metadata

--- a/model/Core/Individuals/SpdxOrganization.md
+++ b/model/Core/Individuals/SpdxOrganization.md
@@ -11,7 +11,7 @@ An Organization representing the SPDX Project.
 SpdxOrganization is an Organization representing the SPDX Project.
 It is by definition the creator of all Element type individuals defined by
 the SPDX Project.
-These individuals include licences and exceptions defined in the SPDX License
+These individuals include licenses and exceptions defined in the SPDX License
 List, as well as individuals defined in the specification.
 
 ## Metadata

--- a/model/Core/Properties/scope.md
+++ b/model/Core/Properties/scope.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Capture the scope of information about a specific relationship between elements. 
+Capture the scope of information about a specific relationship between elements.
 
 ## Description
 
-A scope is additional context about a relationship, that clarifies the relationship between elements. 
+A scope is additional context about a relationship, that clarifies the relationship between elements.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -29,7 +29,7 @@ ExternalRefType specifies the type of an external reference.
 - documentation: A reference to the documentation for a package.
 - dynamicAnalysisReport: A reference to a dynamic analysis report for a package.
 - eolNotice: A reference to the End Of Sale (EOS) and/or End Of Life (EOL) information related to a package.
-- exportControlAssessment: A reference to a export control assessment for a package.
+- exportControlAssessment: A reference to an export control assessment for a package.
 - funding: A reference to funding information related to a package.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.

--- a/model/Core/Vocabularies/LifecycleScopeType.md
+++ b/model/Core/Vocabularies/LifecycleScopeType.md
@@ -8,7 +8,7 @@ Provide an enumerated set of lifecycle phases that can provide context to relati
 
 ## Description
 
-This enumeration summarizes common phases when dependency and other relationships, have different implications, based on their context.  For example,  a build dependency, may have different implications than a operational dependency.
+This enumeration summarizes common phases when dependency and other relationships, have different implications, based on their context. For example, a build dependency, may have different implications than an operational dependency.
 
 ## Metadata
 

--- a/model/Extension/Properties/cdxProperty.md
+++ b/model/Extension/Properties/cdxProperty.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides a map of a property names to a values.
+Provides a map of a property name to a value.
 
 ## Description
 

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -112,7 +112,7 @@ can be made from a missing hasConcludedLicense relationship.
 - id: https://spdx.org/rdf/3.0.1/terms/Licensing
 - name: Licensing
 
-## Profile conformance 
+## Profile conformance
 
 For an element collection to be conformant with this profile,
 the following has to hold:

--- a/model/Software/Vocabularies/SbomType.md
+++ b/model/Software/Vocabularies/SbomType.md
@@ -26,7 +26,7 @@ A single SBOM can have multiple SBOM document types associated with it.
 ## Entries
 
 - design: SBOM of intended, planned software project or product with included components (some of which may not yet exist) for a new software artifact.
-- source: SBOM created directly from the development environment, source files, and included dependencies used to build an product artifact.
+- source: SBOM created directly from the development environment, source files, and included dependencies used to build a product artifact.
 - build: SBOM generated as part of the process of building the software to create a releasable artifact (e.g., executable or package) from data such as source files, dependencies, built components, build process ephemeral data, and other SBOMs.
 - deployed: SBOM provides an inventory of software that is present on a system. This may be an assembly of other SBOMs that combines analysis of configuration options, and examination of execution behavior in a (potentially simulated) deployment environment.
 - runtime: SBOM generated through instrumenting the system running the software, to capture only components present in the system, as well as external call-outs or dynamically loaded components. In some contexts, this may also be referred to as an "Instrumented" or "Dynamic" SBOM.

--- a/model/Software/Vocabularies/SoftwarePurpose.md
+++ b/model/Software/Vocabularies/SoftwarePurpose.md
@@ -51,7 +51,7 @@ conclusions about the context in which the Element exists.
 - requirement: The Element provides a requirement needed as input for another Element.
 - source: The Element is a single or a collection of source files.
 - specification: The Element is a plan, guideline or strategy how to create, perform or analyze an application.
-- test: The Element is a test used to verify functionality on an software element.
+- test: The Element is a test used to verify functionality on a software element.
 
 ## Summary @zh-Hans
 


### PR DESCRIPTION
> This PR targets `support/3.0` branch.
> For a similar PR that targets `develop` branch, see #1040

- provenence -> provenance
- licences -> licenses *(all other instances use this US spelling)*
- a export control ->  an export control
- a operational dependency -> an operational dependency
- to a values -> to a value *(to matches the Description section as well)*
- an product artifact -> a product artifact
- an software element -> a software element
