### PR TITLE
Add Assumption.md to define assumption element

### DIFF
--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A distinct unit representing an assumption associated with an item's use in a systems.
+A distinct unit representing a constraint associated with an item's use in a system.
 
 ## Description
 

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -12,7 +12,6 @@ An assumption element is a distinct unit that defines a design constraint.
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
 
-The `rationale` is usually less formal than the wording of the assumption statement itself.
 
 ## Metadata
 

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -11,7 +11,6 @@ A distinct unit representing a constraint associated with an item's use in a sys
 An assumption element is a distinct unit that defines a design constraint. 
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
-
 ## Metadata
 
 - name: Assumption

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -10,7 +10,6 @@ A distinct unit representing a constraint associated with an item's use in a sys
 
 An assumption element is a distinct unit that defines a design constraint. 
 This constraint is imposed by the intended design, the requirement context,
-or the operational context.
 It ensures the item operates correctly within a system context.
 
 A `rationale` is an additional detail used to define the reason or justification for the existence of the assumption.

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -11,6 +11,7 @@ A distinct unit representing a constraint associated with an item's use in a sys
 An assumption element is a distinct unit that defines a design constraint. 
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
+
 ## Metadata
 
 - name: Assumption

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# Requirement
+# Assumption
 
 ## Summary
 

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -12,7 +12,6 @@ An assumption element is a distinct unit that defines a design constraint.
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
 
-
 ## Metadata
 
 - name: Assumption

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -12,7 +12,6 @@ An assumption element is a distinct unit that defines a design constraint.
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
 
-A `rationale` is an additional detail used to define the reason or justification for the existence of the assumption.
 The `rationale` is usually less formal than the wording of the assumption statement itself.
 
 ## Metadata

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -9,7 +9,7 @@ A distinct unit representing a constraint associated with an item's use in a sys
 ## Description
 
 An assumption element is a distinct unit that defines a design constraint. 
-This constraint is imposed by the intended design, the requirement context,
+This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
 
 A `rationale` is an additional detail used to define the reason or justification for the existence of the assumption.

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -8,7 +8,7 @@ A distinct unit representing a constraint associated with an item's use in a sys
 
 ## Description
 
-An assumption element is a distinct unit that defines a design constraint. 
+An assumption element is a distinct unit that defines a design constraint.
 This constraint is imposed by the intended design, the requirement context, or the operational context.
 It ensures the item operates correctly within a system context.
 

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -20,10 +20,6 @@ The `rationale` is usually less formal than the wording of the assumption statem
 
 ## Properties
 
-- devLifecycleStage
-  - type: LifecycleScopeType
-  - minCount: 0
-  - maxCount: *
 - rationale
   - type: xsd:string
   - minCount: 0

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -8,7 +8,10 @@ A distinct unit representing a constraint associated with an item's use in a sys
 
 ## Description
 
-A assumption element is a distinct unit that defines an constraints imposed by intended design, requirement context or operational context, for correct operation of an item in a system context. 
+An assumption element is a distinct unit that defines a design constraint. 
+This constraint is imposed by the intended design, the requirement context,
+or the operational context.
+It ensures the item operates correctly within a system context.
 
 A `rationale` is an additional detail used to define the reason or justification for the existence of the assumption.
 The `rationale` is usually less formal than the wording of the assumption statement itself.

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -1,0 +1,38 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# Requirement
+
+## Summary
+
+A distinct unit representing an assumption associated with an item's use in a systems.
+
+## Description
+
+A assumption element is a distinct unit that defines an constraints imposed by intended design, requirement context or operational context, for correct operation of an item in a system context. 
+
+A `rationale` is an additional detail used to define the reason or justification for the existence of the assumption.
+The `rationale` is usually less formal than the wording of the assumption statement itself.
+
+## Metadata
+
+- name: Assumption
+- SubclassOf: /Core/Element
+
+## Properties
+
+- devLifecycleStage
+  - type: LifecycleScopeType
+  - minCount: 0
+  - maxCount: *
+- rationale
+  - type: xsd:string
+  - minCount: 0
+  - maxCount: *
+- assumptionStatement
+  - type: xsd:string
+  - minCount: 1
+  - maxCount: 1
+- assumptionUUID
+  - type: ExternalIdentifier
+  - minCount: 0
+  - maxCount: 1

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -28,6 +28,6 @@ It ensures the item operates correctly within a system context.
   - minCount: 1
   - maxCount: 1
 - assumptionUUID
-  - type: ExternalIdentifier
+  - type: /Core/ExternalIdentifier
   - minCount: 0
   - maxCount: 1

--- a/model/FunctionalSafety/Classes/Assumption.md
+++ b/model/FunctionalSafety/Classes/Assumption.md
@@ -19,7 +19,7 @@ It ensures the item operates correctly within a system context.
 
 ## Properties
 
-- rationale
+- /Core/rationale
   - type: xsd:string
   - minCount: 0
   - maxCount: *

--- a/model/FunctionalSafety/Properties/assumptionStatement.md
+++ b/model/FunctionalSafety/Properties/assumptionStatement.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# assumptionStatement
+
+## Summary
+
+A text describing the design constraint defined by the assumption.
+
+## Description
+
+The text describing a constraint is imposed by the intended design, the requirement context, or the operational context.
+
+## Metadata
+
+- name: assumptionStatement
+- Nature: DataProperty
+- Range: xsd:string

--- a/model/FunctionalSafety/Properties/assumptionUUID.md
+++ b/model/FunctionalSafety/Properties/assumptionUUID.md
@@ -1,0 +1,17 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# assumptionUUID
+
+## Summary
+
+ An assumptionUUID is a universally unique identifier (UUID) assigned to an Assumption item.
+
+## Description
+
+ An assumptionUUID is a universally unique identifier (UUID) assigned to an item that represents a design constraint.
+
+## Metadata
+
+- name: assumptionUUID
+- Nature: ObjectProperty
+- Range: /Core/ExternalIdentifier


### PR DESCRIPTION
This file defines the structure and properties of an assumption element in the context of functional safety, including metadata and properties such as devLifecycleStage, rationale, assumptionStatement, and assumptionUUID.

Signed-off-by:  Kate Stewart <kstewart@linuxfoundation.org>