### PR TITLE
[FuSa] Add SafetyContextRelationship and SafetyIntegrityLevelType

### DIFF
--- a/model/FunctionalSafety/Classes/SafetyContextRelationship.md
+++ b/model/FunctionalSafety/Classes/SafetyContextRelationship.md
@@ -10,7 +10,7 @@ Provides functional safety context for an existing lifecycle-scoped relationship
 
 SafetyContextRelationship provides functional safety context for a relationship
 between SPDX elements. It enables an existing relationship, such as a dependency
-or requirement relationship, to carry a safety integrity level without adding a
+or requirement relationship, to carry a safety integrity level leveraging the existing
 new relationship type for each safety-related use case.
 
 SafetyContextRelationship inherits lifecycle scope from

--- a/model/FunctionalSafety/Classes/SafetyContextRelationship.md
+++ b/model/FunctionalSafety/Classes/SafetyContextRelationship.md
@@ -11,7 +11,7 @@ Provides functional safety context for an existing lifecycle-scoped relationship
 SafetyContextRelationship provides functional safety context for a relationship
 between SPDX elements. It enables an existing relationship, such as a dependency
 or requirement relationship, to carry a safety integrity level leveraging the existing
-new relationship type for each safety-related use case.
+relationship types as needed for safety-related use case.
 
 SafetyContextRelationship inherits lifecycle scope from
 /Core/LifecycleScopedRelationship so the safety context can be interpreted for a

--- a/model/FunctionalSafety/Classes/SafetyContextRelationship.md
+++ b/model/FunctionalSafety/Classes/SafetyContextRelationship.md
@@ -1,0 +1,32 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# SafetyContextRelationship
+
+## Summary
+
+Provides functional safety context for an existing lifecycle-scoped relationship.
+
+## Description
+
+SafetyContextRelationship provides functional safety context for a relationship
+between SPDX elements. It enables an existing relationship, such as a dependency
+or requirement relationship, to carry a safety integrity level without adding a
+new relationship type for each safety-related use case.
+
+SafetyContextRelationship inherits lifecycle scope from
+/Core/LifecycleScopedRelationship so the safety context can be interpreted for a
+specific lifecycle phase, such as design, build, test, runtime, update, or
+decommission.
+
+## Metadata
+
+- name: SafetyContextRelationship
+- SubclassOf: /Core/LifecycleScopedRelationship
+- Instantiability: Concrete
+
+## Properties
+
+- safetyIntegrityLevel
+  - type: SafetyIntegrityLevelType
+  - minCount: 0
+  - maxCount: 1

--- a/model/FunctionalSafety/Properties/safetyIntegrityLevel.md
+++ b/model/FunctionalSafety/Properties/safetyIntegrityLevel.md
@@ -1,0 +1,18 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# safetyIntegrityLevel
+
+## Summary
+
+Identifies a functional safety integrity level associated with a relationship.
+
+## Description
+
+safetyIntegrityLevel identifies the functional safety integrity level associated
+with a relationship in a specified lifecycle context.
+
+## Metadata
+
+- name: safetyIntegrityLevel
+- Nature: ObjectProperty
+- Range: SafetyIntegrityLevelType

--- a/model/FunctionalSafety/Vocabularies/SafetyIntegrityLevelType.md
+++ b/model/FunctionalSafety/Vocabularies/SafetyIntegrityLevelType.md
@@ -1,0 +1,36 @@
+SPDX-License-Identifier: Community-Spec-1.0
+
+# SafetyIntegrityLevelType
+
+## Summary
+
+Specifies common functional safety integrity level labels.
+
+## Description
+
+SafetyIntegrityLevelType provides common functional safety integrity level
+labels used to communicate safety context for relationships. The vocabulary
+includes labels used by ISO 26262 ASIL, IEC 61508 SIL, and aviation DAL.
+
+## Metadata
+
+- name: SafetyIntegrityLevelType
+
+## Entries
+
+- qm: Quality management level under ISO 26262.
+- asilA: Automotive Safety Integrity Level A under ISO 26262.
+- asilB: Automotive Safety Integrity Level B under ISO 26262.
+- asilC: Automotive Safety Integrity Level C under ISO 26262.
+- asilD: Automotive Safety Integrity Level D under ISO 26262.
+- sil1: Safety Integrity Level 1 under IEC 61508.
+- sil2: Safety Integrity Level 2 under IEC 61508.
+- sil3: Safety Integrity Level 3 under IEC 61508.
+- sil4: Safety Integrity Level 4 under IEC 61508.
+- dalA: Design Assurance Level A for aviation software assurance.
+- dalB: Design Assurance Level B for aviation software assurance.
+- dalC: Design Assurance Level C for aviation software assurance.
+- dalD: Design Assurance Level D for aviation software assurance.
+- dalE: Design Assurance Level E for aviation software assurance.
+- other: Any other safety integrity level not covered above.
+- noAssertion: No assertion is made about the safety integrity level.

--- a/model/FunctionalSafety/Vocabularies/SafetyIntegrityLevelType.md
+++ b/model/FunctionalSafety/Vocabularies/SafetyIntegrityLevelType.md
@@ -18,7 +18,7 @@ includes labels used by ISO 26262 ASIL, IEC 61508 SIL, and aviation DAL.
 
 ## Entries
 
-- qm: Quality management level under ISO 26262.
+- qm: Quality management level.
 - asilA: Automotive Safety Integrity Level A under ISO 26262.
 - asilB: Automotive Safety Integrity Level B under ISO 26262.
 - asilC: Automotive Safety Integrity Level C under ISO 26262.


### PR DESCRIPTION
## Summary

Adds `/FunctionalSafety/SafetyContextRelationship` as a subclass of `/Core/LifecycleScopedRelationship`.

Adds one optional FunctionalSafety property:

- `safetyIntegrityLevel: SafetyIntegrityLevelType [0..1]`

Adds `/FunctionalSafety/SafetyIntegrityLevelType` vocabulary for common functional-safety integrity labels, including ISO 26262 ASIL values, IEC 61508 SIL values, aviation DAL values, plus `other` and `noAssertion`.

This is an additive FunctionalSafety profile change only. It does not modify SPDX Core classes, existing RelationshipTypes, or lifecycle vocabulary.

Discussed and agreed at the SPDX FuSa SIG meeting on August 14, 2026.

## Validation

- `python spec-parser/main.py --verbose --no-output model`
