### PR TITLE
Maintainers: Update AI and Dataset profiles

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -78,10 +78,10 @@ Each profile in active development phase also has their own
 
 | Profile | Maintainer(s) |
 | ------- | ------------- |
-| AI | [Karen Bennet][gh-karen] and [Gopi Krishnan Rajbahadur][gh-gopi] |
+| AI | [Gopi Krishnan Rajbahadur][gh-gopi] and [Arthit Suriyawongkul][gh-arthit] |
 | Build | [Brandon Lum][gh-brandon] and [Nisha Kumar][gh-nisha] |
 | Core | [William Bartholomew][gh-william], [Gary O'Neall][gh-gary], and [Kate Stewart][gh-kate] |
-| Dataset | [Karen Bennet][gh-karen] and [Gopi Krishnan Rajbahadur][gh-gopi] |
+| Dataset | [Gopi Krishnan Rajbahadur][gh-gopi] and [Arthit Suriyawongkul][gh-arthit] |
 | FunctionalSafety | [Nicole Pappler][gh-nicole] |
 | Hardware | [Steven Carbno][gh-stevenc] and Alfred Strauch |
 | Licensing | [Steve Winslow][gh-steve] and [Alexios Zavras][gh-alexios] |
@@ -102,12 +102,12 @@ Each profile in active development phase also has their own
 [cla]: CLA.md
 [gh-adolfo]: https://github.com/puerco
 [gh-alexios]: https://github.com/zvr
+[gh-arthit]: https://github.com/bact
 [gh-brandon]: https://github.com/lumjjb
 [gh-gary]: https://github.com/goneall
 [gh-gopi]: https://github.com/rgopikrishnan91
 [gh-nicole]: https://github.com/nicpappler
 [gh-nisha]: https://github.com/nishakm
-[gh-karen]: https://github.com/bennetkl
 [gh-kate]: https://github.com/kestewart
 [gh-rose]: https://github.com/rnjudge
 [gh-steve]: https://github.com/swinslow


### PR DESCRIPTION
Based on 8 Apr 2026 AI WG call https://docs.google.com/document/d/1Q2a2HAV_ipbPhV6pqWWqzxYjBaTKtIW7H_CfAFF0kek/edit?tab=t.xbiph2z90f42

Karen Bennet (@bennetkl) is stepping down as co-chair of the SPDX AI WG. Arthit Suriyawongkul (@bact) will step up to co-chair the group alongside Gopi Krishnan Rajbahadur (@rgopikrishnan91), who continues in his role.



To address part of https://github.com/spdx/spdx-3-model/issues/1244

@bennetkl @rgopikrishnan91 @bobmartin3000 please review.