### PR TITLE
Update Package-URL description, refer to ECMA-427

### DIFF
--- a/model/Core/Vocabularies/ExternalIdentifierType.md
+++ b/model/Core/Vocabularies/ExternalIdentifierType.md
@@ -49,7 +49,7 @@ ExternalIdentifierType specifies the type of an external identifier.
 - nli: [Natural Location Identifier (NLI)](https://eccma.org/enli-eccma-natural-location-identifier/) is a 14- or 15-character alphanumeric string standardized by [ISO 8000-118](https://www.iso.org/standard/85428.html) that uniquely identifies a three-dimensional geographic point location. The identifier is generated from geodetic coordinates and elevation data. For electronic storage, the `ISO.NLI:` prefix shall be retained (e.g., `ISO.NLI:41TS8M-A8ELTQ-H2`).
 - orcidid: [Open Researcher and Contributor ID (ORCID) iD](https://info.orcid.org/what-is-orcid/) is a unique identifier for authors and contributors in scholarly communication; as a subset of the International Standard Name Identifier (ISNI), it typically appears as a URI such as `https://orcid.org/0000-0002-1825-0097`.
 - other: Used when the type does not match any of the other options.
-- packageUrl: Package-URL, as defined in the corresponding [Annex](../../../annexes/pkg-url-specification.md) of this document.
+- packageUrl: Package-URL (PURL), as defined in [ECMA-427](https://ecma-international.org/publications-and-standards/standards/ecma-427/).
 - phoneNumber: Phone number; A string of decimal digits that uniquely indicates the network termination point defined in [RFC 3966](https://datatracker.ietf.org/doc/rfc3966/) Section 5.
 - requirementUID: The unique identifier used by a requirements management or any other lifecycle management tool to uniquely identify a requirement item.
 - rorid: [Research Organization Registry (ROR) identifier](https://ror.org/about/) is a unique identifier for research and funding organization, typically expressed in its preferred URI form such as `https://ror.org/02mhbdp94`.

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -4,30 +4,41 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Provides a place for the SPDX data creator to record the Package-URL string
-(in accordance with the Package-URL specification) for a software Package.
+Provides a place for the SPDX data creator to record the Package-URL
+for a software Package.
 
 ## Description
 
-A Package-URL (commonly pronounced and referred to as "PURL") is an attempt to standardize package representations
-in order to reliably identify and locate software packages.
-A packageUrl is a URL string which represents a package in a
-mostly universal and uniform way across programming languages, package
-managers, packaging conventions, tools, APIs and databases.
+A packageUrl property captures a Package-URL (PURL), which is a valid URL and
+URI to identify a software package, independently from their ecosystem or
+distribution channel, as specified in
+[ECMA-427](https://ecma-international.org/publications-and-standards/standards/ecma-427/).
 
-A packageUrl is composed of seven components:
+A PURL is composed of seven components:
 
 ```text
 scheme:type/namespace/name@version?qualifiers#subpath
 ```
 
-The definition for each component can be found in the corresponding
-[Annex](../../../annexes/pkg-url-specification.md) of this document.
-Known type definitions can be found in the
-Package-URL [type definitions](https://github.com/package-url/purl-spec/blob/main/types/README.md).
+The permitted characters, separators, character encodings, and rules for each
+component are defined in Section 5 of ECMA-427.
 
 Components are designed such that they form a hierarchy from the most
 significant on the left to the least significant components on the right.
+
+The PURL type component defines the ecosystem-specific structure and meaning
+for the other PURL components.
+
+The machine-readable definitions of all registered PURL types
+are maintained in the
+[PURL Type Definitions](https://github.com/package-url/purl-spec/blob/main/types/README.md).
+
+While the following are valid URL or URI schemes, they shall not be used as
+PURL types. They may be used as values within a PURL qualifier:
+
+- Special URL schemes defined in <https://url.spec.whatwg.org/>
+  (such as file://, https://, http://, and ftp://).
+- Version control system (VCS) URLs (such as git://, svn://, and hg://).
 
 ## Metadata
 

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -37,8 +37,8 @@ While the following are valid URL or URI schemes, they shall not be used as
 PURL types. They may be used as values within a PURL qualifier:
 
 - Special URL schemes defined in <https://url.spec.whatwg.org/>
-  (such as file://, https://, http://, and ftp://).
-- Version control system (VCS) URLs (such as git://, svn://, and hg://).
+  (such as `file://`, `ftp://`, `http://`, and `https://`).
+- Version control system (VCS) URLs (such as `git://`, `hg://`, and `svn://`).
 
 ## Metadata
 

--- a/model/Software/Properties/packageUrl.md
+++ b/model/Software/Properties/packageUrl.md
@@ -9,36 +9,17 @@ for a software Package.
 
 ## Description
 
-A packageUrl property captures a Package-URL (PURL), which is a valid URL and
-URI to identify a software package, independently from their ecosystem or
-distribution channel, as specified in
+A packageUrl property specifies a Package-URL (PURL).
+The PURL shall be a valid Uniform Resource Identifier (URI) and
+Uniform Resource Locator (URL) that identifies a software package independent
+of its ecosystem or distribution channel, in accordance with
 [ECMA-427](https://ecma-international.org/publications-and-standards/standards/ecma-427/).
 
-A PURL is composed of seven components:
+The PURL contains a type component that defines the ecosystem-specific
+structure and semantics for the remaining PURL components.
 
-```text
-scheme:type/namespace/name@version?qualifiers#subpath
-```
-
-The permitted characters, separators, character encodings, and rules for each
-component are defined in Section 5 of ECMA-427.
-
-Components are designed such that they form a hierarchy from the most
-significant on the left to the least significant components on the right.
-
-The PURL type component defines the ecosystem-specific structure and meaning
-for the other PURL components.
-
-The machine-readable definitions of all registered PURL types
-are maintained in the
-[PURL Type Definitions](https://github.com/package-url/purl-spec/blob/main/types/README.md).
-
-While the following are valid URL or URI schemes, they shall not be used as
-PURL types. They may be used as values within a PURL qualifier:
-
-- Special URL schemes defined in <https://url.spec.whatwg.org/>
-  (such as `file://`, `ftp://`, `http://`, and `https://`).
-- Version control system (VCS) URLs (such as `git://`, `hg://`, and `svn://`).
+The registered PURL type definitions are maintained in the Package-URL type
+registry available at <https://packageurl.org/docs/purl/purl-types>.
 
 ## Metadata
 


### PR DESCRIPTION
Update ECMA-427, revising few mentions to make it clear that it is already a formalized standard, using some texts from the standard itself.

- Para 1 revision paraphrases text snippets from ECMA-427 Section 1 (para 2's 1st sentence & para 1's 1st sentence).
- Para 5 addition ("The PURL type component defines ...") uses text snippets from ECMA-427 Section 1 (para 2's 2nd sentence).
- Para 6 addition uses old Para 3 text together with text from https://github.com/package-url/purl-spec/blob/main/types/README.md (1st para)
- Para 7 addition use information from ECMA-427 Section 5.1 (last two bullets).

The last paragraph (para 7) can be omitted if it feels unnecessary (it is already in the ECMA-427 spec).

> [!NOTE]  
> The PR in spdx-spec repo at https://github.com/spdx/spdx-spec/pull/1397 is removing the Package URL Annex.
> This PR is removing references to the Annex.


@vargenau please help review if you can
