### PR TITLE
 assessedElement fix

### DIFF
--- a/model/Security/Classes/VulnAssessmentRelationship.md
+++ b/model/Security/Classes/VulnAssessmentRelationship.md
@@ -20,7 +20,7 @@ assessment relationships. It factors out the common properties shared by them.
 ## Properties
 
 - assessedElement
-  - type: /Software/SoftwareArtifact
+  - type: /Core/Artifact
   - minCount: 0
   - maxCount: 1
 - publishedTime

--- a/model/Security/Properties/assessedElement.md
+++ b/model/Security/Properties/assessedElement.md
@@ -4,16 +4,15 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Specifies an Element contained in a piece of software where a vulnerability was
-found.
+Specifies an Element where a vulnerability was found.
 
 ## Description
 
-Specifies subpackages, files or snippets referenced by a security assessment
+Specifies compoment, subpackages, files or snippets referenced by a security assessment
 to specify the precise location where a vulnerability was found.
 
 ## Metadata
 
 - name: assessedElement
 - Nature: ObjectProperty
-- Range: /Software/SoftwareArtifact
+- Range: /Core/Artifact

--- a/model/Security/Properties/assessedElement.md
+++ b/model/Security/Properties/assessedElement.md
@@ -8,7 +8,7 @@ Specifies an Element where a vulnerability was found.
 
 ## Description
 
-Specifies compoment, subpackages, files or snippets referenced by a security assessment
+Specifies components, subpackages, files or snippets referenced by a security assessment
 to specify the precise location where a vulnerability was found.
 
 ## Metadata


### PR DESCRIPTION
assessedElement property is typed as /Software/SoftwareArtifact, not as arbitrary /Core/Artifact. As a result, hardware assessment can not be a assessedElement.
Fixes #1270

Changed  - assessedElement
  - type: /Software/SoftwareArtifact -> /Core/Artifact

updated assessedElement : Summary + Description