### PR TITLE
Add validatedOn relationship type

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -87,3 +87,4 @@ name completes the sentence:
 - trainedOn: The `from` Element has been trained on the `to` Element(s).
 - underInvestigationFor: The `from` Vulnerability impact is being investigated for each `to` Element. The use of the `underInvestigationFor` type is constrained to `VexUnderInvestigationVulnAssessmentRelationship` classed relationships.
 - usesTool: The `from` Element uses each `to` Element as a tool, during a LifecycleScopeType period.
+- validatedOn: The `from` Element has been validated on the `to` Element(s).


### PR DESCRIPTION
- Per 15 Oct 2025 AI WG call, add "validatedOn" relationship type
- Based on proposal discussed on 2 Aug 2023 AI WG call "Add validated on & interpreted on relationships." https://github.com/spdx/meetings/blob/main/ai/2023/2023-08-02.md
- This relationship type is generic and could be used for non-AI use case as well.

```mermaid
graph LR;
  B(Element) -->|validatedOn| A(Element)
```

- [x] Added to [3.1-dev RelationshipType sheet](https://docs.google.com/spreadsheets/d/1g9TophkZ2tWhTPMGGHqGOUurzZvOdkBtBJCvyBsa8kc/edit?usp=sharing)