### PR TITLE
Fix wrong Capitalisation of License and License Addition

### DIFF
--- a/docs/format.md
+++ b/docs/format.md
@@ -165,12 +165,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A license or addition that is not listed on the SPDX License List.
+A license or a license addition that is not listed on the SPDX License List.
 
 ## Description
 
-A SimpleLicensingText represents a License or Addition that is not listed on
-the [SPDX License List](https://spdx.org/licenses),
+A SimpleLicensingText represents a license or a license addition
+that is not listed on the [SPDX License List](https://spdx.org/licenses),
 and is therefore defined by an SPDX data creator.
 
 ## Metadata
@@ -193,7 +193,7 @@ will give this RDF graph
 ```ttl
 <https://spdx.org/rdf/3/terms/SimpleLicensing/SimpleLicensingText> a owl:Class,
         sh:NodeShape ;
-    rdfs:comment "A license or addition that is not listed on the SPDX License List."@en ;
+    rdfs:comment "A license or a license addition that is not listed on the SPDX License List."@en ;
     rdfs:subClassOf <https://spdx.org/rdf/3/terms/Core/Element> ;
     sh:nodeKind sh:IRI ;
     sh:property [ sh:datatype xsd:string ;

--- a/model/SimpleLicensing/Classes/SimpleLicensingText.md
+++ b/model/SimpleLicensing/Classes/SimpleLicensingText.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A license or addition that is not listed on the SPDX License List.
+A license or a license addition that is not listed on the SPDX License List.
 
 ## Description
 
-A SimpleLicensingText represents a License or Addition that is not listed on
-the [SPDX License List](https://spdx.org/licenses),
+A SimpleLicensingText represents a license or a license addition
+that is not listed on the [SPDX License List](https://spdx.org/licenses),
 and is therefore defined by an SPDX data creator.
 
 ## Metadata

--- a/model/SimpleLicensing/Classes/SimpleLicensingText.md
+++ b/model/SimpleLicensing/Classes/SimpleLicensingText.md
@@ -24,3 +24,8 @@ and is therefore defined by an SPDX data creator.
   - type: xsd:string
   - minCount: 1
   - maxCount: 1
+
+## External properties restrictions
+
+- /Core/Element/name
+  - minCount: 1

--- a/model/SimpleLicensing/Classes/SimpleLicensingText.md
+++ b/model/SimpleLicensing/Classes/SimpleLicensingText.md
@@ -24,8 +24,3 @@ and is therefore defined by an SPDX data creator.
   - type: xsd:string
   - minCount: 1
   - maxCount: 1
-
-## External properties restrictions
-
-- /Core/Element/name
-  - minCount: 1

--- a/model/SimpleLicensing/Properties/customIdToUri.md
+++ b/model/SimpleLicensing/Properties/customIdToUri.md
@@ -7,8 +7,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 **DEPRECATED in SPDX 3.1.**
 Use [customIdToLicense](./customIdToLicense.md) instead.
 
-Maps a LicenseRef or AdditionRef string for a Custom License or a Custom
-License Addition to its URI ID.
+Maps a "LicenseRef-" string for a custom license or a "AdditionRef-" string for
+a custom license addition to its URI identifier.
 
 **NOTE:**
 This property is deprecated and only included for backward compatibility.

--- a/model/SimpleLicensing/Properties/licenseText.md
+++ b/model/SimpleLicensing/Properties/licenseText.md
@@ -4,14 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Identifies the full text of a License or Addition.
+Full text of a license or a license addition.
 
 ## Description
 
-A licenseText contains the plain text of the License or Addition,
+Plain text of a license or a license addition.
 without templating or other similar markup.
 
-Users of the licenseText for a License can apply the
+Users of the licenseText for a license can apply the
 [SPDX License List Matching Guidelines](../../../annexes/license-matching-guidelines-and-templates.md)
 when comparing it to another text for matching purposes.
 

--- a/model/SimpleLicensing/Properties/licenseText.md
+++ b/model/SimpleLicensing/Properties/licenseText.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Full text of a license or a license addition.
+The full plain text of a license or a license addition.
 
 ## Description
 
-Plain text of a license or a license addition.
+The full plain text of a license or a license addition,
 without templating or other similar markup.
 
 Users of the licenseText for a license can apply the


### PR DESCRIPTION
- Fix typo of lone "addition", it should be "license addition".
- The "license" and "license addition" referred here are general concepts, not classes in ExpandedLicensing namespace. So they should be in lowercase. No caps.
- The revised language in [`customIdToUri`](https://github.com/spdx/spdx-3-model/blob/develop/model/SimpleLicensing/Properties/customIdToUri.md) here mimics structure of [customIdToLicense](https://github.com/spdx/spdx-3-model/blob/develop/model/SimpleLicensing/Properties/customIdToLicense.md)