### PR TITLE
DefinedStateProcess -> StateProcess

### DIFF
--- a/docs/model.drawio
+++ b/docs/model.drawio
@@ -2107,7 +2107,7 @@
         <mxCell id="Gllw5IAAax8XE4wCEWVt-9" parent="8_UPuNKhLgLkakI1TAIx-102" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontColor=#000000;fontFamily=Verdana;fontSize=10;" value="+ currentState: State[1]" vertex="1">
           <mxGeometry height="26" width="290" y="26" as="geometry" />
         </mxCell>
-        <mxCell id="Gllw5IAAax8XE4wCEWVt-10" parent="8_UPuNKhLgLkakI1TAIx-102" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontColor=#000000;fontFamily=Verdana;fontSize=10;fontStyle=0" value="+ decisionProcess: DefinedStateProcess[1]" vertex="1">
+        <mxCell id="Gllw5IAAax8XE4wCEWVt-10" parent="8_UPuNKhLgLkakI1TAIx-102" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontColor=#000000;fontFamily=Verdana;fontSize=10;fontStyle=0" value="+ decisionProcess: StateProcess[1]" vertex="1">
           <mxGeometry height="26" width="290" y="52" as="geometry" />
         </mxCell>
         <mxCell id="8_UPuNKhLgLkakI1TAIx-105" edge="1" parent="1" source="8_UPuNKhLgLkakI1TAIx-106" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.25;exitDx=0;exitDy=0;endArrow=block;endFill=0;" target="8_UPuNKhLgLkakI1TAIx-84">
@@ -2417,7 +2417,7 @@
         <mxCell id="Gllw5IAAax8XE4wCEWVt-6" parent="1" style="swimlane;fontStyle=3;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#e1d5e7;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;strokeColor=#9673a6;fontFamily=Verdana;fontSize=10;" value="/Core/Artifact " vertex="1">
           <mxGeometry height="56" width="122" x="923" y="305" as="geometry" />
         </mxCell>
-        <mxCell id="Gllw5IAAax8XE4wCEWVt-11" parent="1" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=none;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;fontFamily=Verdana;fontSize=10;" value="&lt;b&gt;DefinedStateProcess&lt;/b&gt;" vertex="1">
+        <mxCell id="Gllw5IAAax8XE4wCEWVt-11" parent="1" style="swimlane;fontStyle=0;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=none;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;fontFamily=Verdana;fontSize=10;" value="&lt;b&gt;StateProcess&lt;/b&gt;" vertex="1">
           <mxGeometry height="52" width="274" x="1390" y="1120" as="geometry" />
         </mxCell>
         <mxCell id="Gllw5IAAax8XE4wCEWVt-12" parent="Gllw5IAAax8XE4wCEWVt-11" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;fontColor=#000000;fontFamily=Verdana;fontSize=10;" value="+ validState: State[1..*]" vertex="1">

--- a/model/SupplyChain/Classes/StateAction.md
+++ b/model/SupplyChain/Classes/StateAction.md
@@ -10,7 +10,7 @@ This is the state of an affected Element at a specific moment in time.
 
 The state of a specific Element is defined, measured or observed in this class at a specific moment in time.
 
-The StateAction is defined by the method used by the DefinedStateProcess to
+The StateAction is defined by the method used by the StateProcess to
 produce an outcome.
 
 ## Metadata
@@ -26,6 +26,6 @@ produce an outcome.
   - minCount: 1
   - maxCount: 1
 - decisionProcess
-  - type: DefinedStateProcess
+  - type: StateProcess
   - minCount: 1
   - maxCount: 1

--- a/model/SupplyChain/Classes/StateProcess.md
+++ b/model/SupplyChain/Classes/StateProcess.md
@@ -1,6 +1,6 @@
 SPDX-License-Identifier: Community-Spec-1.0
 
-# DefinedStateProcess
+# StateProcess
 
 ## Summary
 
@@ -9,13 +9,13 @@ This process is used to determine the state of an affected Element.
 ## Description
 
 This process is used to determine the state of an affected Element.
-The DefinedStateProcess is used to define a list of valid states of an affected Element.
+The StateProcess is used to define a list of valid states of an affected Element.
 
-A DefinedStateProcess may describe the steps or conditions required to move an entity from one state to another.
+A StateProcess may describe the steps or conditions required to move an entity from one state to another.
 
 ## Metadata
 
-- name: DefinedStateProcess
+- name: StateProcess
 - SubclassOf: UseProcess
 - Instantiability: Concrete
 

--- a/model/SupplyChain/Properties/decisionProcess.md
+++ b/model/SupplyChain/Properties/decisionProcess.md
@@ -14,4 +14,4 @@ This is how the currentState of an affected Element is found.
 
 - name: decisionProcess
 - Nature: ObjectProperty
-- Range: DefinedStateProcess
+- Range: StateProcess

--- a/model/SupplyChain/Properties/validState.md
+++ b/model/SupplyChain/Properties/validState.md
@@ -4,11 +4,11 @@ SPDX-License-Identifier: Community-Spec-1.0.
 
 ## Summary
 
-The valid state for DefinedStateProcess.
+The valid state for StateProcess.
 
 ## Description
 
-The valid state for DefinedStateProcess.
+The valid state for StateProcess.
 
 ## Metadata
 


### PR DESCRIPTION
- Rename `DefinedStateProcess` to `StateProcess`
  - Will match with `StateAction` 
- Make it consistent with other *Action / *Process pairs.
- Other `DefinedProcess` subclasses also don't have the "Defined" prefix.