### PR TITLE
Move profileConformance claims to ElementCollection

### DIFF
--- a/model/Core/Classes/ElementCollection.md
+++ b/model/Core/Classes/ElementCollection.md
@@ -11,11 +11,15 @@ A collection of Elements, not necessarily with unifying context.
 An ElementCollection is a collection of Elements, not necessarily with unifying
 context.
 
-Note that all ElementCollections shall conform to the Core profile even if the
+All ElementCollections shall conform to the Core profile even if the
 Core profile is not specified in the profileConformance property.
 
-If the profileConformance property is not provided, "core" is to be assumed as
-the default.
+If the profileConformance property is not provided, it shall be evaluated as
+a list containing the "core" profile identifier.
+
+The inclusion of a profile identifier within the profileConformance property
+shall constitute a declaration that all constituent elements conform to the
+restrictions specified by that profile.
 
 *Constraints*
 

--- a/model/Core/Vocabularies/ProfileIdentifierType.md
+++ b/model/Core/Vocabularies/ProfileIdentifierType.md
@@ -4,21 +4,18 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Enumeration of the valid profiles.
+Enumeration of valid profile identifiers.
 
 ## Description
 
-There are a set of profiles that have been defined by a profile team.
+The ProfileIdentifierType provides the permitted values used to declare
+conformance to an SPDX profile.
 
 A profile consists of a namespace that may add properties and classes to the
 Core profile unique to the domain covered by the profile.
 
 The profile may also contain additional restrictions on existing properties and
 classes defined in other profiles.
-
-If the creator of an SPDX collection of elements includes a profile in the list
-of profileConformance, they are claiming that all contained elements conform
-to all restrictions defined for that profile.
 
 ## Metadata
 


### PR DESCRIPTION
`ElementCollection` provides better context for the description.
The "elements" in question is with the ElementCollection.

(Changes in this PR was part of #1291)