### PR TITLE
Add "licensing" profile identifier

### DIFF
--- a/model/Core/Classes/ElementCollection.md
+++ b/model/Core/Classes/ElementCollection.md
@@ -11,11 +11,15 @@ A collection of Elements, not necessarily with unifying context.
 An ElementCollection is a collection of Elements, not necessarily with unifying
 context.
 
-Note that all ElementCollections shall conform to the Core profile even if the
-Core profile is not specified in the profileConformance property.
+An ElementCollection shall conform to the Core profile, regardless of whether
+the Core profile is explicitly specified in the profileConformance property.
 
-If the profileConformance property is not provided, "core" is to be assumed as
-the default.
+If the profileConformance property is omitted, it shall be evaluated as a list
+containing the "core" profile identifier.
+
+The inclusion of a profile identifier within the profileConformance property
+shall constitute a declaration that all constituent elements conform to the
+restrictions specified by that profile.
 
 *Constraints*
 

--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Enumeration of the valid profiles.
+Enumeration of valid profile identifiers.
 
 ## Description
 
-There are a set of profiles that have been defined by a profile team.
+The ProfileIdentifierType provides the permitted values used to declare
+conformance to an SPDX profile.
 
 A profile consists of a namespace that may add properties and classes to the
 Core profile unique to the domain covered by the profile.
@@ -16,28 +17,25 @@ Core profile unique to the domain covered by the profile.
 The profile may also contain additional restrictions on existing properties and
 classes defined in other profiles.
 
-If the creator of an SPDX collection of elements includes a profile in the list
-of profileConformance, they are claiming that all contained elements conform
-to all restrictions defined for that profile.
-
 ## Metadata
 
 - name: ProfileIdentifierType
 
 ## Entries
 
-- core: The element follows the Core profile specification.
-- software: The element follows the Software profile specification.
-- simpleLicensing: The element follows the SimpleLicensing profile specification.
-- expandedLicensing: The element follows the ExpandedLicensing profile specification.
-- security: The element follows the Security profile specification.
-- build: The element follows the Build profile specification.
 - ai: The element follows the AI profile specification.
+- build: The element follows the Build profile specification.
+- core: The element follows the Core profile specification.
 - dataset: The element follows the Dataset profile specification.
+- expandedLicensing: The element follows the ExpandedLicensing profile specification. **DEPRECATED in SPDX 3.1.** Use "licensing" instead.
 - extension: The element follows the Extension profile specification.
-- lite: The element follows the Lite profile specification.
-- hardware: The element follows the Hardware profile specification.
-- supplyChain: The element follows the SupplyChain profile specification.
-- operations: The element follows the Operations profile specification.
 - functionalSafety: The element follows the FunctionalSafety profile specification.
+- hardware: The element follows the Hardware profile specification.
+- licensing: The element follows the Licensing profile specification.
+- lite: The element follows the Lite profile specification.
+- operations: The element follows the Operations profile specification.
+- security: The element follows the Security profile specification.
 - service: The element follows the Service profile specification.
+- simpleLicensing: The element follows the SimpleLicensing profile specification. **DEPRECATED in SPDX 3.1.** Use "licensing" instead.
+- software: The element follows the Software profile specification.
+- supplyChain: The element follows the SupplyChain profile specification.


### PR DESCRIPTION
- Add "licensing" profile identifier to `ProfileIdentifierType` vocab
- Deprecate "simpleLicensing" and "expandedLicensing" identifiers
- Sort entries
- Move information about `profileConformance` from `ProfileIdentifierType` to `ElementCollection`

To fix #1238