### PR TITLE
Revise standardName and standardCompliance descriptions

### DIFF
--- a/model/AI/Properties/standardCompliance.md
+++ b/model/AI/Properties/standardCompliance.md
@@ -4,17 +4,20 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Captures a standard that is being complied with.
+Captures a standard that an artifact is being complied with.
 
 ## Description
 
-A free-form text that captures a standard that the AI software complies with.
+A free-form text that captures a standard that an artifact complies with.
 
 This includes both published and unpublished standards, such as those developed
-by ISO, IEEE, and ETSI.
+by ETSI, IEEE, IETF, ISO, and W3C, as well as national standards bodies.
 
 The standard may, but is not necessarily required to, satisfy a legal or
 regulatory requirement.
+
+If the artifact is using a standard as a reference or guideline, but not
+necessarily compliant with it, use the `standardName` property instead.
 
 ## Metadata
 

--- a/model/AI/Properties/standardCompliance.md
+++ b/model/AI/Properties/standardCompliance.md
@@ -10,14 +10,14 @@ Captures a standard that an artifact is being complied with.
 
 A free-form text that captures a standard that an artifact complies with.
 
-This includes both published and unpublished standards, such as those developed
-by ETSI, IEEE, IETF, ISO, and W3C, as well as national standards bodies.
-
 The standard may, but is not necessarily required to, satisfy a legal or
 regulatory requirement.
 
 If the artifact is using a standard as a reference or guideline, but not
 necessarily compliant with it, use the `standardName` property instead.
+
+For a detailed compliance information, please consider defining
+a `Relationship` with "conformsTo" relationship type to a `Regulation`.
 
 ## Metadata
 

--- a/model/Core/Properties/standardName.md
+++ b/model/Core/Properties/standardName.md
@@ -10,6 +10,12 @@ The name of a relevant standard that may apply to an artifact.
 
 Various standards may be relevant or useful to capture for specific artifacts.
 
+This does not imply that the artifact is compliant with the standard,
+but rather that the standard is used as a reference or guideline for
+the design, implementation, production, or evaluation of the artifact.
+
+For compliance with a standard, use the `standardCompliance` property instead.
+
 ## Metadata
 
 - name: standardName


### PR DESCRIPTION
To address the ambiguous relationship between `Core/standardName` and `AI/standardCompliance`, as discussed in #893.

- We might need to thinking should we like to move `AI/standardCompliance` to Core profile or not, as it can be use with other artifacts as well.
  - If we chose this, it means we will deprecate `AI/standardCompliance`; and create new `Core/standardCompliance` and let it be a property of an `Artifact`.

Other related relationship and class:
- [`hasSpecification`](https://github.com/spdx/spdx-3-model/blob/develop/model/Core/Vocabularies/RelationshipType.md) relationship type: "Every `to` Element is a specification for the `from` Element (`from` hasSpecification `to`), during a LifecycleScopeType period."
  - This may not imply compliance.
- `conformsTo` relationship type, to be added in 3.1: "The `from` Element conforms to each `to` Regulation." 
- Hardware profile, to be added in 3.1, adds [`Specification`](https://github.com/spdx/spdx-3-model/blob/profile-hardware/model/Core/Classes/Specification.md) class which can also include standard ("specifications are referenced in this class. Requirements, standards, specification and processes are referenced in this class.")
  - As `Specification` is also an Element, we can have `from` hasSpecification `Specification`.

To resolve  #893

