### PR TITLE
Add Dataset/inLanguage

### DIFF
--- a/model/Core/Datatypes/LanguageTag.md
+++ b/model/Core/Datatypes/LanguageTag.md
@@ -1,0 +1,36 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# LanguageTag
+
+## Summary
+
+A string constrained to the IETF BCP 47 language tag format.
+
+## Description
+
+The string must be in the format as describes in the Section 2 of
+[IETF RFC 5646](https://datatracker.ietf.org/doc/rfc5646/) (part of BCP 47).
+
+It provides a standardized way of indicating the language of the content or
+performance or used in an action.
+
+*Example*
+
+- `es` (Spanish)
+- `es-UY` (Spanish as used in Uruguay)
+- `hy-Latn-IT-arevela` (Eastern Armenian written in Latin script, as used in Italy)
+- `sl-rozaj-biske` (San Giorgio dialect of Resian dialect of Slovenian)
+- `yue-Hant-HK` (Cantonese using traditional Han characters, as spoken in Hong Kong)
+
+See the
+[IETF language tag Wikipedia page](https://en.wikipedia.org/wiki/IETF_language_tag)
+for more information.
+
+## Metadata
+
+- name: LanguageTag
+- SubclassOf: xsd:string
+
+## Format
+
+- pattern: ^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$

--- a/model/Core/Datatypes/LanguageTag.md
+++ b/model/Core/Datatypes/LanguageTag.md
@@ -4,12 +4,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A string constrained to the IETF BCP 47 language tag format.
+A string constrained to the IETF BCP 47 language tag format,
+which is used to identify human languages.
 
 ## Description
 
-The string must be in the format as describes in the Section 2 of
+The language tag must be in the format as describes in the Section 2 of
 [IETF RFC 5646](https://datatracker.ietf.org/doc/rfc5646/) (part of BCP 47).
+
+Each language tag is composed of one or more "subtags" separated by hyphens
+(-). Each subtag is composed of basic Latin letters or digits only.
 
 It provides a standardized way of indicating the language of the content or
 performance or used in an action.

--- a/model/Core/Datatypes/LanguageTag.md
+++ b/model/Core/Datatypes/LanguageTag.md
@@ -18,6 +18,7 @@ performance or used in an action.
 
 - `es` (Spanish)
 - `es-UY` (Spanish as used in Uruguay)
+- `hau-NG` (Hausa as used in Nigeria)
 - `hy-Latn-IT-arevela` (Eastern Armenian written in Latin script, as used in Italy)
 - `sl-rozaj-biske` (San Giorgio dialect of Resian dialect of Slovenian)
 - `yue-Hant-HK` (Cantonese using traditional Han characters, as spoken in Hong Kong)

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -56,7 +56,7 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - minCount: 0
   - maxCount: 1
 - inLanguage
-  - type: xsd:string
+  - type: /Core/LanguageTag
   - minCount: 0
 - intendedUse
   - type: xsd:string

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -55,6 +55,9 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - type: /Core/PresenceType
   - minCount: 0
   - maxCount: 1
+- inLanguage
+  - type: xsd:string
+  - minCount: 0
 - intendedUse
   - type: xsd:string
   - minCount: 0

--- a/model/Dataset/Properties/inLanguage.md
+++ b/model/Dataset/Properties/inLanguage.md
@@ -4,14 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Indicates the language of a dataset.
+The language of a dataset.
 
 ## Description
 
-A BCP 47 string to express the natural language of a dataset.
+This property uses an IETF BCP 47 language tag to indicate the natural language
+used within a dataset.
 
 ## Metadata
 
 - name: inLanguage
 - Nature: DataProperty
-- Range: xsd:string
+- Range: /Core/LanguageTag

--- a/model/Dataset/Properties/inLanguage.md
+++ b/model/Dataset/Properties/inLanguage.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The language of a dataset.
+Specifies a human language used within a dataset.
 
 ## Description
 
-This property uses an IETF BCP 47 language tag to indicate the natural language
+This property uses an IETF BCP 47 language tag to indicate a human language
 used within a dataset.
 
 ## Metadata

--- a/model/Dataset/Properties/inLanguage.md
+++ b/model/Dataset/Properties/inLanguage.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# inLanguage
+
+## Summary
+
+Indicates the language of a dataset.
+
+## Description
+
+A BCP 47 string to express the natural language of a dataset.
+
+## Metadata
+
+- name: inLanguage
+- Nature: DataProperty
+- Range: xsd:string


### PR DESCRIPTION
`inLanguage` to indicates the language of a dataset. 

- The name of the property is from Schema.org: https://schema.org/inLanguage
  - Which is also used by MLCommons Croissant dataset https://docs.mlcommons.org/croissant/docs/croissant-spec.html#recommended
- Using [IETF BCP 47 language tag](https://datatracker.ietf.org/doc/rfc5646/) which is recommended by Schema.org and considered a web standard (also used in RDF)
  - It is also used by Hugging Face data card https://github.com/huggingface/hub-docs/blob/main/datasetcard.md
- See more at #744

--

If there is a use case of use this `inLanguage` to describe language in `File`, `Regulation`, `Annotation` or other artifacts, we may move this property to `Core` profile instead.


To resolve #744