### PR TITLE
Add `application/spdx3+json` to MediaType examples

### DIFF
--- a/model/Core/Datatypes/MediaType.md
+++ b/model/Core/Datatypes/MediaType.md
@@ -17,7 +17,8 @@ or a property.
 *Example*
 
 - `application/java-archive`
-- `application/vcard+json`
+- `application/spdx+json`
+- `application/spdx3+json`
 - `application/vnd.oasis.opendocument.text`
 - `image/avif`
 - `text/csv;charset=UTF-8`


### PR DESCRIPTION
Add [`application/spdx+json`](https://www.iana.org/assignments/media-types/application/spdx+json) (SPDX 2) and [`application/spdx3+json`](https://www.iana.org/assignments/media-types/application/spdx3+json) (SPDX 3) to MediaType examples. This will also allow a spec reader to aware of these SPDX media types.

Remove `application/vcard+json` to keep the list short. The vCard was added to demonstrated `+json`. But since the two new media types are having `+json`, it is no longer necessary.