### PR TITLE
Fix Hardware relationshipType, formatting and typos

### DIFF
--- a/model/Hardware/Classes/BoundaryDefinitionAction.md
+++ b/model/Hardware/Classes/BoundaryDefinitionAction.md
@@ -8,10 +8,11 @@ The boundary definition is used to define boundaries.
 
 ## Description
 
-Boundaries can be physical or abstract. This is the act of defining the boundaries. 
+Boundaries can be physical or abstract. This is the act of defining the boundaries.
 
-Relationship: 
-For Each `BoundaryDefinitionAction` there is one and only one `/Core/Relationship` class or subclass with the relationshipType of 'Creator’ on the to and an `/Core/Agent` class or subclass on the from. 
+Relationship:
+
+For each `BoundaryDefinitionAction` there is one and only one `/Core/Relationship` class or subclass with the relationshipType of 'Creator’ on the to and a `/Core/Agent` class or subclass on the from.
 
 ## Metadata
 

--- a/model/Hardware/Classes/CreateAction.md
+++ b/model/Hardware/Classes/CreateAction.md
@@ -10,8 +10,9 @@ Products are created using the Creation Action.
 
 To create a product you use the Creation Action.
 
-Relationship: 
-For Each `CreateAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and an `/Core/Element` class or subclass on the to. 
+Relationship:
+
+For each `CreateAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/CreateProcess.md
+++ b/model/Hardware/Classes/CreateProcess.md
@@ -8,7 +8,7 @@ The Creation Process refers to the abstract process class used to produce produc
 
 ## Description
 
-The creation process refers to the systematic steps involved in bringing something new into existence. This can apply to products, ideas, businesses, art, software, and even life itself. 
+The creation process refers to the systematic steps involved in bringing something new into existence. This can apply to products, ideas, businesses, art, software, and even life itself.
 
 Relationship:
 

--- a/model/Hardware/Classes/ModifyAction.md
+++ b/model/Hardware/Classes/ModifyAction.md
@@ -10,9 +10,11 @@ The action of product modification.
 
 This is the specific action of product modification.
 
-Relationship: 
-For Each `ModifyAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and an `/Core/Element` class or subclass on the to. 
-For Each `ModifyAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'performedBy’ on the from and an `/Core/Element` class or subclass on the to. 
+Relationship:
+
+For each `ModifyAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and a `/Core/Element` class or subclass on the to.
+
+For each `ModifyAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'performedBy’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/ModifyProcess.md
+++ b/model/Hardware/Classes/ModifyProcess.md
@@ -9,8 +9,12 @@ Modify process changes, transports or stores a product.
 ## Description
 
 Modify processes interact with a product based on a need such as transport, change or storage. Specific attributes are associated with Modify Classes to track relevant information related to product interactions.
-For Each `ModifyProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and an `/Core/Element` class or subclass on the to. 
-For Each `ModifyProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasInput’ on the from and an `/Core/Element` class or subclass on the to. 
+
+Relationship:
+
+For each `ModifyProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasOutput’ on the from and a `/Core/Element` class or subclass on the to.
+
+For each `ModifyProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasInput’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/PlanAction.md
+++ b/model/Hardware/Classes/PlanAction.md
@@ -11,7 +11,10 @@ A PlanAction involves the execution of a plan in relation to a PlanProcess.
 A PlanAction involves the execution of a plan in relation to a PlanProcess.
 
 The description of the PlanAction is a mandatory property.
-For Each `PlanAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'Generated’ on the to and an `planProcess` class or subclass on the from. 
+
+Relationship:
+
+For each `PlanAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'generates’ on the to and a `PlanProcess` class or subclass on the from.
 
 ## Metadata
 

--- a/model/Hardware/Classes/ReproduceAction.md
+++ b/model/Hardware/Classes/ReproduceAction.md
@@ -10,8 +10,9 @@ Reproduction is the biological process by which organisms generate new individua
 
 Reproduction involves the act of replicating or reproducing a product. This includes producing new products related to husbandry, agriculture, and fishing.
 
