### PR TITLE
Clarify 'exploited' property in Security Profile

### DIFF
--- a/model/Security/Properties/exploited.md
+++ b/model/Security/Properties/exploited.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Describe that a CVE is known to have an exploit because it's been listed in an exploit catalog.
+Denote whether a CVE is present in an exploit catalog.
 
 ## Description
 
-This field is set when a CVE is listed in an exploit catalog.
+This field is set to True when a CVE is present in an exploit catalog and False when the CVE is not present.
 
 ## Metadata
 


### PR DESCRIPTION
Update the description of the property so it is more descriptive and usable. Discussed this change in the July 15th Security call.

Resolves #912
Resolves #652