### PR TITLE
Move inLanguage to Core

### DIFF
--- a/model/Core/Properties/inLanguage.md
+++ b/model/Core/Properties/inLanguage.md
@@ -8,8 +8,11 @@ Specifies a human language used within the content of an Element or a property.
 
 ## Description
 
-This property uses an IETF BCP 47 language tag to indicate a human language
-used within the content of an Element or a property.
+Specifies a human language used within the content of an Element or a property.
+
+The property value shall be an
+[IETF BCP 47 language tag](https://datatracker.ietf.org/doc/rfc5646/)
+used to indicating human languages, dialects, scripts, regions, and variants.
 
 ## Metadata
 

--- a/model/Core/Properties/inLanguage.md
+++ b/model/Core/Properties/inLanguage.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Specifies a human language used within a dataset.
+Specifies a human language used within the content of an Element or a property.
 
 ## Description
 
 This property uses an IETF BCP 47 language tag to indicate a human language
-used within a dataset.
+used within the content of an Element or a property.
 
 ## Metadata
 

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -18,6 +18,9 @@ Metadata information that can be added to a dataset that may be used in a softwa
 
 ## Properties
 
+- /Core/inLanguage
+  - type: /Core/LanguageTag
+  - minCount: 0
 - anonymizationMethodUsed
   - type: xsd:string
   - minCount: 0
@@ -55,9 +58,6 @@ Metadata information that can be added to a dataset that may be used in a softwa
   - type: /Core/PresenceType
   - minCount: 0
   - maxCount: 1
-- inLanguage
-  - type: /Core/LanguageTag
-  - minCount: 0
 - intendedUse
   - type: xsd:string
   - minCount: 0


### PR DESCRIPTION
Per 15 Oct 2025 AI WG call, reviewing a proposal in issue #1097, we agreed to:

- Move `/Dataset/inLanguage` to `/Core/inLanguage`
  - Not a breaking change, as not released yet
- Update summary to be more generic, borrowed language from /Core/contentType
- Update `/Dataset/DatasetPackage` to use the property in new location

To resolve #1097 