-Relationship: 
-For Each `ReproduceAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasInput’ on the from and an `/Core/Element` class or subclass on the to. 
+Relationship:
+
+For each `ReproduceAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'hasInput’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/ResolutionAction.md
+++ b/model/Hardware/Classes/ResolutionAction.md
@@ -9,8 +9,10 @@ Products out of specification require a resolution action. This is the action of
 ## Description
 
 Products out of specification require a resolution action. This is the action of resolution.
-Relationship: 
-For Each `ResolutionAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'resolution’ on the from and an `OutOfSpecAction` class or subclass on the to. 
+
+Relationship:
+
+For each `ResolutionAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'resolution’ on the from and an `OutOfSpecAction` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/StateProcess.md
+++ b/model/Hardware/Classes/StateProcess.md
@@ -4,16 +4,18 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the state of an affected element. 
+This is the state of an affected element.
 
 ## Description
 
-The state of a specific element is defined in this class.The state of an object refers to the set of attributes, properties, or data that define the object's condition at a specific moment in time.
+The state of a specific element is defined in this class. The state of an object refers to the set of attributes, properties, or data that define the object's condition at a specific moment in time.
 
-For Each `StateProcess` there is at least one `/Core/Relationship` class or subclass class with the relationshipType of 'contains’ on the from and an `Requirements` class or subclass on the to. 
+Relationship:
+
+For each `StateProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'contains’ on the from and a `Requirements` class or subclass on the to.
+
 ## Metadata
 
 - name: StateProcess
 - SubclassOf: UseProcess
 - Instantiability: Concrete
-

--- a/model/Hardware/Classes/TestProcess.md
+++ b/model/Hardware/Classes/TestProcess.md
@@ -10,7 +10,10 @@ Test Process defines the testing process for an element.
 
 Tests are processes based on requirements. The process's requirements are met by the test process.
 
-For Each `TestProcess` there is at least one `/Core/Relationship` class or subclass class with the relationshipType of 'contains’ on the from and an `Requirements` class or subclass on the to. 
+Relationship:
+
+For each `TestProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'contains’ on the from and a `Requirements` class or subclass on the to.
+
 ## Metadata
 
 - name: TestProcess

--- a/model/Hardware/Classes/UseAction.md
+++ b/model/Hardware/Classes/UseAction.md
@@ -10,9 +10,11 @@ The action of product use.
 
 This is the specific action of product use.
 
-Relationship: 
-For Each `UseAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'performedBy’ on the from and an `/Core/Agent` class or subclass on the to. 
-For Each `UseAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'effected’ on the from and an `/Core/Element` class or subclass on the to. 
+Relationship:
+
+For each `UseAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'performedBy’ on the from and a `/Core/Agent` class or subclass on the to.
+
+For each `UseAction` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'affects’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 

--- a/model/Hardware/Classes/UseProcess.md
+++ b/model/Hardware/Classes/UseProcess.md
@@ -9,7 +9,10 @@ Use Process defines actions used by elements.
 ## Description
 
 The UseProcess is an abstract class used to define processes that interact with key elements. Plan, state, and inspection processes plus managing boundaries are critical processes used by elements.
-For Each `UseProcess` or subclass except the`planProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'effected’ on the from and an `/Core/Element` class or subclass on the to. 
+
+Relationship:
+
+For each `UseProcess` or subclass except the `PlanProcess` there is at least one `/Core/Relationship` class or subclass with the relationshipType of 'affects’ on the from and a `/Core/Element` class or subclass on the to.
 
 ## Metadata
 


### PR DESCRIPTION
> This PR targets `profile-hardware` branch.

- Fix relationship type:
  - `Generated` -> `generates`
  - `effected` -> `affects`
- Formatting:
  - Make "Relationship:" heading consistent across Hardware profile
  - MkDocs needs a newline to separate paragraphs for readability
- Typos:
  - For Each -> For each
  - class or subclass class -> class or subclass
  - an `/Core/Element` -> a `/Core/Element`
  - an `planProcess` -> a `PlanProcess` (it is a class, starts with uppercase)
  - an `Requirements` -> a `Requirements` (the class may need to be renamed to its singular form separately though)

Still pending issues:

- These relationshipTypes are not exist:
  - `Creator` (used in BoundaryDefinitionAction)
  - `resolution` (used in ResolutionAction)