### PR TITLE
Fix customIdToLicense: wrong range type in text

### DIFF
--- a/model/SimpleLicensing/Properties/customIdToLicense.md
+++ b/model/SimpleLicensing/Properties/customIdToLicense.md
@@ -18,7 +18,7 @@ dictates any reference starting with a
 "LicenseRef-" or "AdditionRef-" refers to license or addition text not found in
 the official [SPDX License List](https://spdx.org/licenses/).
 
-The key for the DictionaryEntry is the string used in the license expression
+The key for the ElementMap is the string used in the license expression
 and the value is target Element, which must be a CustomLicense,
 CustomLicenseAddition, or SimpleLicensingText.
 


### PR DESCRIPTION
customIdToLicense range is /`Core/ElementMap` not `/Core/DictionaryEntry`.

The text should be 'ElementMap'.

(The paragraph was copied from customIdToUri without modification; customIdToUri uses DictionaryEntry)

@JPEWdev please review.