### PR TITLE
[3.0] "Profile" -> "profile"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@
   - Corrected `actionStatement` cardinality from `0..1` to `1..1` to match its textual description.
   - Corrected `actionStatementTime` cardinality from `0..*` to `0..1` to match its textual description.
 - **Fixed:** Typo in `Core/import` property - [#847](https://github.com/spdx/spdx-3-model/pull/847)
-  - Corrected `imports` to `import` in Core Profile.
+  - Corrected `imports` to `import` in Core profile.
 - **Fixed:** Typo in `Build/parameter` property - [#836](https://github.com/spdx/spdx-3-model/pull/836)
-  - Corrected `parameters` to `parameter` in Build Profile.
+  - Corrected `parameters` to `parameter` in Build profile.
 - **Fixed:** Typo in `hasInput` and `hasOutput` entries - [#854](https://github.com/spdx/spdx-3-model/pull/854)
   - Corrected `hasInputs` to `hasInput` and `hasOutputs` to `hasOutput` in
     `Core/RelationshipType`.
 - **Fixed:** Typo in `hasPrerequisite` entry- [#817](https://github.com/spdx/spdx-3-model/pull/817)
   - Corrected the misspelling of `hasPrerequsite` to `hasPrerequisite` in
     `Core/RelationshipType`.
-- **Fixed:** Licensing relationship type names in Profile conformance - [#779](https://github.com/spdx/spdx-3-model/pull/779)
+- **Fixed:** Licensing relationship type names in profile conformance - [#779](https://github.com/spdx/spdx-3-model/pull/779)
   - Corrected `concludedLicense` to `hasConcludedLicense` and
-    `declaredLicense` to `hasDeclaredLicense` in the "Profile conformance"
-    section of AI, Dataset, Licensing, and Lite Profiles.
+    `declaredLicense` to `hasDeclaredLicense` in profile conformance
+    section of AI, Dataset, Licensing, and Lite profiles.
 - **Fixed:** `Security/actionStatement` property - [#908](https://github.com/spdx/spdx-3-model/pull/908)
   - Corrected its cardinality from `0..1` to `1..1`.
 - **Fixed:** `Security/actionStatementTime` property - [#908](https://github.com/spdx/spdx-3-model/pull/908)

--- a/Contributing.md
+++ b/Contributing.md
@@ -36,7 +36,7 @@ There are multiple profiles being developed in parallel for the SPDX 3.0 model.
 
 - During its initial phase of development, a profile working group will
   contribute changes to its own branch in this repository.
-  - For example, any changes to the "Future Profile" should be submitted as a
+  - For example, any changes to the "Future" profile should be submitted as a
     change request to the `future-profile` branch.
 - There will be at least one maintainer per profile in charge of merging any
   profile development changes to the profile-specific branch.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -39,7 +39,7 @@ A specific sphere of activity or knowledge. For example, cyber security, softwar
 
 A class representing a concept of primary focus within a given domain.
 
-In a graph or serialized set of instance content this would be the granularity of what would be a node in the graph or a top-level object in the serialization set. This is typically similar to the scoping seen in labelled property graphs.
+In a graph or serialized set of instance content this would be the granularity of what would be a node in the graph or a top-level object in the serialization set. This is typically similar to the scoping seen in labeled property graphs.
 
 ## Namespace
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,4 @@
-# Glossary of Terms
+# Glossary of terms
 
 ## Agent
 
@@ -35,11 +35,11 @@ A representation of a relationship between a class (definition or instance) and 
 
 A specific sphere of activity or knowledge. For example, cyber security, software, bills of material, licensing, software security, etc.
 
-## Domain Class
+## Domain class
 
 A class representing a concept of primary focus within a given domain.
 
-In a graph or serialized set of instance content this would be the granularity of what would be a node in the graph or a top-level object in the serialization set. This is typically similar to the scoping seen in labeled property graphs.
+In a graph or serialized set of instance content this would be the granularity of what would be a node in the graph or a top-level object in the serialization set. This is typically similar to the scoping seen in labelled property graphs.
 
 ## Namespace
 
@@ -49,7 +49,7 @@ Each namespace typically defines its own IRI prefix utilized in the IRI IDs of a
 
 In SPDX 3.0, the "core" namespace is the scoping within which all foundational BOM concept classes and properties are defined and managed.
 
-## Non-domain Class
+## Non-domain class
 
 A class representing a concept of secondary or tertiary focus within a given domain that is a characterization of some aspect of a domain class.
 
@@ -81,11 +81,11 @@ The creator of the ElementCollection can also indicate whether any of the associ
 
 A representation of a relationship between a class (definition or instance) and some descriptive characterization of the class.
 
-## Property Domain
+## Property domain
 
 The class at the root of a property relationship. In other words, the class being characterized.
 
-## Property Range
+## Property range
 
 The class or literal datatype of the value of a property relationship.
 
@@ -97,7 +97,7 @@ The process of translating an abstract logical data structure into a format that
 
 A formally defined set of constraints that explicitly specify the valid "shape" of particular data to support validation against SPDX conformance requirements.
 
-A Property Shape defines the set of constraints for a given property when applied to a particular concept class. A Node Shape defines the set of property shapes (and thus constraints) relevant for validation of instance data realization of a given concept class.
+A property shape defines the set of constraints for a given property when applied to a particular concept class. A node shape defines the set of property shapes (and thus constraints) relevant for validation of instance data realization of a given concept class.
 
 In SPDX 3.0 these shapes are expressed using the W3C SHACL language.
 

--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The AI Profile is designed to provide a standardized way of documenting and
+The AI profile is designed to provide a standardized way of documenting and
 sharing information about AI software packages (i.e. systems).
 
 ## Description

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Build Profile defines the set of information required to describe an
+The Build profile defines the set of information required to describe an
 instance of a Software Build.
 
 ## Description
@@ -37,7 +37,7 @@ In addition, the following Relationship Types may be used to describe a Build.
   parent.
 - usesTool: Describes a relationship from a Build element to a build tool.
 
-All relationships in the Build Profile are scoped to the "build"
+All relationships in the Build profile are scoped to the "build"
 LifecycleScopeType period.
 
 The `hasInput` relationship can be applied to a config file or a build tool if

--- a/model/Build/Properties/configSourceDigest.md
+++ b/model/Build/Properties/configSourceDigest.md
@@ -12,7 +12,7 @@ invoke a build.
 configSourceDigest is the checksum of the build configuration file used by a
 builder to execute a build, according to the buildType.
 
-This Property uses the Core model's [Hash](../../Core/Classes/Hash.md) class.
+This property uses the Core model's [Hash](../../Core/Classes/Hash.md) class.
 
 ## Metadata
 

--- a/model/Core/Classes/NamespaceMap.md
+++ b/model/Core/Classes/NamespaceMap.md
@@ -32,7 +32,7 @@ Namespace maps support a variety of relevant use cases such as:
 2. An SPDX content producer wishing to maintain consistent prefix use and
     understanding across multiple different serialization formats of the
     produced content.
-  
+
     For example, an SBOM producer wishes to share/publish the SBOM as JSON-LD
     and XML. The producer can specify the preferred prefix mappings in the
     native serialization format using information from a single NamespaceMap

--- a/model/Core/Classes/PackageVerificationCode.md
+++ b/model/Core/Classes/PackageVerificationCode.md
@@ -28,10 +28,10 @@ Algorithm:
     }
 
     sort templist in ascending order by value
-    
+
     /* remove separators from ordered sequence */
     valueslist = remove "/n"s from templist
-     
+
     if valueslist is empty
        hashValue = 0
     else

--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -4,8 +4,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Standardized way of indicating the type of content of an Element or a Property.
-A String constrained to the RFC 2046 specification.
+Standardized way of indicating the type of content of an Element or a property.
+A string constrained to the RFC 2046 specification.
 
 ## Description
 

--- a/model/Core/Properties/contentType.md
+++ b/model/Core/Properties/contentType.md
@@ -4,14 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides information about the content type of an Element or a Property.
+Provides information about the content type of an Element or a property.
 
 ## Description
 
 This field is a reasonable estimation of the content type of the Element or the
-Property, from a creator perspective.
+property, from a creator perspective.
 
-Content type is intrinsic to the Element or the Property, independent of how it
+Content type is intrinsic to the Element or the property, independent of how it
 is being used.
 
 ## Metadata
@@ -22,10 +22,10 @@ is being used.
 
 ## Summary @zh-Hans
 
-提供有关`Element`或`Property`内容类型的信息。
+提供有关`Element`或`property`内容类型的信息。
 
 ## Description @zh-Hans
 
-此字段是从创建者的角度对`Element`或`Property`的内容类型的合理估计。
+此字段是从创建者的角度对`Element`或`property`的内容类型的合理估计。
 
-内容类型是`Element`或`Property`固有的，与其使用方式无关。
+内容类型是`Element`或`property`固有的，与其使用方式无关。

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -94,7 +94,7 @@ name completes the sentence:
 提供关于两个`Element`之间关系的信息。
 例如，可以表示两个不同`File`之间的关系，`Package`与`File`之间的关系，两个`Package`之间的关系，或者一个`SpdxDocument`与另一个`SpdxDocument`之间的关系。
 
-关系名称应该具有足够的描述性，以便根据其名称轻松推断出正确的方向。最佳做法是确保关系名称能够完整地表达以下句子: 
+关系名称应该具有足够的描述性，以便根据其名称轻松推断出正确的方向。最佳做法是确保关系名称能够完整地表达以下句子:
 
 `from`（是）`RELATIONSHIP` `to`
 

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Dataset Profile provides additional metadata, based on Software Profile,
+The Dataset profile provides additional metadata, based on Software profile,
 that is useful for datasets.
 
 ## Description

--- a/model/ExpandedLicensing/Classes/ConjunctiveLicenseSet.md
+++ b/model/ExpandedLicensing/Classes/ConjunctiveLicenseSet.md
@@ -40,7 +40,7 @@ left to the consumer of SPDX data to determine for themselves.
 `AnyLicenseInfo`的一部分，指所有元素都需要遵守的许可信息集。
 
 ## Description @zh-Hans
-  
+
 联合许可证集（`ConjunctiveLicenseSet`）表示 *每个* 附属`AnyLicenseInfos`都需要遵守。换句话说，一个由两个或更多许可证组成的`ConjunctiveLicenseSet`代表了一种许可情况，即 *所有* 特定的许可证都需要遵守。它在SPDX许可证表达式语法中通过`AND`运算符来表示。
 
 语法上正确的做法是指定一个`ConjunctiveLicenseSet`，其中的附属`AnyLicenseInfos`可以根据对相应许可证的特定解释而 “不兼容”。

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -72,7 +72,7 @@ indicates that one of the following applies:
 - the SPDX data creator has made no attempt to determine this field; or
 - the SPDX data creator has intentionally provided no information (no meaning
   should be implied by doing so).
-  
+
 If a hasDeclaredLicense relationship is not present, no assumptions can be made
 about whether or not a hasDeclaredLicense exists.
 

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Licensing Profile defines a minimum set of license information to
+The Licensing profile defines a minimum set of license information to
 facilitate compliance with typical license use cases.
 
 ## Description
@@ -12,10 +12,10 @@ facilitate compliance with typical license use cases.
 The Licensing profile only contains the additional requirement that any
 Software Artifact must have a `Relationship` of type `hasConcludedLicense`.
 
-Classes and Property restrictions are defined in the SimpleLicensing Profile
-(Classes and Properties associated with
+Classes and property restrictions are defined in the SimpleLicensing profile
+(classes and properties associated with
 [license expression strings](../../annexes/spdx-license-expressions.md))
-and in the ExpandedLicensing Profile (Classes and Properties used for a
+and in the ExpandedLicensing profile (classes and properties used for a
 fully parsed syntax tree of license expressions).
 
 There are 2 relationship types related to licensing - `hasDeclaredLicense` and
@@ -130,7 +130,7 @@ the following has to hold:
 
 许可配置文件仅包含一个附加要求，即任何软件工件必须具有类型为`hasConcludedLicense`的`Relationship`。
 
-类和属性的限制在 `SimpleLicensingProfile`（与[许可表达字符串](../../annexes/spdx-license-expressions.md)相关的类和属性）和`ExpandedLicensingProfile`（用于许可表达式的完全解析语法树的类和属性）中定义。
+类和属性的限制在 `SimpleLicensing profile`（与[许可表达字符串](../../annexes/spdx-license-expressions.md)相关的类和属性）和`ExpandedLicensing profile`（用于许可表达式的完全解析语法树的类和属性）中定义。
 
 与许可相关的关系类型有两种 -`hasDeclaredLicense`and`hasConcludedLicense`。
 

--- a/model/Security/Security.md
+++ b/model/Security/Security.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Security Profile captures security related information.
+The Security profile captures security related information.
 
 ## Description
 
-The Security Profile captures security related information.
+The Security profile captures security related information.
 
 ## Metadata
 

--- a/model/Software/Classes/Package.md
+++ b/model/Software/Classes/Package.md
@@ -12,7 +12,7 @@ software.
 A package refers to any unit of content that can be associated with a
 distribution of software.
 
-Typically, a package is composed of one or more files.  
+Typically, a package is composed of one or more files.
 
 Any of the following non-limiting examples may be (but are not required to be)
 represented in SPDX as a package:

--- a/serialization/README.md
+++ b/serialization/README.md
@@ -26,7 +26,7 @@ Current supported formats are:
 
 Examples of how to serialize the following cases:
 
-### Core and Software Profiles use cases
+### Core and Software profiles use cases
 
 - `Agent`
 - `Annotation`
@@ -50,7 +50,7 @@ Examples of how to serialize the following cases:
   - `SpdxDocument` with `NamespaceMap`
   - `SpdxDocument` with two `File`s
 
-### Licensing Profile use cases
+### Licensing profile use cases
 
 - Single `Artifact` under one `ListedLicense`
 - Single `Artifact` under one `CustomLicense`
@@ -58,7 +58,7 @@ Examples of how to serialize the following cases:
 - Single `Artifact` under license expression of `ListedLicense` and `CustomLicense`
 - Two `Artifact`s under same license expression of `ListedLicense` and `CustomLicense`
 
-### Security Profile use cases
+### Security profile use cases
 
 The following list begins with base examples and sequentially adds expositional
 elements and relationships step-by-step:

--- a/serialization/json.md
+++ b/serialization/json.md
@@ -12,7 +12,7 @@ The object consists of key-value pairs that allow the shortening of IDs and whic
 
 For deserialization purposes, follow this process:
 
-- For every string that is an ID (that includes values of the keys "spdxId" and "@id", 
+- For every string that is an ID (that includes values of the keys "spdxId" and "@id",
   as well as all strings where you would expect objects according to the SPDX-3 model),
   split that string at the first colon into "prefix:suffix".
 - If the suffix does not start with "//" and the prefix is a key in the namespace map,

--- a/serialization/jsonld/validation.md
+++ b/serialization/jsonld/validation.md
@@ -162,16 +162,16 @@ Here are some common errors worth looking into if an SPDX JSON-LD fails validati
 
 Serialized names take the form of either `profilename_ClassName` or
 `profilename_propertyName`.  The prefix `profilename_` is derived from the name
-of the Profile and is always written in lowercase letters.
-There is an exception for the `Core` Profile, where serialized names omit the
+of the profile and is always written in lowercase letters.
+There is an exception for the `Core` profile, where serialized names omit the
 prefix entirely.
 
 For example,
 
-- `dataset_datasetType` for a `datasetType` Property in the `Dataset` Profile
-- `expandedlicensing_CustomLicense` for a `CustomLicense` Class in the
-  `ExpandedLicensing` Profile
-- `Person` for a Class `Person` in the `Core` Profile (no prefix)
+- `dataset_datasetType` for a `datasetType` property in the `Dataset` profile
+- `expandedlicensing_CustomLicense` for a `CustomLicense` class in the
+  `ExpandedLicensing` profile
+- `Person` for a class `Person` in the `Core` profile (no prefix)
 
 ### Cardinality
 


### PR DESCRIPTION
> This PR targets `support/3.0` branch.

Change "Profile" (starts with upper case) to "profile" (starts with lower case):

- To fix editorial issue as explained in https://github.com/spdx/spdx-spec/issues/1250
- Also update headings in "Glossary of terms" to be a sentence case, see https://github.com/spdx/spdx-spec/issues/1232