### PR TITLE
Update /Core/Specification description

### DIFF
--- a/model/Core/Classes/Specification.md
+++ b/model/Core/Classes/Specification.md
@@ -10,7 +10,7 @@ process, or system.
 ## Description
 
 A specification (spec) is a detailed document that outlines the 
-requirements for a product, process, or system.
+of the design, requirements, or features for a product, process, or system.
 
 Specifications are often based on standards but provide more specific details
 for implementation.

--- a/model/Core/Classes/Specification.md
+++ b/model/Core/Classes/Specification.md
@@ -4,14 +4,19 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
- specifications are identified in this class.
+A detailed document that outlines the exact requirements for a product,
+process, or system.
 
 ## Description
 
-specifications are referenced in this class. Requirements, standards, specification and processes are referenced in this class.
+A specification (spec) is a detailed document that outlines the exact
+requirements for a product, process, or system.
 
-A standard is an agreed-upon set of rules established by industry organizations or regulatory bodies. It ensures uniformity, safety, and compatibility across different systems, products, and services.
-A specification (spec) is a detailed document that outlines the exact requirements for a product, process, or system. Specifications are often based on standards but provide more specific details for implementation.
+Specifications are often based on standards but provide more specific details
+for implementation.
+
+Requirements, standards, specifications and processes can be referenced in this
+class.
 
 ## Metadata
 
@@ -30,5 +35,3 @@ A specification (spec) is a detailed document that outlines the exact requiremen
 
 - /Core/Element/externalIdentifier
   - minCount: 1
-
-

--- a/model/Core/Classes/Specification.md
+++ b/model/Core/Classes/Specification.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A detailed document that outlines the exact requirements for a product,
+A specification is a detailed description of the design, requirements, or features of a product, process, or system.
 process, or system.
 
 ## Description

--- a/model/Core/Classes/Specification.md
+++ b/model/Core/Classes/Specification.md
@@ -4,19 +4,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A specification is a detailed description of the design, requirements, or features of a product, process, or system.
-process, or system.
+A specification is a detailed description of the design, requirements,
+or features of a product, process, or system.
 
 ## Description
 
-A specification (spec) is a detailed document that outlines the 
-of the design, requirements, or features for a product, process, or system.
+A specification (spec) is a detailed document that outlines the
+design, requirements, or features for a product, process, or system.
 
-Specifications are often based on standards but provide more specific details
-for implementation.
-
-Requirements, standards, specifications and processes can be referenced in this
-class.
+Requirements, standards, specifications and processes
+can be referenced in this class.
 
 ## Metadata
 

--- a/model/Core/Classes/Specification.md
+++ b/model/Core/Classes/Specification.md
@@ -9,7 +9,7 @@ process, or system.
 
 ## Description
 
-A specification (spec) is a detailed document that outlines the exact
+A specification (spec) is a detailed document that outlines the 
 requirements for a product, process, or system.
 
 Specifications are often based on standards but provide more specific details

--- a/model/Core/Vocabularies/SpecificationType.md
+++ b/model/Core/Vocabularies/SpecificationType.md
@@ -16,7 +16,7 @@ A specification type defines the nature of a specification.
 
 ## Entries
 
-- formalStandard: A formal standard is a documented specification created and ratified by a recognized standards‐development organization and published as a normative reference.
-- specifications: A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference.
-- other: Any other Type of specification
-
+- formalStandard: A formal standard is a standard created and ratified by a recognized standards-development organization and published as a normative reference.
+- specification: A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference.
+- standard: An agreed-upon specification established by groups or organizations that ensures uniformity, safety, and compatibility across different systems, products, and services.
+- other: Any other type of specification.

--- a/model/Core/Vocabularies/SpecificationType.md
+++ b/model/Core/Vocabularies/SpecificationType.md
@@ -17,6 +17,6 @@ A specification type defines the nature of a specification.
 ## Entries
 
 - formalStandard: A formal standard is a standard ratified by a recognized standards-development organization and published as a normative reference.
+- regulation: A mandatory legal specification issued by a governmental or regulatory authority. Compliance is enforceable by law.
 - specification: A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference.
-- regulation:  A mandatory legal specification issued by a governmental or regulatory authority. Compliance is enforceable by law.
 - other: Any other type of specification.

--- a/model/Core/Vocabularies/SpecificationType.md
+++ b/model/Core/Vocabularies/SpecificationType.md
@@ -18,5 +18,5 @@ A specification type defines the nature of a specification.
 
 - formalStandard: A formal standard is a standard ratified by a recognized standards-development organization and published as a normative reference.
 - specification: A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference.
-- standard: An agreed-upon specification established by groups or organizations that ensures uniformity, safety, and compatibility across different systems, products, and services.
+- regulation:  A mandatory legal specification issued by a governmental or regulatory authority. Compliance is enforceable by law.
 - other: Any other type of specification.

--- a/model/Core/Vocabularies/SpecificationType.md
+++ b/model/Core/Vocabularies/SpecificationType.md
@@ -16,7 +16,7 @@ A specification type defines the nature of a specification.
 
 ## Entries
 
-- formalStandard: A formal standard is a standard created and ratified by a recognized standards-development organization and published as a normative reference.
+- formalStandard: A formal standard is a standard ratified by a recognized standards-development organization and published as a normative reference.
 - specification: A specification is a detailed document (or set of documents) that describes the requirements, design, behavior, or other characteristics of a system, component, or process so that all stakeholders have a clear, unambiguous reference.
 - standard: An agreed-upon specification established by groups or organizations that ensures uniformity, safety, and compatibility across different systems, products, and services.
 - other: Any other type of specification.


### PR DESCRIPTION
Updated 2025-11-04: Revised per @stevenc-stb suggestions, see resolved comments below.

--

Current `/Core/Specification` class has a definition of "standard" that looks a bit out of place.
  <s>Move that to be a new entry "standard" in `/Core/SpecificationType` and modified "formalStandard" to refer to this new "standard".</s>

Resolution: Remove the sentence.

--

Try to keep the same language but anyway there is a question about this sentence:

> Specifications are often based on standards but provide more specific details for implementation.

If a standard/formalStandard is a type of specification, does it a bit circular to say a specification is based on a standard?

- What is standard? - It is a type of a specification.
- What is specification - It is based on a standard.

Resolution: Remove the sentence.

--

Add a new "regulation" entry to `/Core/SpecificationType`, per Steven's suggestion.