### PR TITLE
Editorial cleanup: Model Core (7.3)

### DIFF
--- a/model/AI/Properties/standardCompliance.md
+++ b/model/AI/Properties/standardCompliance.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Standard that an artifact is being complied with.
+A standard with which the artifact complies.
 
 ## Description
 
-A free-form text that captures a standard that an artifact complies with.
+A free-form textual description that captures a standard with which the
+artifact complies.
 
 The standard may, but is not necessarily required to, satisfy a legal or
 regulatory requirement.
@@ -17,7 +18,8 @@ If the artifact is using a standard as a reference or guideline, but not
 necessarily compliant with it, use the `/Core/standardName` property instead.
 
 For a detailed compliance information, please consider defining
-a `Relationship` with "conformsTo" relationship type to a `Regulation`.
+a `/Core/Relationship` with "conformsTo" relationship type to
+a `/Core/Regulation`.
 
 ## Metadata
 

--- a/model/Core/Classes/UnitOfMeasure.md
+++ b/model/Core/Classes/UnitOfMeasure.md
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-UnitofMeasure specify information structures through industry standards for Units of Measure, Quantity Kinds, Dimensions and Data Types.
+UnitOfMeasure specify information structures through industry standards for
+Units of Measure, Quantity Kinds, Dimensions and Data Types.
 
 ## Description
 

--- a/model/Core/Properties/geographicPointLocation.md
+++ b/model/Core/Properties/geographicPointLocation.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-This is a set of point coordinates as defined in by the GPS standard.
+A set of geographic point location coordinates.
 
 ## Description
 
-GPL coordinates are defined in the format Standard: ISO 6709:2022
+Geographic point location coordinates expressed in the format defined by
+ISO 6709:2022.
 
 ## Metadata
 

--- a/model/Core/Properties/headquartersLocation.md
+++ b/model/Core/Properties/headquartersLocation.md
@@ -4,12 +4,18 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The headquartersLocation defines the location of the organization's headquarters.
+A location of the organization's headquarters.
 
 ## Description
 
-Headquarters denotes the location where most or all of the important functions of an organization are coordinated. In the United States, the corporate headquarters represents the entity at the center or the top of a corporation taking full responsibility for managing all business activities.
-To identify an organization's headquarters accurately, you provide address information (mailing, street and GPL) information related to the organization’s headquarters.
+Headquarters denotes the location where most or all of the important functions
+of an organization are coordinated. In some jurisdictions, it represents the
+central entity of a corporation that assumes full responsibility for managing
+all business activities.
+
+Accurate identification of an organization's headquarters requires the
+provision of relevant address data, including mailing, street, and geographic
+point location.
 
 ## Metadata
 

--- a/model/Core/Properties/intendedUse.md
+++ b/model/Core/Properties/intendedUse.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-The intendedUse property is designed to capture a summary of how or for what item or artifact is meant to be used for.
+A statement of how, or for what purpose, an item or artifact is intended
+to be used.
 
 ## Description
 
-The intendedUse field allows users to enter a free-form textual description outlining the scope and boundaries of appropriate or intended applications for the item or artifact.
+A free-form textual description outlining the scope and boundaries of
+appropriate or intended applications for the item or artifact.
 
 ## Metadata
 

--- a/model/Core/Properties/processReadiness.md
+++ b/model/Core/Properties/processReadiness.md
@@ -4,11 +4,12 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-processReadiness describes the readiness of a process.
+The readiness of a process.
 
 ## Description
 
-Draft, active, obsolete or other are used to define the readiness of a proceedure.
+The readiness of a process, expressed using the ProcessReadinessType
+enumeration.
 
 ## Metadata
 

--- a/model/Core/Properties/requirementStatement.md
+++ b/model/Core/Properties/requirementStatement.md
@@ -4,11 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A text describing the actual need defined by the requirement.
+A textual expression describing the actual need defined by the requirement.
 
 ## Description
 
-The text portion of the requirement, usually following specific rules and best practices of requirements engineering. e.g. EARS.
+The text-based portion of a requirement. This statement typically adheres to
+established rules and best practices of requirements engineering,
+such as the Easy Approach to Requirements Syntax (EARS).
 
 ## Metadata
 

--- a/model/Core/Properties/unitQUDT.md
+++ b/model/Core/Properties/unitQUDT.md
@@ -4,11 +4,16 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-QUDT unit is used for measurement criteria based on product type, region and use.
+A QUDT unit applied to measurement criteria based on product type, region,
+and use.
 
 ## Description
 
-QUDT units are used to describe measurable quantities, units for measuring different kinds of quantities, the numerical values of quantities in different units of measure and the data structures and data types. https://www.qudt.org/
+QUDT (Quantity, Unit, Dimension and Type) specifies a standardized framework
+for describing measurable quantities, units of measure, numerical values,
+and their underlying data structures and types.
+
+The QUDT ontology and specifications are available at <https://www.qudt.org/>.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/ExternalRefType.md
+++ b/model/Core/Vocabularies/ExternalRefType.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-Specifies the type of an external reference.
+The type of external reference.
 
 ## Description
 
