### PR TITLE
Drop the minor version in namespace URIs

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -191,16 +191,16 @@ will give this RDF graph
 (in [Turtle syntax](https://en.wikipedia.org/wiki/Turtle_(syntax))):
 
 ```ttl
-<https://spdx.org/rdf/3.1/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
+<https://spdx.org/rdf/3/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
         sh:NodeShape ;
     rdfs:comment "A license or addition that is not listed on the SPDX License List."@en ;
-    rdfs:subClassOf <https://spdx.org/rdf/3.1/terms/Core/Element> ;
+    rdfs:subClassOf <https://spdx.org/rdf/3/terms/Core/Element> ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:path <https://spdx.org/rdf/3.1/terms/SimpleLicensing/licenseText> ] .
+            sh:path <https://spdx.org/rdf/3/terms/SimpleLicensing/licenseText> ] .
 ```
 
 ## Syntax

--- a/docs/translation.md
+++ b/docs/translation.md
@@ -106,7 +106,7 @@ The above model Markdown file will generate the following RDF
 (showing partial):
 
 ```ttl
-<https://spdx.org/rdf/3.1/terms/Core/AnnotationType> a owl:Class;
+<https://spdx.org/rdf/3/terms/Core/AnnotationType> a owl:Class;
     rdfs:comment "Specifies the type of an annotation."@en ;
     rdfs:comment "注釈の種類を指定します。"@ja ;
     rdfs:comment "指定注释的类型。"@zh-hans ;

--- a/model/AI/AI.md
+++ b/model/AI/AI.md
@@ -15,5 +15,5 @@ development process, such as software packages, models, and datasets.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/AI
+- id: https://spdx.org/rdf/3/terms/AI
 - name: AI

--- a/model/Build/Build.md
+++ b/model/Build/Build.md
@@ -45,7 +45,7 @@ the nature of these inputs are not known at the creation of an SPDX document.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Build
+- id: https://spdx.org/rdf/3/terms/Build
 - name: Build
 
 ## Profile conformance

--- a/model/Core/Core.md
+++ b/model/Core/Core.md
@@ -13,5 +13,5 @@ SPDX 3 profiles.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Core
+- id: https://spdx.org/rdf/3/terms/Core
 - name: Core

--- a/model/Dataset/Dataset.md
+++ b/model/Dataset/Dataset.md
@@ -14,5 +14,5 @@ preparation process, its characteristics, and its access methods.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Dataset
+- id: https://spdx.org/rdf/3/terms/Dataset
 - name: Dataset

--- a/model/ExpandedLicensing/ExpandedLicensing.md
+++ b/model/ExpandedLicensing/ExpandedLicensing.md
@@ -14,5 +14,5 @@ in object form.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/ExpandedLicensing
+- id: https://spdx.org/rdf/3/terms/ExpandedLicensing
 - name: ExpandedLicensing

--- a/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoAssertionLicense.md
@@ -21,7 +21,7 @@ NoAssertionLicense shall be used if
 
 - name: NoAssertionLicense
 - type: IndividualLicensingInfo
-- IRI: https://spdx.org/rdf/3.1/terms/Licensing/NoAssertion
+- IRI: https://spdx.org/rdf/3/terms/Licensing/NoAssertion
 
 ## Property Values
 

--- a/model/ExpandedLicensing/Individuals/NoneLicense.md
+++ b/model/ExpandedLicensing/Individuals/NoneLicense.md
@@ -16,7 +16,7 @@ available for this Artifact.
 
 - name: NoneLicense
 - type: IndividualLicensingInfo
-- IRI: https://spdx.org/rdf/3.1/terms/Licensing/None
+- IRI: https://spdx.org/rdf/3/terms/Licensing/None
 
 ## Property Values
 

--- a/model/Extension/Extension.md
+++ b/model/Extension/Extension.md
@@ -13,5 +13,5 @@ base for all defined extension subclasses.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Extension
+- id: https://spdx.org/rdf/3/terms/Extension
 - name: Extension

--- a/model/FunctionalSafety/FunctionalSafety.md
+++ b/model/FunctionalSafety/FunctionalSafety.md
@@ -16,5 +16,5 @@ These artifacts include the outputs of the safety engineering phases regarding p
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/FunctionalSafety
+- id: https://spdx.org/rdf/3/terms/FunctionalSafety
 - name: FunctionalSafety

--- a/model/Hardware/Hardware.md
+++ b/model/Hardware/Hardware.md
@@ -13,5 +13,5 @@ Hardware is any product, real or virtual. A product is tangible and is the resul
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Hardware
+- id: https://spdx.org/rdf/3/terms/Hardware
 - name: Hardware

--- a/model/Licensing/Licensing.md
+++ b/model/Licensing/Licensing.md
@@ -110,7 +110,7 @@ can be made from a missing hasConcludedLicense relationship.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Licensing
+- id: https://spdx.org/rdf/3/terms/Licensing
 - name: Licensing
 
 ## Profile conformance

--- a/model/Lite/Lite.md
+++ b/model/Lite/Lite.md
@@ -20,7 +20,7 @@ An SPDX Lite document can also be used in parallel with other SPDX documents in 
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Lite
+- id: https://spdx.org/rdf/3/terms/Lite
 - name: Lite
 
 ## Profile conformance

--- a/model/Operations/Operations.md
+++ b/model/Operations/Operations.md
@@ -18,5 +18,5 @@ The Operations assessment descriptions are patterns for business relevant assess
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Operations
+- id: https://spdx.org/rdf/3/terms/Operations
 - name: Operations

--- a/model/Security/Security.md
+++ b/model/Security/Security.md
@@ -12,5 +12,5 @@ The Security profile captures security related information.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Security
+- id: https://spdx.org/rdf/3/terms/Security
 - name: Security

--- a/model/Service/Service.md
+++ b/model/Service/Service.md
@@ -12,5 +12,5 @@ The profile captures software as a service related information.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Service
+- id: https://spdx.org/rdf/3/terms/Service
 - name: Service

--- a/model/SimpleLicensing/SimpleLicensing.md
+++ b/model/SimpleLicensing/SimpleLicensing.md
@@ -23,5 +23,5 @@ license expressions.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/SimpleLicensing
+- id: https://spdx.org/rdf/3/terms/SimpleLicensing
 - name: SimpleLicensing

--- a/model/Software/Software.md
+++ b/model/Software/Software.md
@@ -12,5 +12,5 @@ The Software namespace defines concepts related to software artifacts.
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/Software
+- id: https://spdx.org/rdf/3/terms/Software
 - name: Software

--- a/model/SupplyChain/SupplyChain.md
+++ b/model/SupplyChain/SupplyChain.md
@@ -17,5 +17,5 @@ The term “goods” is a common way of referring to artifacts within many commu
 
 ## Metadata
 
-- id: https://spdx.org/rdf/3.1/terms/SupplyChain
+- id: https://spdx.org/rdf/3/terms/SupplyChain
 - name: SupplyChain


### PR DESCRIPTION
Update namespace URIs to use the form `https://spdx.org/rdf/3/`... removing the minor version per discussion on the 2026 19 2026 tech team call.
Fixes #1146
Fixes https://github.com/spdx/spdx-spec/issues/1378