### PR TITLE
Extend hasInput and hasOutput descriptions

### DIFF
--- a/model/Core/Vocabularies/RelationshipType.md
+++ b/model/Core/Vocabularies/RelationshipType.md
@@ -65,11 +65,11 @@ name completes the sentence:
 - hasEvidence: Every `to` Element is considered as evidence for the `from` Element (`from` hasEvidence `to`).
 - hasExample: Every `to` Element is an example for the `from` Element (`from` hasExample `to`).
 - hasHost: The `from` /Build/Build was run on the `to` Element during a LifecycleScopeType period (e.g. the host that the build runs on).
-- hasInput: The `from` /Build/Build, DefinedProcess or Action element has each `to` Element as an input.
+- hasInput: The `from` element has each `to` Element as an input.
 - hasMetadata: Every `to` Element is metadata about the `from` Element (`from` hasMetadata `to`).
 - hasOptionalComponent: Every `to` Element is an optional component of the `from` Element (`from` hasOptionalComponent `to`).
 - hasOptionalDependency: The `from` Element optionally depends on each `to` Element, during a LifecycleScopeType period.
-- hasOutput: The `from` /Build/Build, DefinedProcess or Action element generates each `to` Element as an output.
+- hasOutput: The `from` element generates each `to` Element as an output.
 - hasPrerequisite: The `from` Element has a prerequisite on each `to` Element, during a LifecycleScopeType period.
 - hasProvidedDependency: The `from` Element has a dependency on each `to` Element, dependency is not in the distributed artifact, but assumed to be provided, during a LifecycleScopeType period.
 - hasRequirement: The `from` Element has a requirement on each `to` Element, during a LifecycleScopeType period.


### PR DESCRIPTION
Safety Assessment needs to have ChangeImpactAnalyisis hasInput ChangeTrigger(s) - based on discussion in Safety Call on 9/11.   

Adjusted hasOutput to be symmetric and future proof it as it as well.   Currently was just limited to build, action & process, but it's seems appropriate to generalize it at this point.