-ExternalRefType specifies the type of an external reference.
+The type of external reference.
 
 ## Metadata
 
@@ -21,12 +21,12 @@ ExternalRefType specifies the type of an external reference.
 - binaryArtifact: A reference to binary artifacts related to a package.
 - bom: A reference to a bill of materials related to a package.
 - bower: A reference to a Bower package. The package locator format, looks like `package#version`, is defined in the "install" section of [Bower API documentation](https://bower.io/docs/api/#install).
-- buildMeta: A reference to a build metadata related to a published package.
-- buildSystem: A reference to a build system used to create or publish the package.
+- buildMeta: A reference to the build metadata related to a published package.
+- buildSystem: A reference to the build system used to create or publish the package.
 - chat: A reference to the instant messaging system used by the maintainer for a package.
 - certificationReport: A reference to a certification report for a package from an accredited/independent body.
 - componentAnalysisReport: A reference to a Software Composition Analysis (SCA) report.
-- cwe: [Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaw defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/).
+- cwe: [Common Weakness Enumeration](https://csrc.nist.gov/glossary/term/common_weakness_enumeration). A reference to a source of software flaws defined within the official [CWE List](https://cwe.mitre.org/data/) that conforms to the [CWE specification](https://cwe.mitre.org/).
 - documentation: A reference to the documentation for a package.
 - dynamicAnalysisReport: A reference to a dynamic analysis report for a package.
 - eolNotice: A reference to the End Of Sale (EOS) and/or End Of Life (EOL) information related to a package.
@@ -35,13 +35,13 @@ ExternalRefType specifies the type of an external reference.
 - issueTracker: A reference to the issue tracker for a package.
 - mailingList: A reference to the mailing list used by the maintainer for a package.
 - mavenCentral: A reference to a Maven repository artifact. The artifact locator format is defined in the [Maven documentation](https://maven.apache.org/guides/mini/guide-naming-conventions.html) and looks like `groupId:artifactId[:version]`.
-- metrics: A reference to metrics related to package such as OpenSSF scorecards.
+- metrics: A reference to metrics related to a package such as OpenSSF scorecards.
 - npm: A reference to an npm package. The package locator format is defined in the [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) and looks like `package@version`.
 - nuget: A reference to a NuGet package. The package locator format is defined in the [NuGet documentation](https://docs.nuget.org) and looks like `package/version`.
 - license: A reference to additional license information related to an artifact.
 - other: Used when the type does not match any of the other options.
 - privacyAssessment: A reference to a privacy assessment for a package.
-- productMetadata: A reference to additional product metadata such as reference within organization's product catalog.
+- productMetadata: A reference to additional product metadata such as a reference within an organization's product catalog.
 - purchaseOrder: A reference to a purchase order for a package.
 - qualityAssessmentReport: A reference to a quality assessment for a package.
 - releaseNotes: A reference to the release notes for a package.
@@ -49,13 +49,13 @@ ExternalRefType specifies the type of an external reference.
 - riskAssessment: A reference to a risk assessment for a package.
 - runtimeAnalysisReport: A reference to a runtime analysis report for a package.
 - secureSoftwareAttestation: A reference to information assuring that the software is developed using security practices as defined by [NIST SP 800-218 Secure Software Development Framework (SSDF) Version 1.1](https://csrc.nist.gov/pubs/sp/800/218/final) or [CISA Secure Software Development Attestation Form](https://www.cisa.gov/resources-tools/resources/secure-software-development-attestation-form).
-- securityAdvisory: A reference to a published security advisory (where advisory as defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries.
+- securityAdvisory: A reference to a published security advisory (where advisory is defined per [ISO 29147:2018](https://www.iso.org/standard/72311.html)) that may affect one or more elements, e.g., vendor advisories or specific NVD entries.
 - securityAdversaryModel: A reference to the security adversary model for a package.
 - securityFix: A reference to the patch or source code that fixes a vulnerability.
 - securityOther: A reference to related security information of unspecified type.
 - securityPenTestReport: A reference to a [penetration test](https://en.wikipedia.org/wiki/Penetration_test) report for a package.
 - securityPolicy: A reference to instructions for reporting newly discovered security vulnerabilities for a package.
-- securityThreatModel: A reference to the [security threat model](https://en.wikipedia.org/wiki/Threat_model) for a package.
+- securityThreatModel: A reference to the [security threat model](https://en.wikipedia.org/wiki/Threat_model) for the package.
 - socialMedia: A reference to a social media channel for a package.
 - sourceArtifact: A reference to an artifact containing the sources for a package.
 - staticAnalysisReport: A reference to a static analysis report for a package.

--- a/model/Core/Vocabularies/IsoAutomationLevel.md
+++ b/model/Core/Vocabularies/IsoAutomationLevel.md
@@ -24,8 +24,8 @@ Systems categorized with automation levels 0-5 are heteronomous.
 This means that while they can be fully automated, their goals and objectives
 are set by external entities, typically human operators.
 
-A system with automation level 6 is autonomous, capable of independently define
-and pursue its own goals.
+A system with automation level 6 is autonomous, possessing the capability to
+independently define and pursue its own goals.
 
 ## Metadata
 

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -73,7 +73,7 @@ name completes the sentence:
 - hasPrerequisite: The `from` Element has a prerequisite on each `to` Element, during a LifecycleScopeType period.
 - hasProvidedDependency: The `from` Element has a dependency on each `to` Element, dependency is not in the distributed artifact, but assumed to be provided, during a LifecycleScopeType period.
 - hasRequirement: The `from` Element has a requirement on each `to` Element, during a LifecycleScopeType period.
-- hasResolution: The `from` /SupplyChain/ResolutionAction point to the `to` /SupplyChain/OutOfSpecAction that is addressed.
+- hasResolution: The `from` /SupplyChain/ResolutionAction points to the `to` /SupplyChain/OutOfSpecAction that is addressed.
 - hasRoleIn: The `from` Element has a role in the `to` Element. The use of the hasRoleIn is constrained to `RoleRelationship` classed relationships.
 - hasSpecification: Every `to` Element is a specification for the `from` Element (`from` hasSpecification `to`), during a LifecycleScopeType period.
 - hasStaticLink: The `from` Element statically links in each `to` Element, during a LifecycleScopeType period.
@@ -87,14 +87,14 @@ name completes the sentence:
 - other: Every `to` Element is related to the `from` Element where the relationship type is not described by any of the SPDX relationship types (this relationship is directionless).
 - packagedBy: Every `to` Element is a packaged instance of the `from` Element (`from` packagedBy `to`).
 - patchedBy: Every `to` Element is a patch for the `from` Element (`from` patchedBy `to`).
+- performedBy: Every `from` Action is performedBy `to` Agent.
 - pretrainedOn: The `from` Element has been pretrained on the `to` Element(s).
 - providesSupportFor: The `from` Agent provides support for each `to` Artifact. The use of the `providesSupportFor` type is constrained to `SupportRelationship` classed relationships.
-- performedBy: Every `from` Action is performedBy `to` Agent.
 - publishedBy: Designates a `from` /Security/Vulnerability was made available for public use or reference by each `to` Agent.
 - reportedBy: Designates a `from` /Security/Vulnerability was first reported to a project, vendor, or tracking database for formal identification by each `to` Agent.
 - republishedBy: Designates a `from` /Security/Vulnerability's details were tracked, aggregated, and/or enriched to improve context (i.e. NVD) by each `to` Agent.
 - resolved: The `to` /SupplyChain/OutOfSpecAction is resolved in the `from` /SupplyChain/ResolutionAction.
-- runsOn: The `from` Element (the instructions) of runs on each `to` /Hardware/Hardware (processing element), during a LifecycleScopeType period.
+- runsOn: The `from` Element (the instructions) runs on each `to` /Hardware/Hardware (processing element), during a LifecycleScopeType period.
 - serializedInArtifact: The `from` SpdxDocument can be found in a serialized form in each `to` Artifact.
 - testedOn: The `from` Element has been tested on the `to` Element(s).
 - tracedToDetail: The `from` Requirement is refined and further elaborated by each `to` Requirement, which contains more detailed implementation information.

--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -36,7 +36,7 @@ name completes the sentence:
 - coordinatedBy: The `from` /Security/Vulnerability is coordinatedBy the `to` Agent(s) (vendor, researcher, or consumer agent).
 - copiedTo: The `from` Element has been copied to each `to` Element.
 - createdBy: The `from` Action or DefinedProcess is createdBy `to` Agent(s).
-- delegatedTo: The `from` Agent is delegating an action to the Agent of the `to` Relationship (which shall be of type invokedBy), during a LifecycleScopeType (e.g. the `to` invokedBy Relationship is being done on behalf of `from`).
+- delegatedTo: The `from` Agent is delegating an action to the Agent of the `to` Relationship (which shall be of type invokedBy), during a LifecycleScopeType period (e.g. the `to` invokedBy Relationship is being done on behalf of `from`).
 - dependsOn: The `from` Element depends on each `to` Element, during a LifecycleScopeType period.
 - descendantOf: The `from` Element is a descendant of each `to` Element.
 - describes: The `from` Element describes each `to` Element. To denote the root(s) of a tree of elements in a collection, the rootElement property shall be used.


### PR DESCRIPTION
- Fix issues in https://github.com/spdx/spdx-3-model/issues/1400
  - Dangling 'for', 'with'
  - 'QUDT' and 'EARS' not expanded
  - Missing prepositions/articles in ExternalRefType
- postalName.md and ProcessReadinessType.md are to be fixed by https://github.com/spdx/spdx-3-model/pull/1405
- Some reported typos are no longer exist in current version


Together with #1405, this PR will fix #1400