### PR TITLE
Update CountryCodeAlpha3.md for clarity and accuracy

### DIFF
--- a/model/Core/Datatypes/CountryCodeAlpha3.md
+++ b/model/Core/Datatypes/CountryCodeAlpha3.md
@@ -8,7 +8,7 @@ A string constrained to the ISO 3166-1 alpha-3 three-letter uppercase format.
 
 ## Description
 
-The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element is created.
+The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element containing this data type is created.
 
 The pattern constraint validates only the lexical form; it does not establish that the value is an assigned ISO 3166-1 alpha-3 code. Implementations should validate values against the applicable ISO code list.
 

--- a/model/Core/Datatypes/CountryCodeAlpha3.md
+++ b/model/Core/Datatypes/CountryCodeAlpha3.md
@@ -4,7 +4,7 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A string containing an assigned ISO 3166-1 alpha-3 country code.
+A string constrained to the ISO 3166-1 alpha-3 three-letter uppercase format.
 
 ## Description
 

--- a/model/Core/Datatypes/CountryCodeAlpha3.md
+++ b/model/Core/Datatypes/CountryCodeAlpha3.md
@@ -4,13 +4,13 @@ SPDX-License-Identifier: Community-Spec-1.0
 
 ## Summary
 
-A string constrained to the ISO 3166-1 alpha-3 three-letter format.
+A string containing an assigned ISO 3166-1 alpha-3 country code.
 
 ## Description
 
-The string shall be in the [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) three-letter format.
+The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element is created.
 
-See the [ISO 3166-1 alpha-3 Wikipedia page](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) for more information.
+The pattern constraint validates only the lexical form; it does not establish that the value is an assigned ISO 3166-1 alpha-3 code. Implementations should validate values against the applicable ISO code list.
 
 ## Metadata
 

--- a/model/Core/Properties/country.md
+++ b/model/Core/Properties/country.md
@@ -9,6 +9,7 @@ Specifies a country code of the location.
 ## Description
 
 Specifies a country code of the location.
+The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element containing this property is created.
 
 ## Metadata
 

--- a/model/Operations/Properties/exportingCountry.md
+++ b/model/Operations/Properties/exportingCountry.md
@@ -9,6 +9,7 @@ Country for which export controls must be taken into account.
 ## Description
 
 Country for which export controls must be taken into account.
+The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element containing this property is created.
 
 ## Metadata
 

--- a/model/Service/Properties/serviceHostingCountry.md
+++ b/model/Service/Properties/serviceHostingCountry.md
@@ -11,8 +11,7 @@ Specifies a country code where a software service is hosted.
 Specifies a country or territory where a software service is located.
 This includes indirect locations (e.g., where the data may be hosted).
 
-The string shall be in the [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) three-letter format.
-See the [ISO 3166-1 alpha-3 Wikipedia page](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) for more information.
+The value shall be an uppercase three-letter country code assigned by [ISO 3166-1 alpha-3](https://www.iso.org/obp/ui/#iso:std:iso:3166:-1) at the time the SPDX element containing this property is created.
 
 ## Metadata
 


### PR DESCRIPTION
Clarified the definition and validation requirements for the ISO 3166-1 alpha-3 country code.

Fixes #1369 

Includes the text proposed in [this comment.](https://github.com/spdx/spdx-3-model/issues/1369#issuecomment-5198586149)