### PR TITLE
Editorial cleanup: Model FunctionalSafety/Hardware (7.4)

### DIFF
--- a/model/FunctionalSafety/Vocabularies/EvaluationResultType.md
+++ b/model/FunctionalSafety/Vocabularies/EvaluationResultType.md
@@ -4,12 +4,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-EvaluationResultType describes the outcome of an evaluation or verification process with.
+Specifies the outcome of an evaluation or verification process.
 
 ## Description
 
-EvaluationResultType describes the outcome of an evaluation or verification process with.
-This classification helps to clearly communicate the status of an evaluation, ensuring transparency about when results are definitive and when more information is needed before making decisions.
+EvaluationResultType categorizes whether a requirement or condition was met,
+not met, or could not be clearly determined.
+
+This classification helps to communicate the status of an evaluation clearly,
+so it is transparent when a result is definitive and when more information
+is needed before a decision can be made.
 
 ## Metadata
 

--- a/model/Hardware/Vocabularies/VirtualHardwareModelType.md
+++ b/model/Hardware/Vocabularies/VirtualHardwareModelType.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-VirtualHardwareModelType sets the VirtualHardware Model Type.
+Specifies the type of simulation model used to represent virtual hardware.
 
 ## Description
 
-VirtualHardwareModelType sets the VirtualHardware set the simulation process.
+VirtualHardwareModelType categorizes the level of fidelity at which virtual
+hardware is simulated, such as at the level of its function or its
+cycle-accurate timing.
 
 ## Metadata
 


### PR DESCRIPTION
Fix EvaluationResultType and VirtualHardwareModelType descriptions.

Fix parts of https://github.com/spdx/spdx-3-model/issues/1401

- The rewrite of model/Operations/Operations.md is omitted.
- PMBOK ref for model/Operations/Classes/Project.md is omitted. (It is on References chapter, to be tracked by this issue on spdx-spec instead: https://github.com/spdx/spdx-spec/issues/1433)
- model/Hardware/Properties/bulkQuantity.md is already in PR #1405
- Other reported typos are no longer exist.