### PR TITLE
Fix Hardware typos and formatting

### DIFF
--- a/model/Core/Properties/additionalInformation.md
+++ b/model/Core/Properties/additionalInformation.md
@@ -8,7 +8,7 @@ Additional relevance information.
 
 ## Description
 
-This elemtent provides relevant information to the action.
+This element provides relevant information to the action.
 
 ## Metadata
 

--- a/model/Hardware/Classes/DestroyAction.md
+++ b/model/Hardware/Classes/DestroyAction.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The record of destruction is entered in this action. 
+The record of destruction is entered in this action.
 
 ## Description
 
-The action of destroying an element is recorded as part of the DestroyAction. To destroy refers to the act of completely eliminating, or rendering something unusable or irretrievable. 
+The action of destroying an element is recorded as part of the DestroyAction. To destroy refers to the act of completely eliminating, or rendering something unusable or irretrievable.
 
 ## Metadata
 

--- a/model/Hardware/Classes/Dimensions.md
+++ b/model/Hardware/Classes/Dimensions.md
@@ -7,7 +7,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 Dimensions generally refer to measurable extents or attributes that define the size, shape, or scale of an object, system, or concept.
 
 ## Description
-Dimensions generally refer to measurable extents or attributes that define the size, shape, or scale of an object, system, or concept. The Z axis is the height of the object. 
+
+Dimensions generally refer to measurable extents or attributes that define the size, shape, or scale of an object, system, or concept. The Z axis is the height of the object.
 
 ## Metadata
 
@@ -28,4 +29,3 @@ Dimensions generally refer to measurable extents or attributes that define the s
   - type: /Core/MeasureOfLength
   - minCount: 1
   - maxCount: 1
-

--- a/model/Hardware/Classes/HarvestingAction.md
+++ b/model/Hardware/Classes/HarvestingAction.md
@@ -8,11 +8,12 @@ HarvestingAction is the Action of extracting goods or products from nature.
 
 ## Description
 
-HarvestingAction is the Action of extracting goods or products from nature. This includes agriculture, mining, and fishing. 
+HarvestingAction is the Action of extracting goods or products from nature.
+
+This includes agriculture, mining, and fishing.
 
 ## Metadata
 
 - name: HarvestingAction
 - SubclassOf: CreateAction
 - Instantiability: Concrete
-

--- a/model/Hardware/Classes/ProductSpecification.md
+++ b/model/Hardware/Classes/ProductSpecification.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A product specification (product spec) is a detailed document that outlines the technical, functional, and design requirements of a product. 
+A product specification (product spec) is a detailed document that outlines the technical, functional, and design requirements of a product.
 
 ## Description
 

--- a/model/Hardware/Classes/ReproductionProcess.md
+++ b/model/Hardware/Classes/ReproductionProcess.md
@@ -8,7 +8,9 @@ Reproduction is the biological process by which living organisms produce offspri
 
 ## Description
 
-Reproduction is the biological process by which living organisms produce offspring.  It occurs in plants, animals, and microorganisms.
+Reproduction is the biological process by which living organisms produce offspring.
+
+It occurs in plants, animals, and microorganisms.
 
 ## Metadata
 

--- a/model/Hardware/Classes/ResponsibilityChangeAction.md
+++ b/model/Hardware/Classes/ResponsibilityChangeAction.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-ResponsibilityChangeAction refers to the transfer of responsibility from one party to another. 
+ResponsibilityChangeAction refers to the transfer of responsibility from one party to another.
 
 ## Description
 
-Changes of responsibility are recorded in this process. Responsibility Change refers to the transfer of rights, responsibilities, or/and control of an asset, property, business, or entity from one party to another. This change can occur in various contexts, including real estate, business acquisitions, intellectual property, and assets.
+Changes of responsibility are recorded in this process. Responsibility Change refers to the transfer of rights, responsibilities, and/or control of an asset, property, business, or entity from one party to another. This change can occur in various contexts, including real estate, business acquisitions, intellectual property, and assets.
 
 ## Metadata
 
