### PR TITLE
Update Package-URL spelling as ECMA

### DIFF
--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -49,7 +49,7 @@ ExternalIdentifierType specifies the type of an external identifier.
 - nli: [Natural Location Identifier (NLI)](https://eccma.org/enli-eccma-natural-location-identifier/) is a 14- or 15-character alphanumeric string standardized by [ISO 8000-118](https://www.iso.org/standard/85428.html) that uniquely identifies a three-dimensional geographic point location. The identifier is generated from geodetic coordinates and elevation data. For electronic storage, the `ISO.NLI:` prefix shall be retained (e.g., `ISO.NLI:41TS8M-A8ELTQ-H2`).
 - orcidid: [Open Researcher and Contributor ID (ORCID) iD](https://info.orcid.org/what-is-orcid/) is a unique identifier for authors and contributors in scholarly communication; as a subset of the International Standard Name Identifier (ISNI), it typically appears as a URI such as `https://orcid.org/0000-0002-1825-0097`.
 - other: Used when the type does not match any of the other options.
-- packageUrl: Package URL, as defined in the corresponding [Annex](../../../annexes/pkg-url-specification.md) of this document.
+- packageUrl: Package-URL, as defined in the corresponding [Annex](../../../annexes/pkg-url-specification.md) of this document.
 - phoneNumber: Phone number; A string of decimal digits that uniquely indicates the network termination point defined in [RFC 3966](https://datatracker.ietf.org/doc/rfc3966/) Section 5.
 - requirementUID: The unique identifier used by a requirements management or any other lifecycle management tool to uniquely identify a requirement item.
 - rorid: [Research Organization Registry (ROR) identifier](https://ror.org/about/) is a unique identifier for research and funding organization, typically expressed in its preferred URI form such as `https://ror.org/02mhbdp94`.

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides a place for the SPDX data creator to record the package URL string
-(in accordance with the Package URL specification) for a software Package.
+Provides a place for the SPDX data creator to record the Package-URL string
+(in accordance with the Package-URL specification) for a software Package.
 
 ## Description
 
-A package URL (commonly pronounced and referred to as "purl") is an attempt to standardize package representations
+A Package-URL (commonly pronounced and referred to as "PURL") is an attempt to standardize package representations
 in order to reliably identify and locate software packages.
 A packageUrl is a URL string which represents a package in a
 mostly universal and uniform way across programming languages, package
@@ -24,7 +24,7 @@ scheme:type/namespace/name@version?qualifiers#subpath
 The definition for each component can be found in the corresponding
 [Annex](../../../annexes/pkg-url-specification.md) of this document.
 Known type definitions can be found in the
-Package URL [type definitions](https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst).
+Package-URL [type definitions](https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst).
 
 Components are designed such that they form a hierarchy from the most
 significant on the left to the least significant components on the right.

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -24,7 +24,7 @@ scheme:type/namespace/name@version?qualifiers#subpath
 The definition for each component can be found in the corresponding
 [Annex](../../../annexes/pkg-url-specification.md) of this document.
 Known type definitions can be found in the
-Package-URL [type definitions](https://github.com/package-url/purl-spec/blob/b33dda1cf4515efa8eabbbe8e9b140950805f845/PURL-TYPES.rst).
+Package-URL [type definitions](https://github.com/package-url/purl-spec/blob/main/types/README.md).
 
 Components are designed such that they form a hierarchy from the most
 significant on the left to the least significant components on the right.


### PR DESCRIPTION
Package-URL is now an ECMA standard.

https://ecma-international.org/publications-and-standards/standards/ecma-427/

Let us use the standard spelling with an hyphen ("-").
