### PR TITLE
AI/Dataset: Relax property and relationship requirements

### DIFF
--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -17,15 +17,3 @@ development process, such as software packages, models, and datasets.
 
 - id: https://spdx.org/rdf/3.1/terms/AI
 - name: AI
-
-## Profile conformance
-
-For an element collection to be conformant with this profile,
-the following has to hold:
-
-1. for every `/AI/AIPackage` there shall exist exactly one `/Core/Relationship`
-   of type `hasConcludedLicense` having that element as its `from` property
-   and a `/SimpleLicensing/AnyLicenseInfo` as its `to` property.
-2. for every `/AI/AIPackage` there shall exist exactly one `/Core/Relationship`
-   of type `hasDeclaredLicense` having that element as its `from` property
-   and a `/SimpleLicensing/AnyLicenseInfo` as its `to` property.

--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -8,7 +8,7 @@ A Package that contains AI software or an AI model.
 
 ## Description
 
-A software package that contains code or a model that provides
+A Package that contains code or a model that provides
 artificial intelligence capabilities.
 
 ## Metadata

--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Specifies an AI package and its associated information.
+Refers to any unit of content that can be associated with a distribution of
+AI software or AI model.
 
 ## Description
 
-Metadata information that can be added to a package to describe an AI application or trained AI model.
+An AI Package is a specialized type of software Package that includes
+code or model that implements artificial intelligence functionalities.
 
 ## Metadata
 
@@ -74,16 +76,3 @@ Metadata information that can be added to a package to describe an AI applicatio
   - type: /Core/PresenceType
   - minCount: 0
   - maxCount: 1
-
-## External properties restrictions
-
-- /Core/Artifact/releaseTime
-  - minCount: 1
-- /Core/Artifact/suppliedBy
-  - minCount: 1
-- /Software/Package/downloadLocation
-  - minCount: 1
-- /Software/Package/packageVersion
-  - minCount: 1
-- /Software/SoftwareArtifact/primaryPurpose
-  - minCount: 1

--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -4,13 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Refers to any unit of content that can be associated with a distribution of
-AI software or AI model.
+A Package that contains AI software or an AI model.
 
 ## Description
 
-An AI Package is a specialized type of software Package that includes
-code or model that implements artificial intelligence functionalities.
+A software package that contains code or a model that provides
+artificial intelligence capabilities.
 
 ## Metadata
 

--- a/model/AI/Classes/AIPackage.md
+++ b/model/AI/Classes/AIPackage.md
@@ -76,3 +76,8 @@ code or model that implements artificial intelligence functionalities.
   - type: /Core/PresenceType
   - minCount: 0
   - maxCount: 1
+
+## External properties restrictions
+
+- /Software/SoftwareArtifact/primaryPurpose
+  - minCount: 1

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Specifies a data package and its associated information.
+Refers to any unit of content that can be associated with a distribution of
+dataset.
 
 ## Description
 
-Metadata information that can be added to a dataset that may be used in a software or to train/test an AI package.
+A Dataset Package is a specialized type of software package that includes
+data used for software, hardware, or system training, testing, and calibration,
+as well as for reference, archival, or other purposes.
 
 ## Metadata
 
@@ -68,17 +71,3 @@ Metadata information that can be added to a dataset that may be used in a softwa
 - sensor
   - type: /Core/DictionaryEntry
   - minCount: 0
-
-## External properties restrictions
-
-- /Core/Artifact/builtTime
-  - minCount: 1
-- /Core/Artifact/originatedBy
-  - minCount: 1
-  - maxCount: 1
-- /Core/Artifact/releaseTime
-  - minCount: 1
-- /Software/Package/downloadLocation
-  - minCount: 1
-- /Software/SoftwareArtifact/primaryPurpose
-  - minCount: 1

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -71,3 +71,8 @@ as well as for reference, archival, or other purposes.
 - sensor
   - type: /Core/DictionaryEntry
   - minCount: 0
+
+## External properties restrictions
+
+- /Software/SoftwareArtifact/primaryPurpose
+  - minCount: 1

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -4,14 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Refers to any unit of content that can be associated with a distribution of
-dataset.
+A Package that contains a dataset.
 
 ## Description
 
-A Dataset Package is a specialized type of software package that includes
-data used for software, hardware, or system training, testing, and calibration,
-as well as for reference, archival, or other purposes.
+A Package that contains data used for the operation, training,
+testing, evaluation, or calibration of software, hardware, or systems,
+or for reference and archival purposes.
 
 ## Metadata
 

--- a/model/Dataset/Classes/DatasetPackage.md
+++ b/model/Dataset/Classes/DatasetPackage.md
@@ -10,7 +10,7 @@ A Package that contains a dataset.
 
 A Package that contains data used for the operation, training,
 testing, evaluation, or calibration of software, hardware, or systems,
-or for reference and archival purposes.
+or for reporting, documentation, reference, and archival purposes.
 
 ## Metadata
 

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -16,17 +16,3 @@ preparation process, its characteristics, and its access methods.
 
 - id: https://spdx.org/rdf/3.1/terms/Dataset
 - name: Dataset
-
-## Profile conformance
-
-For an element collection to be conformant with this profile,
-the following has to hold:
-
-1. for every `/Dataset/DatasetPackage` there shall exist exactly one
-   `/Core/Relationship` of type `hasConcludedLicense` having that element as its
-   `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
-    property.
-2. for every `/Dataset/DatasetPackage` there shall exist exactly one
-   `/Core/Relationship` of type `hasDeclaredLicense` having that element as its
-   `from` property and a `/SimpleLicensing/AnyLicenseInfo` as its `to`
-    property.


### PR DESCRIPTION
From 2025-10-29 AI Team Meeting, we discussed the possibility to relax property and relationship requirements.

Update: On 2025-11-19 AI Team Meeting, we are agreed to drop these requirements:

1) properties in the "External properties restrictions" of `AIPackage` and `DatasetPackage` classes:
    - `releaseTime`
    - `suppliedBy`
    - `downloadLocation`
    - `packageVersion`; and

2) license relationships `hasConcludedLicense` and `hasDeclaredLicense`, in the "Profile conformance" sections of AI and Dataset profiles. (Sames as Software profile)

We will keep `primaryPurpose` as a mandatory property for both AIPackage and DatasetPackage.
The `primaryPurpose` has a range of `SoftwarePurpose` vocab, which allows "other" as a value.

----

(Old description)

- The general tone from the 2025-10-29 meeting we understand that these information are very useful for different purposes, but they may not always be available.
  - For example, some dataset may not be obtainable thru download.
  - So the question is which one should we keep as mandatory and which one we should made it optional.
- <s>*We are not yet reach the agreement* specifically on each individual property/relationship. This PR is to work that out.</s>

Also note that if we want to require the `AIPackage` or the `DatasetPacakge` to have  `hasConcludedLicense` relationship, we can always ask for the conformance of Licensing profile -- without the need to repeat the same requirement in the AI or Dataset profile.

Since this is a relaxation, it is not a breaking change. An SBOM that conforms SPDX 3.0 will conform SPDX 3.1 too.

@bennetkl @rgopikrishnan91 @cngo20 @stevenc-stb @ElyasRashno