### PR TITLE
Update Language Tag pattern

### DIFF
--- a/model/Core/Datatypes/LanguageTag.md
+++ b/model/Core/Datatypes/LanguageTag.md
@@ -9,14 +9,17 @@ which is used to identify human languages.
 
 ## Description
 
+A language tag provides a standardized way to identify the language of content,
+a performance, or an action.
+
 The language tag shall be in the format as describes in the Section 2 of
 [IETF RFC 5646](https://datatracker.ietf.org/doc/rfc5646/) (part of BCP 47).
 
-Each language tag is composed of one or more "subtags" separated by hyphens
-(-). Each subtag is composed of basic Latin letters or digits only.
+Each tag consists of one or more subtags separated by hyphens
+("-", Unicode U+002D).
+Subtags contain only basic Latin letters and digits.
 
-It provides a standardized way of indicating the language of the content or
-performance or used in an action.
+Language tags and their subtags are to be treated as case insensitive.
 
 *Example*
 
@@ -38,4 +41,4 @@ for more information.
 
 ## Format
 
-- pattern: ^[a-zA-Z]{2,8}(-[a-zA-Z0-9]{1,8})*$
+- pattern: ^([a-zA-Z]{2,8}|[iIxX])(-[a-zA-Z0-9]{1,8})*$


### PR DESCRIPTION
To allow "i-" (irregular, grandfathered) and "x-" (private use) prefixes.

As reported by issue #1327, current pattern of Language Tag doesn't validate all BCP 47 / RFC 5646 forms.
Discussed in 5 August 2026 AI WG to widen the pattern to support the irregulars ("i-").

This PR also expand it to support private use ("x-")
(`privateuse    = "x" 1*("-" (1*8alphanum))` in RFC 5646 ABNF)