### PR TITLE
projectOwner, productAgent: Consistent language + expand abbreviation

### DIFF
--- a/model/Hardware/Properties/productAgent.md
+++ b/model/Hardware/Properties/productAgent.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The Agent who is responsible for product branding such as an OEM.
+Agent responsible for product identification,
+such as an original equipment manufacturer (OEM).
 
 ## Description
 
-The Agent is responsible for defining the partNumber, batchNumber or serialNumber of the unit of hardware.
+Agent responsible for defining the partNumber, batchNumber
+or serialNumber of the unit of hardware.
 
 ## Metadata
 

--- a/model/Hardware/Properties/productAgent.md
+++ b/model/Hardware/Properties/productAgent.md
@@ -4,12 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Agent responsible for product identification,
+An Agent responsible for product identification,
 such as an original equipment manufacturer (OEM).
 
 ## Description
 
-Agent responsible for defining the partNumber, batchNumber
+An Agent responsible for defining the partNumber, batchNumber
 or serialNumber of the unit of hardware.
 
 ## Metadata

--- a/model/Operations/Properties/projectOwner.md
+++ b/model/Operations/Properties/projectOwner.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Owner or Lead of the project.
+Owner or lead of the project.
 
 ## Description
 
-Person responsible for the project.
+Agent responsible for the project.
 
 ## Metadata
 


### PR DESCRIPTION
- Use "Agent responsible for ..." template to make languages in these two properties consistent:
  - `productAgent`
  - `projectOwner`
- Expand "OEM" abbreviation
- Fix "Person" -> "Agent" in `projectOwner` to match its range (`/Core/Agent`) (note: `Person` is subclass of `Agent`; If intended to use "Person", should update the range)