### PR TITLE
[SupplyChain] Update location-related properties' description

### DIFF
--- a/model/SupplyChain/Properties/dropoffLocation.md
+++ b/model/SupplyChain/Properties/dropoffLocation.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The location for dropping off or delivering a package or item.
+A location where a package or an item is being dropped off or delivered.
 
 ## Description
 
-This is a specific location that an item was dropped off to.
+A specific location where a package or an item was dropped off or delivered.
+
+For a location that is being designated for dropping off,
+see `forDropoffLocation`.
 
 ## Metadata
 

--- a/model/SupplyChain/Properties/forDropoffLocation.md
+++ b/model/SupplyChain/Properties/forDropoffLocation.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The location that an item will be dropping off or delivered.
+A location where a package or an item will be dropped off or delivered.
 
 ## Description
 
-This is a specific location designated for dropping off or delivering an item.
+A designated location for dropping off or delivering a package or an item.
+
+For a location where an item was dropped off,
+see `dropoffLocation`.
 
 ## Metadata
 

--- a/model/SupplyChain/Properties/forPickupLocation.md
+++ b/model/SupplyChain/Properties/forPickupLocation.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The location for picking up a package or item.
+A location where a package or an item will be picked up.
 
 ## Description
 
-This is the designated location for pickup of an item.
+A designated location for picking up a package or an item.
+
+For a location where an item was picked up,
+see `pickupLocation`.
 
 ## Metadata
 

--- a/model/SupplyChain/Properties/pickupLocation.md
+++ b/model/SupplyChain/Properties/pickupLocation.md
@@ -4,11 +4,14 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The location for picking up a package or item.
+A location where a package or an item is being picked up.
 
 ## Description
 
-This is a specific location that an item was picked up.
+A specific location where a package or an item was picked up.
+
+For a location that is being designated for picking up,
+see `forPickupLocation`.
 
 ## Metadata
 

--- a/model/SupplyChain/Properties/plannedInspectionLocation.md
+++ b/model/SupplyChain/Properties/plannedInspectionLocation.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The planned location that a good, product or material is inspected.
+A planned location where a good, product, or material is inspected.
 
 ## Description
 
-This is the property of the storage class that defines a planned location related to the inspection of a good, product or material.
+A planned location related to the inspection of a good, product, or material.
 
 ## Metadata
 

--- a/model/SupplyChain/Properties/plannedStorageLocation.md
+++ b/model/SupplyChain/Properties/plannedStorageLocation.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The planned location that a good, product or material is stored.
+A planned location where a good, product, or material is stored.
 
 ## Description
 
-This is the property of the storage class that defines a planned location related to the storage of a good, product or material.
+A planned location related to the storage of a good, product, or material.
 
 ## Metadata
 


### PR DESCRIPTION
Make writing style of location-related properties in SupplyChain more consistent to each other.
- "xxxLocation" = actual location (done; past tense)
- "forXxxLocation" = planned/designated location

--

1) "location that" -> "location where"
2) "will be dropping off or delivered" ->  "will be dropped off or delivered"
3) Remove "This is ..." leading.
4) Add ref to closely related property to avoid confusion.

1 & 2 were reported by https://github.com/spdx/spdx-3-model/issues/1402