@@ -33,6 +33,7 @@ Changes of responsibility are recorded in this process. Responsibility Change re
   - type: ResponsibilityType
   - minCount: 1
   - maxCount: 1
+
 ## External properties restrictions
 
 - /Core/Action/actionStartTime

--- a/model/Hardware/Classes/ResponsibilityChangeProcess.md
+++ b/model/Hardware/Classes/ResponsibilityChangeProcess.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-ResponsibilityChangeProcess refers to the process of transferring responsibility from one party to another. 
+ResponsibilityChangeProcess refers to the process of transferring responsibility from one party to another.
 
 ## Description
 
-The process changes of responsibility are recorded in this process. Responsibility Change refers to the transfer of rights, responsibilities, or/and control of an asset, property, business, or entity from one party to another.
+The process changes of responsibility are recorded in this process. Responsibility Change refers to the transfer of rights, responsibilities, and/or control of an asset, property, business, or entity from one party to another.
 
 ## Metadata
 

--- a/model/Hardware/Classes/StateAction.md
+++ b/model/Hardware/Classes/StateAction.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the state of an affected element. 
+This is the state of an affected element.
 
 ## Description
 

--- a/model/Hardware/Classes/TestAction.md
+++ b/model/Hardware/Classes/TestAction.md
@@ -8,7 +8,8 @@ A test action is a specific action associated with a test.
 
 ## Description
 
-A test action is a specific action associated with a test. The execution of a test is a testAction.
+A test action is a specific action associated with a test.
+The execution of a test is a test action.
 
 ## Metadata
 

--- a/model/Hardware/Classes/TransportAction.md
+++ b/model/Hardware/Classes/TransportAction.md
@@ -20,7 +20,7 @@ Transporting refers to the act of moving people, goods, information, or substanc
 
 - transportRoute
   - type: xsd:string
-  -  minCount: 0
+  - minCount: 0
 - pickupLocation
   - type: /Core/Location
   - minCount: 1

--- a/model/Hardware/Classes/VirtualHardware.md
+++ b/model/Hardware/Classes/VirtualHardware.md
@@ -8,10 +8,11 @@ Class that describes an instance of VirtualHardware.
 
 ## Description
 
-A VirtualHardware is a distinct article related to simulation or emulation hardware. 
+A VirtualHardware is a distinct article related to simulation or emulation hardware.
 This is used to assist in recording "Digital Twinning".
-A FPGA simualtion of hardware is a VirtualHardware. 
-Virtual hardware requires instantiation involving specific hardware and software. 
+
+An FPGA simulation of hardware is a VirtualHardware.
+Virtual hardware requires instantiation involving specific hardware and software.
 
 ## Metadata
 

--- a/model/Hardware/Hardware.md
+++ b/model/Hardware/Hardware.md
@@ -24,7 +24,7 @@ the following has to hold:
 1. for every `/Hardware/InstantiationVirtualHardwareProcess` there MUST exist exactly one
    `/Core/Relationship` of type `instantiates` having that element as its
    `from` property and a `/Hardware/VirualHardware` as its `to`.
-   
+
 2. for every `/Hardware/PhysicalHardware`, if the properties `dimensions` and
    `centerOfMass` are defined then both `dimensions` and `centerOfMass`
    must have the same `coordinateOrientationType` for x, y, and z.

--- a/model/Hardware/Properties/additionalInformation.md
+++ b/model/Hardware/Properties/additionalInformation.md
@@ -8,7 +8,7 @@ Additional relevance information.
 
 ## Description
 
-This elemtent provides relevant information to the product.
+This element provides relevant information to the product.
 
 ## Metadata
 

