### PR TITLE
[develop] "Profile" -> "profile"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,19 +29,19 @@ semantic changes to the model and may affect compatibility.
   - Corrected `actionStatement` cardinality from `0..1` to `1..1` to match its textual description.
   - Corrected `actionStatementTime` cardinality from `0..*` to `0..1` to match its textual description.
 - **Fixed:** Typo in `Core/import` property - [#847](https://github.com/spdx/spdx-3-model/pull/847)
-  - Corrected `imports` to `import` in Core Profile.
+  - Corrected `imports` to `import` in Core profile.
 - **Fixed:** Typo in `Build/parameter` property - [#836](https://github.com/spdx/spdx-3-model/pull/836)
-  - Corrected `parameters` to `parameter` in Build Profile.
+  - Corrected `parameters` to `parameter` in Build profile.
 - **Fixed:** Typo in `hasInput` and `hasOutput` entries - [#854](https://github.com/spdx/spdx-3-model/pull/854)
   - Corrected `hasInputs` to `hasInput` and `hasOutputs` to `hasOutput` in
     `Core/RelationshipType`.
 - **Fixed:** Typo in `hasPrerequisite` entry- [#817](https://github.com/spdx/spdx-3-model/pull/817)
   - Corrected the misspelling of `hasPrerequsite` to `hasPrerequisite` in
     `Core/RelationshipType`.
-- **Fixed:** Licensing relationship type names in Profile conformance - [#779](https://github.com/spdx/spdx-3-model/pull/779)
+- **Fixed:** Licensing relationship type names in profile conformance - [#779](https://github.com/spdx/spdx-3-model/pull/779)
   - Corrected `concludedLicense` to `hasConcludedLicense` and
-    `declaredLicense` to `hasDeclaredLicense` in the "Profile conformance"
-    section of AI, Dataset, Licensing, and Lite Profiles.
+    `declaredLicense` to `hasDeclaredLicense` in profile conformance
+    section of AI, Dataset, Licensing, and Lite profiles.
 - **Fixed:** `Security/actionStatement` property - [#908](https://github.com/spdx/spdx-3-model/pull/908)
   - Corrected its cardinality from `0..1` to `1..1`.
 - **Fixed:** `Security/actionStatementTime` property - [#908](https://github.com/spdx/spdx-3-model/pull/908)

--- a/Contributing.md
+++ b/Contributing.md
@@ -38,7 +38,7 @@ There are multiple profiles being developed in parallel for the SPDX 3 model.
 
 - During its initial phase of development, a profile working group will
   contribute changes to its own branch in this repository.
-  - For example, any changes to the "Future Profile" should be submitted as a
+  - For example, any changes to the "Future" profile should be submitted as a
     change request to the `future-profile` branch.
 - There will be at least one maintainer per profile in charge of merging any
   profile development changes to the profile-specific branch.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The profiles are organized as sub-directories under the `model/` directory.
 The model diagram is available in [model.drawio][model-diagram] file
 and in [`images/`](./images/) directory.
 
-<a href="./images/" title="Click to see more Profile diagrams" ><img src="./images/model-Core.png" alt="Core Profile diagram" height="120" /></a>
+<a href="./images/" title="Click to see more profile diagrams" ><img src="./images/model-Core.png" alt="Core profile diagram" height="120" /></a>
 
 Note:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,4 @@
-# Glossary of Terms
+# Glossary of terms
 
 ## Agent
 
@@ -35,7 +35,7 @@ A representation of a relationship between a class (definition or instance) and 
 
 A specific sphere of activity or knowledge. For example, cyber security, software, bills of material, licensing, software security, etc.
 
-## Domain Class
+## Domain class
 
 A class representing a concept of primary focus within a given domain.
 
@@ -49,7 +49,7 @@ Each namespace typically defines its own IRI prefix utilized in the IRI IDs of a
 
 In SPDX 3, the "core" namespace is the scoping within which all foundational BOM concept classes and properties are defined and managed.
 
-## Non-domain Class
+## Non-domain class
 
 A class representing a concept of secondary or tertiary focus within a given domain that is a characterization of some aspect of a domain class.
 
@@ -81,11 +81,11 @@ The creator of the ElementCollection can also indicate whether any of the associ
 
 A representation of a relationship between a class (definition or instance) and some descriptive characterization of the class.
 
-## Property Domain
+## Property domain
 
 The class at the root of a property relationship. In other words, the class being characterized.
 
-## Property Range
+## Property range
 
 The class or literal datatype of the value of a property relationship.
 
@@ -97,7 +97,7 @@ The process of translating an abstract logical data structure into a format that
 
 A formally defined set of constraints that explicitly specify the valid "shape" of particular data to support validation against SPDX conformance requirements.
 
-A Property Shape defines the set of constraints for a given property when applied to a particular concept class. A Node Shape defines the set of property shapes (and thus constraints) relevant for validation of instance data realization of a given concept class.
+A property shape defines the set of constraints for a given property when applied to a particular concept class. A node shape defines the set of property shapes (and thus constraints) relevant for validation of instance data realization of a given concept class.
 
 In SPDX 3 these shapes are expressed using the W3C SHACL language.
 

--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The AI Profile is designed to provide a standardized way of documenting and
+The AI profile is designed to provide a standardized way of documenting and
 sharing information about AI software packages (i.e. systems).
 
 ## Description

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Build Profile defines the set of information required to describe an
+The Build profile defines the set of information required to describe an
 instance of a Software Build.
 
 ## Description
@@ -37,7 +37,7 @@ In addition, the following Relationship Types may be used to describe a Build.
   parent.
 - usesTool: Describes a relationship from a Build element to a build tool.
 
-All relationships in the Build Profile are scoped to the "build"
+All relationships in the Build profile are scoped to the "build"
 LifecycleScopeType period.
 
 The `hasInput` relationship can be applied to a config file or a build tool if

--- a/model/Build/Properties/configSourceDigest.md
+++ b/model/Build/Properties/configSourceDigest.md
@@ -12,7 +12,7 @@ invoke a build.
 configSourceDigest is the checksum of the build configuration file used by a
 builder to execute a build, according to the buildType.
 
-This Property uses the Core model's [Hash](../../Core/Classes/Hash.md) class.
+This property uses the Core model's [Hash](../../Core/Classes/Hash.md) class.
 
 ## Metadata
 

--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -4,15 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Standardized way of indicating the type of content of an Element or a Property.
-A String constrained to the RFC 2046 specification.
+Standardized way of indicating the type of content of an Element or a property.
+A string constrained to the RFC 2046 specification.
 
 ## Description
 
 A MediaType is a string constrained to the
 [RFC 2046 MIME Part Two: Media Types](https://datatracker.ietf.org/doc/rfc2046/).
 It provides a standardized way of indicating the type of content of an Element
-or a Property.
+or a property.
 
 *Example*
 

--- a/model/Core/Properties/contentType.md
+++ b/model/Core/Properties/contentType.md
@@ -4,14 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides information about the content type of an Element or a Property.
+Provides information about the content type of an Element or a property.
 
 ## Description
 
 This field is a reasonable estimation of the content type of the Element or the
-Property, from a creator perspective.
+property, from a creator perspective.
 
-Content type is intrinsic to the Element or the Property, independent of how it
+Content type is intrinsic to the Element or the property, independent of how it
 is being used.
 
 ## Metadata

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Dataset Profile provides additional metadata, based on Software Profile,
+The Dataset profile provides additional metadata, based on Software profile,
 that is useful for datasets.
 
 ## Description

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -12,8 +12,8 @@ facilitate compliance with typical license use cases.
 The Licensing profile only contains the additional requirement that any
 Software Artifact must have a `Relationship` of type `hasConcludedLicense`.
 
-Classes and Property restrictions are defined in the SimpleLicensing profile
-(Classes and Properties associated with
+Classes and property restrictions are defined in the SimpleLicensing profile
+(classes and properties associated with
 [license expression strings](../../annexes/spdx-license-expressions.md))
 and in the ExpandedLicensing profile (classes and properties used for a
 fully parsed syntax tree of license expressions).

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Licensing Profile defines a minimum set of license information to
+The Licensing profile defines a minimum set of license information to
 facilitate compliance with typical license use cases.
 
 ## Description
@@ -12,10 +12,10 @@ facilitate compliance with typical license use cases.
 The Licensing profile only contains the additional requirement that any
 Software Artifact must have a `Relationship` of type `hasConcludedLicense`.
 
-Classes and Property restrictions are defined in the SimpleLicensing Profile
+Classes and Property restrictions are defined in the SimpleLicensing profile
 (Classes and Properties associated with
 [license expression strings](../../annexes/spdx-license-expressions.md))
-and in the ExpandedLicensing Profile (Classes and Properties used for a
+and in the ExpandedLicensing profile (classes and properties used for a
 fully parsed syntax tree of license expressions).
 
 There are 2 relationship types related to licensing - `hasDeclaredLicense` and

--- a/model/Security/Security.md
+++ b/model/Security/Security.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Security Profile captures security related information.
+The Security profile captures security related information.
 
 ## Description
 
-The Security Profile captures security related information.
+The Security profile captures security related information.
 
 ## Metadata
 

--- a/model/Service/Service.md
+++ b/model/Service/Service.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Profile captures software as a service related information.
+The profile captures software as a service related information.
 
 ## Description
 
-The Profile captures software as a service related information.
+The profile captures software as a service related information.
 
 ## Metadata
 

--- a/serialization/README.md
+++ b/serialization/README.md
@@ -26,7 +26,7 @@ Current supported formats are:
 
 Examples of how to serialize the following cases:
 
-### Core and Software Profiles use cases
+### Core and Software profiles use cases
 
 - `Agent`
 - `Annotation`
@@ -50,7 +50,7 @@ Examples of how to serialize the following cases:
   - `SpdxDocument` with `NamespaceMap`
   - `SpdxDocument` with two `File`s
 
-### Licensing Profile use cases
+### Licensing profile use cases
 
 - Single `Artifact` under one `ListedLicense`
 - Single `Artifact` under one `CustomLicense`
@@ -58,7 +58,7 @@ Examples of how to serialize the following cases:
 - Single `Artifact` under license expression of `ListedLicense` and `CustomLicense`
 - Two `Artifact`s under same license expression of `ListedLicense` and `CustomLicense`
 
-### Security Profile use cases
+### Security profile use cases
 
 The following list begins with base examples and sequentially adds expositional
 elements and relationships step-by-step:

--- a/serialization/jsonld/validation.md
+++ b/serialization/jsonld/validation.md
@@ -76,17 +76,17 @@ validation.
 Serialized names take the form of either `profilename_ClassName` or
 `profilename_propertyName`.
 
-The prefix `profilename_` is derived from the name of the Profile and is always
+The prefix `profilename_` is derived from the name of the profile and is always
 written in lowercase letters.
-There is an exception for the `Core` Profile, where serialized names omit the
+There is an exception for the `Core` profile, where serialized names omit the
 prefix entirely.
 
 For example,
 
-- `dataset_datasetType` for a `datasetType` Property in the `Dataset` Profile
+- `dataset_datasetType` for a `datasetType` property in the `Dataset` profile
 - `expandedlicensing_CustomLicense` for a `CustomLicense` Class in the
-  `ExpandedLicensing` Profile
-- `Person` for a Class `Person` in the `Core` Profile (no prefix)
+  `ExpandedLicensing` profile
+- `Person` for a class `Person` in the `Core` profile (no prefix)
 
 ### Cardinality
 
@@ -97,7 +97,7 @@ JSON, regardless of the actual number of values it holds.
 
 Note that SPDX 3 may use different casing than vocabularies in previous versions.
 
-For example, in the SPDX 3.0 Software Profile, the `homePage` property uses an
+For example, in the SPDX 3.0 Software profile, the `homePage` property uses an
 uppercase "P," while SPDX 2.3 uses the DOAP `homepage` property, which has a
 lowercase "p."
 


### PR DESCRIPTION
> This PR targets `develop` branch.

In model description and elsewhere, change "Profile" (starts with upper case) to "profile" (starts with lower case):

- To fix editorial issue as explained in https://github.com/spdx/spdx-spec/issues/1250
- Also update headings in "Glossary of terms" to be a sentence case, see https://github.com/spdx/spdx-spec/issues/1232