### PR TITLE
Update specVersion range to VersionNumber

### DIFF
--- a/model/Core/Classes/CreationInfo.md
+++ b/model/Core/Classes/CreationInfo.md
@@ -23,7 +23,7 @@ doing so supports reproducible builds.
 ## Properties
 
 - specVersion
-  - type: Version
+  - type: VersionNumber
   - minCount: 1
   - maxCount: 1
 - comment

--- a/model/Core/Properties/specVersion.md
+++ b/model/Core/Properties/specVersion.md
@@ -30,4 +30,4 @@ information is conforming to.
 
 - name: specVersion
 - Nature: DataProperty
-- Range: Version
+- Range: VersionNumber


### PR DESCRIPTION
Follow up of https://github.com/spdx/spdx-3-model/pull/1265 (generic version)

One remaining property that didn't get updated yet: `specVersion`

To fix the failing publication CI (see https://github.com/spdx/spdx-spec/actions/runs/26844413727/job/79159925085)