--- a/model/Hardware/Properties/additionalInformationSpecification.md
+++ b/model/Hardware/Properties/additionalInformationSpecification.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-It is the authoritative or credible entity, document, or body of knowledge that provides the meaning of the additionalInformation key or/and values, ensuring accuracy, context, and standardization.
+It is the authoritative or credible entity, document, or body of knowledge that provides the meaning of an additionalInformation key and/or its values, ensuring accuracy, context, and standardization.
 
 ## Description
 
-It is the authoritative or credible entity, document, or body of knowledge that provides the meaning of a additionalInformation key or/and values, ensuring accuracy, context, and standardization. These are adopted to create uniformity and facilitate interoperability within industries.
+It is the authoritative or credible entity, document, or body of knowledge that provides the meaning of an additionalInformation key and/or its values, ensuring accuracy, context, and standardization.
+These are adopted to create uniformity and facilitate interoperability within industries.
 
 ## Metadata
 

--- a/model/Hardware/Properties/centerOfMass.md
+++ b/model/Hardware/Properties/centerOfMass.md
@@ -15,4 +15,3 @@ The mass-center is a fixed property for a given rigid body (e.g. with no slosh o
 - name: centerOfMass
 - Nature: ObjectProperty
 - Range: Dimensions
-

--- a/model/Hardware/Properties/coordinateOrientation.md
+++ b/model/Hardware/Properties/coordinateOrientation.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Coordinate orientation System.
+The coordinate orientation system.
 
 ## Description
 
-The Coordinate orientation System use by XYZ axis. 
+The coordinate orientation system use by XYZ axis.
 
 ## Metadata
 

--- a/model/Hardware/Properties/current.md
+++ b/model/Hardware/Properties/current.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the individual, business, or organization who currently manages goods, services, or assets. 
+This is the individual, business, or organization who currently manages goods, services, or assets.
 
 ## Description
 

--- a/model/Hardware/Properties/dimensionsUnit.md
+++ b/model/Hardware/Properties/dimensionsUnit.md
@@ -8,7 +8,7 @@ Unit of measurement of the Dimensions.
 
 ## Description
 
-Standard units of measure for dimensions - ISO 80000-1:2009
+Standard units of measure for dimensions - ISO 80000-1:2009.
 
 ## Metadata
 

--- a/model/Hardware/Properties/hardwareVersion.md
+++ b/model/Hardware/Properties/hardwareVersion.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Version identifier for the hardware product
+Version identifier for the hardware product.
 
 ## Description
 
-Describes the specific hardware version. 
+Describes the specific hardware version.
 
 ## Metadata
 

--- a/model/Hardware/Properties/hazard.md
+++ b/model/Hardware/Properties/hazard.md
@@ -8,7 +8,7 @@ Hazards are potential sources of harm, danger, or adverse effects to people, pro
 
 ## Description
 
-Hazards are potential sources of harm, danger, or adverse effects to people, property, the environment, or systems within or related to a specific piece of hardware. For example, a lithium battery is a hazardous hardware item. 
+Hazards are potential sources of harm, danger, or adverse effects to people, property, the environment, or systems within or related to a specific piece of hardware. For example, a lithium battery is a hazardous hardware item.
 
 ## Metadata
 

--- a/model/Hardware/Properties/informationElementList.md
+++ b/model/Hardware/Properties/informationElementList.md
@@ -8,7 +8,7 @@ Additional relevance information.
 
 ## Description
 
-This elemtent provides relevant information to the product.
+This element provides relevant information to the product.
 
 ## Metadata
 

--- a/model/Hardware/Properties/massOfHardware.md
+++ b/model/Hardware/Properties/massOfHardware.md
@@ -8,7 +8,7 @@ Information related to massOfHardware physical hardware.
 
 ## Description
 
-Mass is defined as an intrinsic property of a body for describing a physical hardware component. 
+Mass is defined as an intrinsic property of a body for describing a physical hardware component.
 
 ## Metadata
 

--- a/model/Hardware/Properties/massUnit.md
+++ b/model/Hardware/Properties/massUnit.md
@@ -8,7 +8,7 @@ Information related to the mass of a hardware unit.
 
 ## Description
 
-Mass units are used to describe the physical nature of a hardware unit. Unit types used are defined for mass unit. 
+Mass units are used to describe the physical nature of a hardware unit. Unit types used are defined for mass unit.
 
 ## Metadata
 

--- a/model/Hardware/Properties/objectState.md
+++ b/model/Hardware/Properties/objectState.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the state of an affected element. 
+This is the state of an affected element.
 
 ## Description
 

--- a/model/Hardware/Properties/organizationalEntity.md
+++ b/model/Hardware/Properties/organizationalEntity.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Product Manufacture Name and related information
+Product Manufacture Name and related information.
 
 ## Description
 
-The Agent is responsible for defining the PartNumber, batchNumber or serialNumber of unit of hardware.
+The Agent is responsible for defining the partNumber, batchNumber or serialNumber of unit of hardware.
 
 ## Metadata
 

--- a/model/Hardware/Properties/plannedCurrent.md
+++ b/model/Hardware/Properties/plannedCurrent.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the planned individual, business, or organization who currently manages goods, services, or assets. 
+This is the planned individual, business, or organization who currently manages goods, services, or assets.
 
 ## Description
 
-This is the planned individual, business, or organization who currently manages goods, services, or assets. 
+This is the planned individual, business, or organization who currently manages goods, services, or assets.
 
 ## Metadata
 

--- a/model/Hardware/Properties/plannedPrevious.md
+++ b/model/Hardware/Properties/plannedPrevious.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the planned individual, business, or organization who was previously managing goods, services, or assets. 
+This is the planned individual, business, or organization who was previously managing goods, services, or assets.
 
 ## Description
 
-This is the planned individual, business, or organization who was previously managing goods, services, or assets. 
+This is the planned individual, business, or organization who was previously managing goods, services, or assets.
 
 ## Metadata
 

--- a/model/Hardware/Properties/previous.md
+++ b/model/Hardware/Properties/previous.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the individual, business, or organization who was previously managing goods, services, or assets. 
+This is the individual, business, or organization who was previously managing goods, services, or assets.
 
 ## Description
 
-This is the individual, business, or organization who was previously managing goods, services, or assets. 
+This is the individual, business, or organization who was previously managing goods, services, or assets.
 
 ## Metadata
 

--- a/model/Hardware/Properties/productAgent.md
+++ b/model/Hardware/Properties/productAgent.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Product Manufacture Name and related information
+Product Manufacture Name and related information.
 
 ## Description
 
-The Agent is responsible for defining the PartNumber, batchNumber or serialNumber of unit of hardware.
+The Agent is responsible for defining the partNumber, batchNumber or serialNumber of unit of hardware.
 
 ## Metadata
 

--- a/model/Hardware/Properties/releaseDate.md
+++ b/model/Hardware/Properties/releaseDate.md
@@ -8,7 +8,7 @@ Date of product release.
 
 ## Description
 
-This is the first date associated to a specific product release. 
+This is the first date associated to a specific product release.
 
 ## Metadata
 

--- a/model/Hardware/Properties/requirementsLevel.md
+++ b/model/Hardware/Properties/requirementsLevel.md
@@ -8,7 +8,8 @@ Requirements levels define the hierarchy of requirements in a system, helping to
 
 ## Description
 
-Requirements levels define the hierarchy of requirements in a system, helping to structure and organize them from high-level needs to low level specifications. 
+Requirements levels define the hierarchy of requirements in a system, helping to structure and organize them from high-level needs to low level specifications.
+
 1 is the highest level of abstraction followed by a descending order of abstraction as the number of levels increases.
 
 ## Metadata

--- a/model/Hardware/Properties/requirementsRationale.md
+++ b/model/Hardware/Properties/requirementsRationale.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is the rationale of why this requirement must exist. 
+This is the rationale of why this requirement must exist.
 
 ## Description
 

--- a/model/Hardware/Properties/requirementsUID.md
+++ b/model/Hardware/Properties/requirementsUID.md
@@ -8,7 +8,7 @@ An UID of the requirement.
 
 ## Description
 
-An UID of the requirement. This can be defined in a different system. 
+An UID of the requirement. This can be defined in a different system.
 
 ## Metadata
 

--- a/model/Hardware/Properties/responsibilityCategory.md
+++ b/model/Hardware/Properties/responsibilityCategory.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Requirements can be categorized into various types based on their focus, purpose, and scope. 
+Requirements can be categorized into various types based on their focus, purpose, and scope.
 
 ## Description
 

--- a/model/Hardware/Properties/yAxisLength.md
+++ b/model/Hardware/Properties/yAxisLength.md
@@ -15,4 +15,3 @@ Information related to yAxis measurement of an object.
 - name: yAxisLength
 - Nature: ObjectProperty
 - Range: /Core/MeasureOfLength
-

--- a/model/Hardware/Properties/zAxisLength.md
+++ b/model/Hardware/Properties/zAxisLength.md
@@ -9,8 +9,8 @@ Information related to hardware dimension.
 ## Description
 
 Information related to zAxis measurement of an object.
-Z axis is the height of the object. 
 
+Z axis is the height of the object.
 
 ## Metadata
 

--- a/model/Hardware/Vocabularies/CoordinateOrientationType.md
+++ b/model/Hardware/Vocabularies/CoordinateOrientationType.md
@@ -11,13 +11,11 @@ CoordinateOrientationType sets the coordinate orientation.
 CoordinateOrientationType sets the coordinate orientation in an object.
 Enumerations are used to define the coordinate orientation.
 
-Any coordinate orientation system must remain in the same order for that class’s `/Hardware/Hardware` element.
-
 ## Metadata
 
 - name: CoordinateOrientationType
 
 ## Entries
 
-- XYZFreeForm: XYZ FreeForm
-- LMS: X = Longest, Y = Middle, Z = Shortest
+- XYZFreeForm: XYZ FreeForm.
+- LMS: X = Longest, Y = Middle, Z = Shortest.

--- a/model/Hardware/Vocabularies/CoordinateOrientationType.md
+++ b/model/Hardware/Vocabularies/CoordinateOrientationType.md
@@ -4,12 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-CoordinateOrientationType sets the coordinate orientation. 
+CoordinateOrientationType sets the coordinate orientation.
 
 ## Description
 
-CoordinateOrientationType sets the coordinate orientation in an object. Enumerations are used to define the coordinate orientation.
-Any coordinate orientation System, that must that orientation must remain in the same order for that class’s `/Hardware/Hardware` element. 
+CoordinateOrientationType sets the coordinate orientation in an object.
+Enumerations are used to define the coordinate orientation.
+
+Any coordinate orientation system must remain in the same order for that class’s `/Hardware/Hardware` element.
 
 ## Metadata
 

--- a/model/Hardware/Vocabularies/VirtualHardwareModelType.md
+++ b/model/Hardware/Vocabularies/VirtualHardwareModelType.md
@@ -16,6 +16,6 @@ VirtualHardwareModelType sets the VirtualHardware set the simulation process.
 
 ## Entries
 
-- function: Simulation the function of the hardware
+- function: Simulation the function of the hardware.
 - cycle: Simulation architectures with precise cycle-level accuracy.
 - other: All other simulation types.


### PR DESCRIPTION
> This PR targets `profile-hardware` branch.

- elemtent -> element
- A FPGA -> An FPGA
- simualtion -> simulation
- PartNumber -> partNumber (property name starts with lowercase)
- Make sure there are blank lines before and after headers
- and more formatting, removing trailing spaces, etc