### PR TITLE
Add "follows" relationship type

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -42,7 +42,7 @@ name completes the sentence:
 - exploitCreatedBy: The `from` Vulnerability has had an exploit created against it by each `to` Agent.
 - fixedBy: Designates a `from` Vulnerability has been fixed by the `to` Agent(s).
 - fixedIn: A `from` Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships.
-- follows: The `to` Element succeeds the `from` Element, establishing a unidirectional sequence. This succession is defined as chronological, procedural, or logical. It is used to represent either a temporal/causal dependence (e.g., in a workflow) or a defined logical order for processing and traversal (e.g., in an ordered list).
+- follows: The `to` Element succeeds the `from` Element, establishing a unidirectional sequence. This succession is defined as chronological, procedural, or logical. It is used to represent either a temporal order (e.g., in a workflow) or a logical order for processing and traversal (e.g., in an ordered list).
 - foundBy: Designates a `from` Vulnerability was originally discovered by the `to` Agent(s).
 - generates: The `from` Element generates each `to` Element.
 - hasAddedFile: Every `to` Element is a file added to the `from` Element (`from` hasAddedFile `to`).

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -42,6 +42,7 @@ name completes the sentence:
 - exploitCreatedBy: The `from` Vulnerability has had an exploit created against it by each `to` Agent.
 - fixedBy: Designates a `from` Vulnerability has been fixed by the `to` Agent(s).
 - fixedIn: A `from` Vulnerability has been fixed in each `to` Element. The use of the `fixedIn` type is constrained to `VexFixedVulnAssessmentRelationship` classed relationships.
+- follows: The `to` Element succeeds the `from` Element, establishing a unidirectional sequence. This succession is defined as chronological, procedural, or logical. It is used to represent either a temporal/causal dependence (e.g., in a workflow) or a defined logical order for processing and traversal (e.g., in an ordered list).
 - foundBy: Designates a `from` Vulnerability was originally discovered by the `to` Agent(s).
 - generates: The `from` Element generates each `to` Element.
 - hasAddedFile: Every `to` Element is a file added to the `from` Element (`from` hasAddedFile `to`).


### PR DESCRIPTION
Follow-up of the discussion from 8 Oct 2025 AI WG meeting, regarding new class `Prompt` #1110, on defining ordinality between two prompts (Prompt1 preceeds Prompt2), a possibility of having a "follows" relationship type is proposed to model a sequence of prompts.

```mermaid
graph LR;
  B(Element 2) -->|follows| A(Element 1)
```

The "follows" relationship type's description can be:

| relationship type | from | to | Description |
|-|-|-|-|
| follows | Element | Element | The `to` Element succeeds the `from` Element, establishing a unidirectional sequence. This succession is defined as chronological, procedural, or logical. It is used to represent either a temporal order (e.g., in a workflow) or a logical order for processing and traversal (e.g., in an ordered list). |

## AI use case

This relationship type can be used to describe "prompt chaining" - a workflow where the output of a preceding prompt serves as the input for the following prompt.

## Non-AI use case

While this new relationship type initiated to serve an AI prompt use case, it should be generic enough for other use cases that need to record a temporal/procedural/logical order.

(also recorded in the [Relationship Type spreadsheet](https://docs.google.com/spreadsheets/d/1g9TophkZ2tWhTPMGGHqGOUurzZvOdkBtBJCvyBsa8kc/edit?usp=sharing))