### PR TITLE
Add `from` type of expandsTo relationship type

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -39,7 +39,7 @@ name completes the sentence:
 - describes: The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property should be used.
 - doesNotAffect: The `from` Vulnerability has no impact on each `to` Element. The use of the `doesNotAffect` is constrained to `VexNotAffectedVulnAssessmentRelationship` classed relationships.
 - evaluatedOn: The `from` Element has been evaluated on the `to` Element(s).
-- expandsTo: The `from` Artifact expands out as an artifact described by each `to` Element.
+- expandsTo: The `from` Element expands out as an artifact described by each `to` Element.
 - exploitCreatedBy: The `from` Vulnerability has had an exploit created against it by each `to` Agent.
 - finetunedOn: The `from` Element has been finetuned on the `to` Element(s).
 - fixedBy: Designates a `from` Vulnerability has been fixed by the `to` Agent(s).

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -39,7 +39,7 @@ name completes the sentence:
 - describes: The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property should be used.
 - doesNotAffect: The `from` Vulnerability has no impact on each `to` Element. The use of the `doesNotAffect` is constrained to `VexNotAffectedVulnAssessmentRelationship` classed relationships.
 - evaluatedOn: The `from` Element has been evaluated on the `to` Element(s).
-- expandsTo: The `from` archive expands out as an artifact described by each `to` Element.
+- expandsTo: The `from` Artifact expands out as an artifact described by each `to` Element.
 - exploitCreatedBy: The `from` Vulnerability has had an exploit created against it by each `to` Agent.
 - finetunedOn: The `from` Element has been finetuned on the `to` Element(s).
 - fixedBy: Designates a `from` Vulnerability has been fixed by the `to` Agent(s).


### PR DESCRIPTION
Per 14 Oct 2025 Tech call, reviewing a proposal in issue #1114:

- Update entry description of `expandsTo` to explicitly state the type of `from`. Make it `Element` (or should it be `Artifact`?)
- During the meeting, there're questions if a non-archive can expand or a hardware can expand?

Current:

> The `from` archive expands out as an artifact described by each `to` Element.

```mermaid
graph LR;
  A(Type unspecified) -->|expandsTo| B(Element)
```

Proposed in this PR:

> The `from` Element expands out as an artifact described by each `to` Element.

```mermaid
graph LR;
  A(Element) -->|expandsTo| B(Element)
```
